### PR TITLE
feat(web): integrate chat widget

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@cossistant/api": "workspace:*",
     "@cossistant/database": "workspace:*",
     "@cossistant/location": "workspace:*",
+    "@cossistant/react": "workspace:*",
     "@hookform/resolvers": "^5.1.1",
     "@polar-sh/nextjs": "^0.4.0",
     "@radix-ui/react-avatar": "^1.1.10",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
+import { ChatWidget } from "@/components/chat/widget";
 import { Toaster } from "@/components/ui/sonner";
 import { Providers } from "./providers";
 
@@ -83,6 +84,7 @@ export default function RootLayout({
 				className={`${geistSans.variable} ${geistMono.variable} antialiased`}
 			>
 				<Providers>{children}</Providers>
+				<ChatWidget />
 				<Toaster />
 			</body>
 		</html>

--- a/apps/web/src/components/chat/widget.tsx
+++ b/apps/web/src/components/chat/widget.tsx
@@ -1,0 +1,58 @@
+"use client";
+import {
+	Bubble,
+	CossistantProvider,
+	Input,
+	SendButton,
+	Window,
+} from "@cossistant/react";
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export function ChatWidget() {
+	const [value, setValue] = React.useState("");
+
+	const handleSubmit = () => {
+		// TODO: integrate with backend
+		setValue("");
+	};
+
+	return (
+		<CossistantProvider>
+			<Bubble
+				className={cn(
+					"fixed right-4 bottom-4",
+					"rounded-full bg-primary px-4 py-2 text-primary-foreground"
+				)}
+			>
+				Chat
+			</Bubble>
+			<Window
+				className={cn(
+					"fixed right-4 bottom-20 flex w-80 flex-col",
+					"rounded border bg-background shadow-lg"
+				)}
+				footer={null}
+				header={<div className="p-3 font-medium">Chat</div>}
+			>
+				<div className="flex-1 overflow-y-auto p-3">
+					{/* messages go here */}
+				</div>
+				<div className="flex items-end gap-2 border-t p-3">
+					<Input
+						className="flex-1 resize-none rounded border px-2 py-1"
+						onChange={setValue}
+						onSubmit={handleSubmit}
+						value={value}
+					/>
+					<SendButton
+						className="rounded bg-primary px-3 py-1 text-primary-foreground"
+						onClick={handleSubmit}
+					>
+						Send
+					</SendButton>
+				</div>
+			</Window>
+		</CossistantProvider>
+	);
+}

--- a/packages/react/src/bubble.tsx
+++ b/packages/react/src/bubble.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+import { useCossistant } from "./provider";
+
+export interface BubbleProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "color"> {
+  unreadCount?: number;
+}
+
+export const Bubble = React.forwardRef<HTMLButtonElement, BubbleProps>(
+  ({ unreadCount, className, children, ...props }, ref) => {
+    const { isOpen, toggle } = useCossistant();
+
+    return (
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        onClick={toggle}
+        ref={ref}
+        className={className}
+        {...props}
+      >
+        {children}
+        {unreadCount ? <span>{unreadCount}</span> : null}
+      </button>
+    );
+  },
+);
+
+Bubble.displayName = "Bubble";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
-export function helloCore(): string {
-	return "Hello from @cossistant/core!";
-}
+export { CossistantProvider, useCossistant } from "./provider";
+export { Bubble } from "./bubble";
+export { Window } from "./window";
+export { Input } from "./input";
+export { SendButton } from "./send-button";

--- a/packages/react/src/input.tsx
+++ b/packages/react/src/input.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+export interface InputProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "value" | "onChange"> {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit?: () => void;
+}
+
+export const Input = React.forwardRef<HTMLTextAreaElement, InputProps>(
+  ({ value, onChange, onSubmit, className, ...props }, ref) => {
+    const innerRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+    React.useImperativeHandle(ref, () => innerRef.current as HTMLTextAreaElement);
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e.target.value);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        onSubmit?.();
+      }
+      props.onKeyDown?.(e);
+    };
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: re-run when value changes
+    React.useLayoutEffect(() => {
+      const el = innerRef.current;
+      if (!el) {
+        return;
+      }
+      el.style.height = "auto";
+      el.style.height = `${el.scrollHeight}px`;
+    }, [value]);
+
+    return (
+      <textarea
+        {...props}
+        className={className}
+        ref={innerRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        rows={1}
+      />
+    );
+  },
+);
+
+Input.displayName = "Input";

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+
+export interface CossistantProviderProps {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}
+
+export interface CossistantContextValue {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const CossistantContext = React.createContext<CossistantContextValue | undefined>(
+  undefined,
+);
+
+export function CossistantProvider({
+  children,
+  defaultOpen = false,
+}: CossistantProviderProps) {
+  const [isOpen, setIsOpen] = React.useState(defaultOpen);
+
+  const open = React.useCallback(() => setIsOpen(true), []);
+  const close = React.useCallback(() => setIsOpen(false), []);
+  const toggle = React.useCallback(() => setIsOpen((o) => !o), []);
+
+  const value = React.useMemo<CossistantContextValue>(
+    () => ({ isOpen, open, close, toggle }),
+    [isOpen, open, close, toggle],
+  );
+
+  return (
+    <CossistantContext.Provider value={value}>{children}</CossistantContext.Provider>
+  );
+}
+
+export function useCossistant() {
+  const context = React.useContext(CossistantContext);
+  if (!context) {
+    throw new Error("useCossistant must be used within a CossistantProvider");
+  }
+  return context;
+}

--- a/packages/react/src/send-button.tsx
+++ b/packages/react/src/send-button.tsx
@@ -1,0 +1,14 @@
+import * as React from "react";
+
+export interface SendButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const SendButton = React.forwardRef<HTMLButtonElement, SendButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button type="button" ref={ref} className={className} {...props} />
+    );
+  },
+);
+
+SendButton.displayName = "SendButton";

--- a/packages/react/src/window.tsx
+++ b/packages/react/src/window.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import { useCossistant } from "./provider";
+
+export interface WindowProps extends React.HTMLAttributes<HTMLDivElement> {
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  id?: string;
+}
+
+export const Window = React.forwardRef<HTMLDivElement, WindowProps>(
+  (
+    { header, footer, children, className, id = "cossistant-window", ...props },
+    ref,
+  ) => {
+    const { isOpen, close } = useCossistant();
+
+    React.useEffect(() => {
+      if (!isOpen) {
+        return;
+      }
+      function onKey(e: KeyboardEvent) {
+        if (e.key === "Escape") {
+          close();
+        }
+      }
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [isOpen, close]);
+
+    if (!isOpen) {
+      return null;
+    }
+
+    return (
+      <div
+        role="dialog"
+        aria-modal="true"
+        id={id}
+        ref={ref}
+        className={className}
+        {...props}
+      >
+        {header && <div>{header}</div>}
+        <div>{children}</div>
+        {footer && <div>{footer}</div>}
+      </div>
+    );
+  },
+);
+
+Window.displayName = "Window";


### PR DESCRIPTION
## Summary
- integrate the new chat primitives into the web app
- expose a `ChatWidget` component using `Bubble`, `Window`, `Input`, and `SendButton`
- mount `ChatWidget` in the Next.js layout
- minor lint fixes to react package

## Testing
- `bun x @biomejs/biome lint packages/react/src apps/web/src/components/chat/widget.tsx`
- `bun run --filter @cossistant/react build`
- `npx tsc -p packages/react/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685fd58b5ab0832baa186bc73eb6ad5e