### PR TITLE
feat(web): add dashboard websocket provider

### DIFF
--- a/apps/api/src/db/queries/session.ts
+++ b/apps/api/src/db/queries/session.ts
@@ -1,8 +1,8 @@
 import type { Database } from "@api/db";
 import type {
-	ApiKeySelect,
-	OrganizationSelect,
-	WebsiteSelect,
+        ApiKeySelect,
+        OrganizationSelect,
+        WebsiteSelect,
 } from "@api/db/schema";
 import { session, user } from "@api/db/schema";
 import { auth } from "@api/lib/auth";
@@ -10,36 +10,87 @@ import { auth } from "@api/lib/auth";
 import { eq } from "drizzle-orm";
 
 export type ApiKeyWithWebsiteAndOrganization = ApiKeySelect & {
-	website: WebsiteSelect;
-	organization: OrganizationSelect;
+        website: WebsiteSelect;
+        organization: OrganizationSelect;
 };
 
-export async function getTRPCSession(
-	db: Database,
-	params: {
-		headers: Headers;
-	},
+const MAX_SESSION_TOKEN_LENGTH = 512;
+
+export function normalizeSessionToken(
+        token: string | null | undefined,
+): string | undefined {
+        if (!token) {
+                return undefined;
+        }
+
+        const trimmed = token.trim();
+        if (!trimmed) {
+                return undefined;
+        }
+
+        if (trimmed.length > MAX_SESSION_TOKEN_LENGTH) {
+                return undefined;
+        }
+
+        return trimmed;
+}
+
+export async function resolveSession(
+        db: Database,
+        params: {
+                headers: Headers;
+                sessionToken?: string | null;
+        },
 ) {
-	let userSession = await auth.api.getSession({ headers: params.headers });
+        let userSession = await auth.api.getSession({ headers: params.headers });
 
-	const sessionToken = params.headers.get("x-user-session-token");
+        const tokensToCheck = new Set<string>();
 
-	if (sessionToken) {
-		const [res] = await db
-			.select()
-			.from(session)
-			.where(eq(session.token, sessionToken))
-			.innerJoin(user, eq(session.userId, user.id))
-			.limit(1)
-			.$withCache({ tag: "session" });
+        const normalizedOverride = normalizeSessionToken(params.sessionToken);
+        if (normalizedOverride) {
+                tokensToCheck.add(normalizedOverride);
+        }
 
-		if (res) {
-			userSession = {
-				session: res.session,
-				user: res.user,
-			};
-		}
-	}
+        const headerToken = normalizeSessionToken(
+                params.headers.get("x-user-session-token"),
+        );
+        if (headerToken) {
+                tokensToCheck.add(headerToken);
+        }
 
-	return userSession;
+        // Avoid querying again if the Better Auth session already resolves to the
+        // same token.
+        const currentToken = normalizeSessionToken(userSession?.session?.token);
+        if (currentToken) {
+                tokensToCheck.delete(currentToken);
+        }
+
+        for (const token of tokensToCheck) {
+                const [res] = await db
+                        .select()
+                        .from(session)
+                        .where(eq(session.token, token))
+                        .innerJoin(user, eq(session.userId, user.id))
+                        .limit(1)
+                        .$withCache({ tag: "session" });
+
+                if (res) {
+                        userSession = {
+                                session: res.session,
+                                user: res.user,
+                        };
+                        break;
+                }
+        }
+
+        return userSession;
+}
+
+export async function getTRPCSession(
+        db: Database,
+        params: {
+                headers: Headers;
+        },
+) {
+        return await resolveSession(db, { headers: params.headers });
 }

--- a/apps/api/src/db/queries/session.ts
+++ b/apps/api/src/db/queries/session.ts
@@ -65,15 +65,15 @@ export async function resolveSession(
                 tokensToCheck.delete(currentToken);
         }
 
+        const now = new Date();
         for (const token of tokensToCheck) {
                 const [res] = await db
                         .select()
                         .from(session)
-                        .where(eq(session.token, token))
+                        .where(and(eq(session.token, token), gt(session.expiresAt, now)))
                         .innerJoin(user, eq(session.userId, user.id))
                         .limit(1)
-                        .$withCache({ tag: "session" });
-
+                        .$withCache({ tag: `session:${token}` });
                 if (res) {
                         userSession = {
                                 session: res.session,

--- a/apps/api/src/ws/socket.test.ts
+++ b/apps/api/src/ws/socket.test.ts
@@ -2,8 +2,19 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 mock.module("@api/db", () => ({ db: {} }));
 mock.module("@api/db/queries/api-keys", () => ({}));
+mock.module("@api/db/queries/session", () => ({
+        normalizeSessionToken: (token: string | null | undefined) =>
+                token?.trim() || undefined,
+        resolveSession: async () => null,
+}));
 mock.module("@api/db/schema", () => ({ website: {} }));
-mock.module("@api/lib/auth", () => ({ auth: {} }));
+mock.module("@api/lib/auth", () => ({
+        auth: {
+                api: {
+                        getSession: async () => null,
+                },
+        },
+}));
 mock.module("drizzle-orm", () => ({
         eq: () => ({}),
 }));

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/layout.tsx
@@ -3,6 +3,7 @@ import { CentralContainer } from "@/components/ui/layout";
 import { NavigationTopbar } from "@/components/ui/layout/navigation-topbar";
 import { InboxesProvider } from "@/contexts/inboxes";
 import { WebsiteProvider } from "@/contexts/website";
+import { DashboardWebSocketProvider } from "./providers/websocket";
 import {
   getQueryClient,
   HydrateClient,
@@ -66,12 +67,14 @@ export default async function Layout({ children, params }: LayoutProps) {
   return (
     <HydrateClient>
       <WebsiteProvider websiteSlug={websiteSlug}>
-        <InboxesProvider websiteSlug={websiteSlug}>
-          <div className="h-screen w-screen overflow-hidden bg-background-100 dark:bg-background">
-            <NavigationTopbar />
-            <CentralContainer>{children}</CentralContainer>
-          </div>
-        </InboxesProvider>
+        <DashboardWebSocketProvider>
+          <InboxesProvider websiteSlug={websiteSlug}>
+            <div className="h-screen w-screen overflow-hidden bg-background-100 dark:bg-background">
+              <NavigationTopbar />
+              <CentralContainer>{children}</CentralContainer>
+            </div>
+          </InboxesProvider>
+        </DashboardWebSocketProvider>
       </WebsiteProvider>
     </HydrateClient>
   );

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/providers/websocket.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/providers/websocket.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import type { RealtimeEvent } from "@cossistant/types/realtime-events";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import useWebSocketLib, { ReadyState } from "react-use-websocket";
+import { useUserSession, useWebsite } from "@/contexts/website";
+import { getWebSocketUrl } from "@/lib/url";
+
+interface DashboardWebSocketContextValue {
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: Error | null;
+  send: (event: RealtimeEvent) => void;
+  subscribe: (handler: (event: RealtimeEvent) => void) => () => void;
+  lastMessage: RealtimeEvent | null;
+  userId: string | null;
+  websiteId: string | null;
+}
+
+interface DashboardWebSocketProviderProps {
+  children: ReactNode;
+  autoConnect?: boolean;
+}
+
+const DashboardWebSocketContext =
+  createContext<DashboardWebSocketContextValue | null>(null);
+
+export function DashboardWebSocketProvider({
+  children,
+  autoConnect = true,
+}: DashboardWebSocketProviderProps) {
+  const { session, user } = useUserSession();
+  const website = useWebsite();
+
+  const [connectionError, setConnectionError] = useState<Error | null>(null);
+  const [socketUrl, setSocketUrl] = useState<string | null>(null);
+
+  const eventHandlersRef = useRef<Set<(event: RealtimeEvent) => void>>(new Set());
+  const lastMessageRef = useRef<RealtimeEvent | null>(null);
+
+  const sessionToken = session?.token ?? null;
+  const websiteId = website?.id ?? null;
+  const userId = user?.id ?? null;
+
+  useEffect(() => {
+    if (!autoConnect) {
+      setSocketUrl(null);
+      return;
+    }
+
+    if (!sessionToken) {
+      setSocketUrl(null);
+      return;
+    }
+
+    try {
+      const url = new URL(getWebSocketUrl());
+      url.searchParams.set("sessionToken", sessionToken);
+      if (websiteId) {
+        url.searchParams.set("websiteId", websiteId);
+      }
+      setSocketUrl(url.toString());
+      setConnectionError(null);
+    } catch (error) {
+      const err =
+        error instanceof Error
+          ? error
+          : new Error("Failed to build dashboard WebSocket URL");
+      console.error("[Dashboard WS] Failed to build WebSocket URL", err);
+      setConnectionError(err);
+      setSocketUrl(null);
+    }
+  }, [autoConnect, sessionToken, websiteId]);
+
+  useEffect(() => {
+    if (!sessionToken && autoConnect) {
+      console.warn(
+        "[Dashboard WS] Session token missing, skipping WebSocket connection.",
+      );
+    }
+  }, [autoConnect, sessionToken]);
+
+  const webSocketOptions = useMemo(
+    () => ({
+      shouldReconnect: (closeEvent: CloseEvent) => {
+        if (closeEvent.code === 1008 || closeEvent.code === 1011) {
+          const err = new Error(
+            closeEvent.reason ||
+              "Authentication failed. Please ensure your session is valid.",
+          );
+          setConnectionError(err);
+          return false;
+        }
+        return true;
+      },
+      reconnectAttempts: 10,
+      reconnectInterval: 3000,
+      onOpen: () => {
+        setConnectionError(null);
+        console.log("[Dashboard WS] Connected", {
+          userId,
+          websiteId,
+        });
+      },
+      onClose: (event: CloseEvent) => {
+        console.log("[Dashboard WS] Disconnected", {
+          code: event.code,
+          reason: event.reason,
+          wasClean: event.wasClean,
+        });
+        if (event.code === 1008 || event.code === 1011) {
+          const err = new Error(
+            event.reason || "Connection closed due to authentication failure",
+          );
+          setConnectionError(err);
+        }
+      },
+      onError: (event: Event) => {
+        const err = new Error(`WebSocket error: ${event.type}`);
+        setConnectionError(err);
+        console.error("[Dashboard WS] WebSocket error", event);
+      },
+    }),
+    [userId, websiteId],
+  );
+
+  const { sendMessage, lastMessage, readyState } = useWebSocketLib(
+    socketUrl,
+    webSocketOptions,
+  );
+
+  useEffect(() => {
+    if (!lastMessage) {
+      return;
+    }
+
+    try {
+      const data = JSON.parse(lastMessage.data);
+
+      if (data?.error && data?.message) {
+        const err = new Error(data.message);
+        setConnectionError(err);
+        return;
+      }
+
+      const event = data as RealtimeEvent;
+      lastMessageRef.current = event;
+
+      if (event.type === "VISITOR_CONNECTED") {
+        console.log("[Dashboard WS] Visitor connected", event.data);
+      } else if (event.type === "VISITOR_DISCONNECTED") {
+        console.log("[Dashboard WS] Visitor disconnected", event.data);
+      }
+
+      for (const handler of eventHandlersRef.current) {
+        handler(event);
+      }
+    } catch (error) {
+      console.error("[Dashboard WS] Failed to parse message", error);
+    }
+  }, [lastMessage]);
+
+  const send = useCallback(
+    (event: RealtimeEvent) => {
+      if (readyState !== ReadyState.OPEN) {
+        throw new Error("WebSocket is not connected");
+      }
+
+      sendMessage(JSON.stringify(event));
+    },
+    [readyState, sendMessage],
+  );
+
+  const subscribe = useCallback((handler: (event: RealtimeEvent) => void) => {
+    eventHandlersRef.current.add(handler);
+    return () => {
+      eventHandlersRef.current.delete(handler);
+    };
+  }, []);
+
+  const value = useMemo<DashboardWebSocketContextValue>(
+    () => ({
+      isConnected: readyState === ReadyState.OPEN,
+      isConnecting: readyState === ReadyState.CONNECTING,
+      error: connectionError,
+      send,
+      subscribe,
+      lastMessage: lastMessageRef.current,
+      userId,
+      websiteId,
+    }),
+    [connectionError, readyState, send, subscribe, userId, websiteId],
+  );
+
+  return (
+    <DashboardWebSocketContext.Provider value={value}>
+      {children}
+    </DashboardWebSocketContext.Provider>
+  );
+}
+
+export function useDashboardWebSocket(): DashboardWebSocketContextValue {
+  const context = useContext(DashboardWebSocketContext);
+
+  if (!context) {
+    throw new Error(
+      "useDashboardWebSocket must be used within a DashboardWebSocketProvider",
+    );
+  }
+
+  return context;
+}
+
+interface UseDashboardRealtimeOptions {
+  onEvent?: (event: RealtimeEvent) => void;
+}
+
+export function useDashboardRealtime(
+  options: UseDashboardRealtimeOptions = {},
+) {
+  const { onEvent } = options;
+  const context = useDashboardWebSocket();
+
+  useEffect(() => {
+    if (!onEvent) {
+      return;
+    }
+
+    const unsubscribe = context.subscribe(onEvent);
+
+    return unsubscribe;
+  }, [context, onEvent]);
+
+  return {
+    isConnected: context.isConnected,
+    isConnecting: context.isConnecting,
+    error: context.error,
+    send: context.send,
+    lastMessage: context.lastMessage,
+  };
+}


### PR DESCRIPTION
## Summary
- add a dashboard websocket context provider that authenticates with the user session token and shares connection utilities across the dashboard
- wire the new provider into the dashboard layout so nested pages can consume realtime events and log visitor connection activity

## Testing
- bun --cwd apps/web lint *(fails: biome CLI missing compatible schema and unknown rule in shared config)*

------
https://chatgpt.com/codex/tasks/task_e_68ca898aae30832b9085ee2d6a572798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time dashboard updates via a new WebSocket connection (auto-connect, reconnection, and event subscription).
  * Live presence signals (e.g., visitor connect/disconnect) and a unified hook to access connection state and send events.
* **Bug Fixes**
  * More reliable session-based authentication for WebSocket connections, reducing unexpected disconnects.
  * Clearer error messaging when session tokens are missing or invalid.
* **Refactor**
  * Consolidated session resolution logic for consistency across API and WebSocket flows, improving stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->