### PR TITLE
fix(api): ensure visitor connection events reach dashboard

### DIFF
--- a/apps/api/src/utils/websocket/websocket-connection.test.ts
+++ b/apps/api/src/utils/websocket/websocket-connection.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+import type { AuthResult } from "./websocket-connection";
+
+mock.module("@api/lib/pubsub", () => ({
+        pubsub: {
+                getServerId: () => "server-1",
+                updatePresence: async () => {},
+        },
+}));
+
+mock.module("@api/ws/socket", () => ({
+        generateConnectionId: () => "generated-connection-id",
+}));
+
+const modulePromise = import("./websocket-connection");
+
+let createConnectionEvent: (authResult: AuthResult, connectionId: string) => unknown;
+
+beforeEach(async () => {
+        const module = await modulePromise;
+        createConnectionEvent = module.createConnectionEvent;
+});
+
+describe("createConnectionEvent", () => {
+        it("creates a USER_CONNECTED event when a user id is present", () => {
+                const authResult: AuthResult = {
+                        userId: "user-123",
+                        websiteId: "site-001",
+                        organizationId: "org-002",
+                };
+
+                const event = createConnectionEvent(authResult, "conn-abc") as {
+                        type: string;
+                        data: Record<string, unknown>;
+                        timestamp: number;
+                };
+
+                expect(event.type).toBe("USER_CONNECTED");
+                expect(event.data).toMatchObject({
+                        userId: "user-123",
+                        connectionId: "conn-abc",
+                });
+                expect(typeof event.data.timestamp).toBe("number");
+                expect(typeof event.timestamp).toBe("number");
+        });
+
+        it("creates a VISITOR_CONNECTED event when a visitor id is present", () => {
+                const authResult: AuthResult = {
+                        visitorId: "visitor-456",
+                        websiteId: "site-001",
+                        organizationId: "org-002",
+                };
+
+                const event = createConnectionEvent(authResult, "conn-def") as {
+                        type: string;
+                        data: Record<string, unknown>;
+                        timestamp: number;
+                };
+
+                expect(event.type).toBe("VISITOR_CONNECTED");
+                expect(event.data).toMatchObject({
+                        visitorId: "visitor-456",
+                        connectionId: "conn-def",
+                });
+                expect(typeof event.data.timestamp).toBe("number");
+                expect(typeof event.timestamp).toBe("number");
+        });
+
+        it("throws when neither user nor visitor identifiers are provided", () => {
+                const authResult = {} as AuthResult;
+
+                expect(() => createConnectionEvent(authResult, "conn-ghi")).toThrow(
+                        "No visitorId available for visitor connection",
+                );
+        });
+});

--- a/apps/api/src/ws/router.test.ts
+++ b/apps/api/src/ws/router.test.ts
@@ -44,4 +44,32 @@ describe("routeEvent", () => {
                         event.data,
                 );
         });
+
+        it("emits VISITOR_CONNECTED to the dashboard when a visitor joins", async () => {
+                const { routeEvent } = await routerModulePromise;
+
+                const event: RealtimeEvent<"VISITOR_CONNECTED"> = {
+                        type: "VISITOR_CONNECTED",
+                        data: {
+                                visitorId: "visitor-123",
+                                connectionId: "conn-456",
+                                timestamp: Date.now(),
+                        },
+                        timestamp: Date.now(),
+                };
+
+                await routeEvent(event, {
+                        connectionId: "conn-456",
+                        visitorId: "visitor-123",
+                        websiteId: "website-abc",
+                        organizationId: "org-xyz",
+                });
+
+                expect(emitToDashboard).toHaveBeenCalledTimes(1);
+                expect(emitToDashboard).toHaveBeenCalledWith(
+                        "website-abc",
+                        "VISITOR_CONNECTED",
+                        event.data,
+                );
+        });
 });

--- a/apps/api/src/ws/socket.ts
+++ b/apps/api/src/ws/socket.ts
@@ -690,21 +690,21 @@ export const upgradedWebsocket = upgradeWebSocket(async (c) => {
 			sendConnectionEstablishedMessage(ws, connectionId, authResult);
 
 			// Emit USER_CONNECTED or VISITOR_CONNECTED event based on authentication type
-			try {
-				const event = createConnectionEvent(authResult, connectionId);
-				const context: EventContext = {
-					connectionId,
-					userId: authResult.userId,
-					visitorId: authResult.visitorId,
-					websiteId: authResult.websiteId,
-					organizationId: authResult.organizationId,
-					ws: undefined,
-				};
-				routeEvent(event, context);
-			} catch (error) {
-				console.error("[WebSocket] Error creating connection event:", error);
-				// Continue with connection setup even if event creation fails
-			}
+                        try {
+                                const event = createConnectionEvent(authResult, connectionId);
+                                const context: EventContext = {
+                                        connectionId,
+                                        userId: authResult.userId,
+                                        visitorId: authResult.visitorId,
+                                        websiteId: authResult.websiteId,
+                                        organizationId: authResult.organizationId,
+                                        ws: undefined,
+                                };
+                                await routeEvent(event, context);
+                        } catch (error) {
+                                console.error("[WebSocket] Error creating connection event:", error);
+                                // Continue with connection setup even if event creation fails
+                        }
 
 			// Set up subscriptions for this connection
 			await ensureSubscriptions(connectionId, authResult.websiteId);


### PR DESCRIPTION
## Summary
- await routing of connection lifecycle events so visitor connects trigger downstream handlers
- cover visitor connection emission in the router test suite to ensure dashboard notifications fire
- add targeted tests for createConnectionEvent to validate user and visitor payloads

## Testing
- bun test apps/api/src/ws/socket.test.ts
- bun test apps/api/src/ws/router.test.ts
- bun test apps/api/src/utils/websocket/websocket-connection.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cab913513c832b9c38f6c9b895e72f