### PR TITLE
Load connection context for WebSocket events

### DIFF
--- a/apps/api/src/lib/pubsub.ts
+++ b/apps/api/src/lib/pubsub.ts
@@ -403,11 +403,11 @@ export class PubSubService {
 		}
 	}
 
-	async unregisterConnection(connectionId: string): Promise<void> {
-		const key = `connection:${connectionId}`;
-		const data = await redis.get<string>(key);
+        async unregisterConnection(connectionId: string): Promise<void> {
+                const key = `connection:${connectionId}`;
+                const data = await redis.get<string>(key);
 
-		if (data) {
+                if (data) {
 			const info = JSON.parse(data) as ConnectionInfo;
 
 			// Remove from website's connection set
@@ -419,14 +419,24 @@ export class PubSubService {
 			await redis.del(key);
 
 			console.log(`[PubSub] Unregistered connection: ${connectionId}`);
-		}
-	}
+                }
+        }
 
-	/**
-	 * Get all connections for a website
-	 */
-	async getWebsiteConnections(websiteId: string): Promise<ConnectionInfo[]> {
-		const connectionIds = await redis.smembers<string[]>(
+        /**
+         * Retrieve connection info directly from Redis
+         */
+        async getConnectionInfo(connectionId: string): Promise<ConnectionInfo | null> {
+                const key = `connection:${connectionId}`;
+                const data = await redis.get<string>(key);
+
+                return data ? (JSON.parse(data) as ConnectionInfo) : null;
+        }
+
+        /**
+         * Get all connections for a website
+         */
+        async getWebsiteConnections(websiteId: string): Promise<ConnectionInfo[]> {
+                const connectionIds = await redis.smembers<string[]>(
 			`website:${websiteId}:connections`,
 		);
 		if (!connectionIds || connectionIds.length === 0) {

--- a/apps/api/src/utils/api-keys/api-keys.test.ts
+++ b/apps/api/src/utils/api-keys/api-keys.test.ts
@@ -1,12 +1,20 @@
-import { describe, expect, it } from "bun:test";
-import { APIKeyType } from "@cossistant/types";
+import { describe, expect, it, mock } from "bun:test";
 
-import {
-	generateApiKey,
-	hashApiKey,
-	isValidPublicApiKeyFormat,
-	isValidSecretApiKeyFormat,
-} from "./index";
+const APIKeyType = {
+        PRIVATE: "PRIVATE",
+        PUBLIC: "PUBLIC",
+} as const;
+
+mock.module("@cossistant/types", () => ({
+        APIKeyType,
+}));
+
+const {
+        generateApiKey,
+        hashApiKey,
+        isValidPublicApiKeyFormat,
+        isValidSecretApiKeyFormat,
+} = await import("./index");
 
 const HEX_REGEX = /^[0-9a-f]+$/;
 

--- a/apps/api/src/ws/router.test.ts
+++ b/apps/api/src/ws/router.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { RealtimeEvent } from "@cossistant/types/realtime-events";
+
+const emitToDashboard = mock(async () => {});
+
+mock.module("@api/lib/pubsub", () => ({
+        emitToDashboard,
+        pubsub: {
+                publish: async () => {},
+        },
+}));
+
+const routerModulePromise = import("./router");
+
+describe("routeEvent", () => {
+        beforeEach(() => {
+                emitToDashboard.mockReset();
+        });
+
+        it("emits USER_PRESENCE_UPDATE to the dashboard when a visitor triggers it", async () => {
+                const { routeEvent } = await routerModulePromise;
+
+                const event: RealtimeEvent<"USER_PRESENCE_UPDATE"> = {
+                        type: "USER_PRESENCE_UPDATE",
+                        data: {
+                                userId: "user-123",
+                                status: "online",
+                                lastSeen: Date.now(),
+                        },
+                        timestamp: Date.now(),
+                };
+
+                await routeEvent(event, {
+                        connectionId: "conn-123",
+                        visitorId: "visitor-456",
+                        websiteId: "website-789",
+                        organizationId: "org-000",
+                });
+
+                expect(emitToDashboard).toHaveBeenCalledTimes(1);
+                expect(emitToDashboard).toHaveBeenCalledWith(
+                        "website-789",
+                        "USER_PRESENCE_UPDATE",
+                        event.data,
+                );
+        });
+});


### PR DESCRIPTION
## Summary
- add a Redis helper to retrieve stored connection metadata
- hydrate WebSocket event context with cached or Redis-backed connection details and report errors when metadata is missing
- add coverage ensuring USER_PRESENCE_UPDATE events from visitors emit dashboard updates and mock heavy dependencies in socket tests

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68ca78925620832b8bbf7e8b2391f1a9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved real-time message handling with stricter validation and clearer error responses for invalid event types or missing connection context.
  - More reliable routing of presence updates and events to dashboards, reducing dropped or misrouted messages.

- Tests
  - Added comprehensive tests for WebSocket routing and messaging, including presence update forwarding.
  - Expanded mocking to ensure deterministic, isolated test coverage for real-time behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->