### PR TITLE
feat(api): adopt redis streams for realtime

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -35,10 +35,11 @@ export const env = {
 		"UPSTASH_REDIS_REST_URL",
 		"http://localhost:8079"
 	),
-	UPSTASH_REDIS_REST_TOKEN: getEnvVariable(
-		"UPSTASH_REDIS_REST_TOKEN",
-		"example_token"
-	),
+        UPSTASH_REDIS_REST_TOKEN: getEnvVariable(
+                "UPSTASH_REDIS_REST_TOKEN",
+                "example_token"
+        ),
+        REDIS_URL: getEnvVariable("REDIS_URL", "redis://localhost:6379"),
 	BETTER_AUTH_URL: getEnvVariable("BETTER_AUTH_URL"),
 	BETTER_AUTH_SECRET: getEnvVariable("BETTER_AUTH_SECRET"),
 	API_KEY_SECRET: getEnvVariable("API_KEY_SECRET"),

--- a/apps/api/src/ws/connection-registry.ts
+++ b/apps/api/src/ws/connection-registry.ts
@@ -1,0 +1,110 @@
+import type { RealtimeEvent } from "@cossistant/types/realtime-events";
+import type { ServerWebSocket } from "bun";
+import type { DispatchOptions } from "./router";
+
+export type RawSocket = ServerWebSocket & { connectionId?: string };
+
+export type LocalConnectionRecord = {
+	socket: RawSocket;
+	websiteId?: string;
+	organizationId?: string;
+	userId?: string;
+	visitorId?: string;
+};
+
+export const localConnections = new Map<string, LocalConnectionRecord>();
+
+function createExcludePredicate(
+	options?: DispatchOptions
+): ((connectionId: string) => boolean) | undefined {
+	if (!options?.exclude) {
+		return;
+	}
+
+	const excludeIds = Array.isArray(options.exclude)
+		? new Set(options.exclude)
+		: new Set<string>([options.exclude]);
+
+	return (connectionId: string) => excludeIds.has(connectionId);
+}
+
+function sendEventToSocket(
+	record: LocalConnectionRecord,
+	serializedEvent: string
+): void {
+	try {
+		record.socket.send(serializedEvent);
+	} catch (error) {
+		console.error("[WebSocket] Failed to send event:", error);
+	}
+}
+
+export function dispatchEventToLocalConnection(
+	connectionId: string,
+	event: RealtimeEvent
+): void {
+	const connection = localConnections.get(connectionId);
+	if (!connection) {
+		return;
+	}
+
+	const serializedEvent = JSON.stringify(event);
+	sendEventToSocket(connection, serializedEvent);
+}
+
+export function dispatchEventToLocalVisitor(
+	visitorId: string,
+	event: RealtimeEvent,
+	options?: DispatchOptions
+): void {
+	const shouldExclude = createExcludePredicate(options);
+	const serializedEvent = JSON.stringify(event);
+
+	for (const [connectionId, connection] of localConnections) {
+		if (connection.visitorId !== visitorId) {
+			continue;
+		}
+
+		if (shouldExclude?.(connectionId)) {
+			continue;
+		}
+
+		console.log("[WebSocket] Dispatching visitor event", {
+			visitorId,
+			connectionId,
+			eventType: event.type,
+		});
+		sendEventToSocket(connection, serializedEvent);
+	}
+}
+
+export function dispatchEventToLocalWebsite(
+	websiteId: string,
+	event: RealtimeEvent,
+	options?: DispatchOptions
+): void {
+	const shouldExclude = createExcludePredicate(options);
+	const serializedEvent = JSON.stringify(event);
+
+	for (const [connectionId, connection] of localConnections) {
+		if (connection.websiteId !== websiteId) {
+			continue;
+		}
+
+		// Only dashboard/user connections should receive website events
+		if (!connection.userId) {
+			continue;
+		}
+
+		if (shouldExclude?.(connectionId)) {
+			continue;
+		}
+
+		console.log("[WebSocket] Dispatching website event", {
+			websiteId,
+			connectionId,
+			eventType: event.type,
+		});
+		sendEventToSocket(connection, serializedEvent);
+	}
+}

--- a/apps/api/src/ws/realtime-pubsub.ts
+++ b/apps/api/src/ws/realtime-pubsub.ts
@@ -1,0 +1,397 @@
+import { env } from "@api/env";
+import {
+        isValidEventType,
+        type RealtimeEvent,
+        validateRealtimeEvent,
+} from "@cossistant/types/realtime-events";
+import Redis, { type RedisOptions } from "ioredis";
+import type { DispatchOptions } from "./router";
+
+const STREAM_KEY = "realtime:dispatch";
+const STREAM_MAX_LEN = 10_000;
+const STREAM_FIELD = "payload";
+const STREAM_BLOCK_MS = 5_000;
+const STREAM_BATCH_SIZE = 50;
+const MAX_PUBLISH_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 100;
+const CURSOR_PERSIST_INTERVAL_MS = 1_000;
+const CURSOR_KEY_PREFIX = "realtime:cursor:";
+
+const instanceId = `api-${process.pid ?? "pid"}-${Math.random()
+        .toString(36)
+        .slice(2, 10)}`;
+
+const redisOptions: RedisOptions = {
+        lazyConnect: true,
+        maxRetriesPerRequest: null,
+        enableAutoPipelining: true,
+        reconnectOnError: (error) => {
+                console.error("[RealtimeRedis] Connection error", error);
+                return true;
+        },
+        retryStrategy: (attempt) => Math.min(1000 * attempt, 5000),
+};
+
+let publisher: Redis | null = null;
+let subscriber: Redis | null = null;
+
+type DispatchTarget =
+	| {
+			type: "connection";
+			id: string;
+	  }
+	| {
+			type: "visitor" | "website";
+			id: string;
+			exclude?: string[];
+	  };
+
+type DispatchEnvelope = {
+        sourceId: string;
+        target: DispatchTarget;
+        event: RealtimeEvent;
+};
+
+type LocalDispatchers = {
+	connection: (connectionId: string, event: RealtimeEvent) => void;
+	visitor: (
+		visitorId: string,
+		event: RealtimeEvent,
+		options?: DispatchOptions
+	) => void;
+	website: (
+		websiteId: string,
+		event: RealtimeEvent,
+		options?: DispatchOptions
+	) => void;
+};
+
+let dispatchersRef: LocalDispatchers | null = null;
+let consumerRunning = false;
+let lastSeenId = "$";
+let lastProcessedId: string | null = null;
+let cursorPersistTimer: ReturnType<typeof setTimeout> | null = null;
+
+const instanceCursorKey = `${CURSOR_KEY_PREFIX}${instanceId}`;
+
+function setInitialLastSeenId(): void {
+        lastSeenId = "$";
+}
+
+function markProcessed(id: string): void {
+        lastProcessedId = id;
+
+        if (cursorPersistTimer) {
+                return;
+        }
+
+        cursorPersistTimer = setTimeout(() => {
+                cursorPersistTimer = null;
+                const idToPersist = lastProcessedId;
+                if (!idToPersist || idToPersist === "$") {
+                        return;
+                }
+
+                void getPublisher()
+                        .then((client) => client.set(instanceCursorKey, idToPersist))
+                        .catch((error) => {
+                                console.error(
+                                        "[RealtimeStreams] Failed to persist cursor", error
+                                );
+                        });
+        }, CURSOR_PERSIST_INTERVAL_MS);
+}
+
+function createRedisClient(role: "publisher" | "subscriber"): Redis {
+        const client = new Redis(env.REDIS_URL, redisOptions);
+        client.on("error", (error) => {
+                console.error(`[RealtimeRedis] ${role} error`, error);
+        });
+        client.on("end", () => {
+                console.warn(`[RealtimeRedis] ${role} connection ended`);
+        });
+
+        return client;
+}
+
+async function getPublisher(): Promise<Redis> {
+        if (!publisher) {
+                publisher = createRedisClient("publisher");
+        }
+
+        if (publisher.status === "wait") {
+                await publisher.connect();
+        }
+
+        return publisher;
+}
+
+async function getSubscriber(): Promise<Redis> {
+        if (!subscriber) {
+                subscriber = createRedisClient("subscriber");
+        }
+
+        if (subscriber.status === "wait") {
+                await subscriber.connect();
+        }
+
+        return subscriber;
+}
+
+async function loadCursor(): Promise<void> {
+        try {
+            const client = await getPublisher();
+            const storedCursor = await client.get(instanceCursorKey);
+            if (storedCursor) {
+                    lastSeenId = storedCursor;
+                    lastProcessedId = storedCursor;
+            } else {
+                    setInitialLastSeenId();
+            }
+        } catch (error) {
+                console.error("[RealtimeStreams] Failed to load cursor", error);
+                setInitialLastSeenId();
+        }
+}
+
+function normalizeExclude(options?: DispatchOptions): string[] | undefined {
+	if (!options?.exclude) {
+		return;
+	}
+
+	return Array.isArray(options.exclude) ? options.exclude : [options.exclude];
+}
+
+function handleEnvelope(envelope: DispatchEnvelope | undefined): void {
+	if (!envelope) {
+		return;
+	}
+
+	const dispatchers = dispatchersRef;
+	if (!dispatchers) {
+		return;
+	}
+
+	const { event, target } = envelope;
+
+	if (!isValidEventType(event.type)) {
+		console.error("[RealtimePubSub] Ignoring invalid event type", event.type);
+		return;
+	}
+
+	try {
+		validateRealtimeEvent(event.type, event.data);
+	} catch (error) {
+		console.error(
+			"[RealtimePubSub] Ignoring event with invalid payload",
+			error
+		);
+		return;
+	}
+
+	const exclude =
+		target.type === "connection"
+			? undefined
+			: target.exclude?.filter(
+					(value): value is string => typeof value === "string"
+				);
+	const options = exclude?.length
+		? ({ exclude } satisfies DispatchOptions)
+		: undefined;
+
+	try {
+		switch (target.type) {
+			case "connection": {
+				dispatchers.connection(target.id, event);
+				break;
+			}
+			case "visitor": {
+				dispatchers.visitor(target.id, event, options);
+				break;
+			}
+			case "website": {
+				dispatchers.website(target.id, event, options);
+				break;
+			}
+			default: {
+				const exhaustiveCheck: never = target;
+                                console.error(
+                                        "[RealtimePubSub] Unsupported dispatch target",
+                                        exhaustiveCheck
+                                );
+                        }
+                }
+        } catch (error) {
+                console.error("[RealtimePubSub] Failed to dispatch realtime event", error);
+        }
+}
+
+function fieldsToRecord(fields: string[]): Record<string, string> {
+        const record: Record<string, string> = {};
+        for (let index = 0; index < fields.length; index += 2) {
+                const key = fields[index];
+                const value = fields[index + 1];
+                if (typeof key === "string" && typeof value === "string") {
+                        record[key] = value;
+                }
+        }
+
+        return record;
+}
+
+function parseStreamEntry(fields: string[]): DispatchEnvelope | null {
+        const record = fieldsToRecord(fields);
+        const payload = record[STREAM_FIELD];
+
+        if (!payload) {
+                return null;
+        }
+
+        try {
+                const parsed = JSON.parse(payload) as DispatchEnvelope;
+                return parsed;
+        } catch (error) {
+                console.error("[RealtimeStreams] Failed to parse payload", error);
+                return null;
+        }
+}
+
+async function runConsumerLoop(): Promise<void> {
+        if (consumerRunning || !dispatchersRef) {
+                return;
+        }
+
+        consumerRunning = true;
+
+        await loadCursor();
+
+        while (dispatchersRef) {
+                try {
+                        const client = await getSubscriber();
+                        const response = await client.xread(
+                                "BLOCK",
+                                STREAM_BLOCK_MS,
+                                "COUNT",
+                                STREAM_BATCH_SIZE,
+                                "STREAMS",
+                                STREAM_KEY,
+                                lastSeenId
+                        );
+
+                        if (!response) {
+                                continue;
+                        }
+
+                        for (const [, entries] of response) {
+                                for (const [id, fields] of entries) {
+                                        const envelope = parseStreamEntry(fields);
+                                        if (!envelope) {
+                                                continue;
+                                        }
+
+                                        lastSeenId = id;
+                                        markProcessed(id);
+                                        handleEnvelope(envelope);
+                                }
+                        }
+                } catch (error) {
+                        console.error("[RealtimeStreams] Consumer loop error", error);
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                }
+        }
+
+        consumerRunning = false;
+}
+
+async function publishEnvelope(
+        envelope: DispatchEnvelope,
+        attempt = 0
+): Promise<void> {
+        try {
+                const client = await getPublisher();
+                await client.xadd(
+                        STREAM_KEY,
+                        "MAXLEN",
+                        "~",
+                        STREAM_MAX_LEN,
+                        "*",
+                        STREAM_FIELD,
+                        JSON.stringify(envelope)
+                );
+        } catch (error) {
+                if (attempt >= MAX_PUBLISH_RETRIES) {
+                        console.error(
+                                "[RealtimePubSub] Failed to publish realtime event after retries",
+                                error
+                        );
+                        return;
+                }
+
+                const retryDelay = BASE_RETRY_DELAY_MS * 2 ** attempt;
+                setTimeout(() => {
+                        publishEnvelope(envelope, attempt + 1).catch((retryError) => {
+                                console.error(
+                                        "[RealtimePubSub] Failed to publish realtime event",
+                                        retryError
+                                );
+                        });
+                }, retryDelay);
+        }
+}
+
+export function initializeRealtimePubSub(dispatchers: LocalDispatchers): void {
+        dispatchersRef = dispatchers;
+
+        void runConsumerLoop();
+}
+
+export function publishToConnection(
+        connectionId: string,
+        event: RealtimeEvent
+): Promise<void> {
+	const envelope: DispatchEnvelope = {
+		sourceId: instanceId,
+		target: { type: "connection", id: connectionId },
+		event,
+	};
+
+	return publishEnvelope(envelope);
+}
+
+export function publishToVisitor(
+	visitorId: string,
+	event: RealtimeEvent,
+	options?: DispatchOptions
+): Promise<void> {
+	const exclude = normalizeExclude(options);
+	const envelope: DispatchEnvelope = {
+		sourceId: instanceId,
+		target: {
+			type: "visitor",
+			id: visitorId,
+			exclude,
+		},
+		event,
+	};
+
+	return publishEnvelope(envelope);
+}
+
+export function publishToWebsite(
+	websiteId: string,
+	event: RealtimeEvent,
+	options?: DispatchOptions
+): Promise<void> {
+	const exclude = normalizeExclude(options);
+	const envelope: DispatchEnvelope = {
+		sourceId: instanceId,
+		target: {
+			type: "website",
+			id: websiteId,
+			exclude,
+		},
+		event,
+	};
+
+	return publishEnvelope(envelope);
+}

--- a/apps/api/src/ws/router.test.ts
+++ b/apps/api/src/ws/router.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
 import type { RealtimeEvent } from "@cossistant/types/realtime-events";
-import { routeEvent } from "./router";
 import type { EventContext } from "./router";
+import { routeEvent } from "./router";
 
 const sendToWebsite = mock<NonNullable<EventContext["sendToWebsite"]>>();
 const sendToVisitor = mock<NonNullable<EventContext["sendToVisitor"]>>();

--- a/apps/api/src/ws/router.ts
+++ b/apps/api/src/ws/router.ts
@@ -177,4 +177,11 @@ export async function routeEvent<T extends RealtimeEventType>(
 	}
 }
 
-export type { EventContext, EventHandler, ConnectionDispatcher, VisitorDispatcher, WebsiteDispatcher, DispatchOptions };
+export type {
+	ConnectionDispatcher,
+	DispatchOptions,
+	EventContext,
+	EventHandler,
+	VisitorDispatcher,
+	WebsiteDispatcher,
+};

--- a/apps/api/src/ws/socket.test.ts
+++ b/apps/api/src/ws/socket.test.ts
@@ -3,7 +3,7 @@ import type { RealtimeEvent } from "@cossistant/types/realtime-events";
 import type { EventContext } from "./router";
 import type { RawSocket } from "./socket";
 
-const routeEventCalls: Array<[RealtimeEvent, EventContext]> = [];
+const routeEventCalls: [RealtimeEvent, EventContext][] = [];
 
 mock.module("@api/db", () => ({ db: {} }));
 mock.module("@api/db/queries/api-keys", () => ({}));
@@ -53,6 +53,12 @@ mock.module("@api/utils/websocket-connection", () => ({
 }));
 mock.module("@api/utils/websocket-updates", () => ({
 	updateLastSeenTimestamps: async () => {},
+}));
+mock.module("./realtime-pubsub", () => ({
+	initializeRealtimePubSub: () => {},
+	publishToConnection: () => Promise.resolve(),
+	publishToVisitor: () => Promise.resolve(),
+	publishToWebsite: () => Promise.resolve(),
 }));
 mock.module("./router", () => ({
 	routeEvent: async (event: RealtimeEvent, context: EventContext) => {

--- a/apps/api/src/ws/socket.ts
+++ b/apps/api/src/ws/socket.ts
@@ -4,148 +4,196 @@ import { normalizeSessionToken, resolveSession } from "@api/db/queries/session";
 
 import { website as websiteTable } from "@api/db/schema";
 import {
-  AuthValidationError,
-  type AuthValidationOptions,
-  performAuthentication,
+	AuthValidationError,
+	type AuthValidationOptions,
+	performAuthentication,
 } from "@api/lib/auth-validation";
 import {
-  createConnectionEvent,
-  getConnectionIdFromSocket,
-  handleAuthenticationFailure,
-  handleIdentificationFailure,
-  sendConnectionEstablishedMessage,
-  sendError,
-  storeConnectionId,
-  updatePresenceIfNeeded,
+	createConnectionEvent,
+	getConnectionIdFromSocket,
+	handleAuthenticationFailure,
+	handleIdentificationFailure,
+	sendConnectionEstablishedMessage,
+	sendError,
+	storeConnectionId,
+	updatePresenceIfNeeded,
 } from "@api/utils/websocket-connection";
 import { updateLastSeenTimestamps } from "@api/utils/websocket-updates";
 import {
-  isValidEventType,
-  type RealtimeEvent,
-  validateRealtimeEvent,
+	isValidEventType,
+	type RealtimeEvent,
+	validateRealtimeEvent,
 } from "@cossistant/types/realtime-events";
 import type { ServerWebSocket } from "bun";
 import { eq } from "drizzle-orm";
 import type { Context } from "hono";
 import { createBunWebSocket } from "hono/bun";
+import type { LocalConnectionRecord, RawSocket } from "./connection-registry";
 import {
-  type ConnectionDispatcher,
-  type DispatchOptions,
-  type EventContext,
-  routeEvent,
-  type VisitorDispatcher,
-  type WebsiteDispatcher,
+	dispatchEventToLocalConnection,
+	dispatchEventToLocalVisitor,
+	dispatchEventToLocalWebsite,
+	localConnections,
+} from "./connection-registry";
+import {
+	initializeRealtimePubSub,
+	publishToConnection,
+	publishToVisitor,
+	publishToWebsite,
+} from "./realtime-pubsub";
+import {
+	type ConnectionDispatcher,
+	type EventContext,
+	routeEvent,
+	type VisitorDispatcher,
+	type WebsiteDispatcher,
 } from "./router";
 
+export type { LocalConnectionRecord, RawSocket } from "./connection-registry";
+export { localConnections } from "./connection-registry";
+
 export type ConnectionData = {
-  connectionId: string;
-  userId?: string;
-  connectedAt: number;
-  apiKey?: ApiKeyWithWebsiteAndOrganization;
-  organizationId?: string;
-  websiteId?: string;
+	connectionId: string;
+	userId?: string;
+	connectedAt: number;
+	apiKey?: ApiKeyWithWebsiteAndOrganization;
+	organizationId?: string;
+	websiteId?: string;
 };
 
-// Local WebSocket connection tracking (only for this server instance)
-export type RawSocket = ServerWebSocket & { connectionId?: string };
+initializeRealtimePubSub({
+	connection: dispatchEventToLocalConnection,
+	visitor: dispatchEventToLocalVisitor,
+	website: dispatchEventToLocalWebsite,
+});
 
-export type LocalConnectionRecord = {
-  socket: RawSocket;
-  websiteId?: string;
-  organizationId?: string;
-  userId?: string;
-  visitorId?: string;
+export const sendEventToConnection: ConnectionDispatcher = (
+	connectionId,
+	event
+) => {
+	publishToConnection(connectionId, event).catch((error) => {
+		console.error("[RealtimePubSub] Failed to publish connection event", {
+			connectionId,
+			error,
+		});
+	});
 };
 
-export const localConnections = new Map<string, LocalConnectionRecord>();
-
-function createExcludePredicate(
-  options?: DispatchOptions
-): ((connectionId: string) => boolean) | undefined {
-  if (!options?.exclude) {
-    return;
-  }
-
-  const excludeIds = Array.isArray(options.exclude)
-    ? new Set(options.exclude)
-    : new Set<string>([options.exclude]);
-
-  return (connectionId: string) => excludeIds.has(connectionId);
-}
-
-function sendEventToSocket(
-  record: LocalConnectionRecord,
-  serializedEvent: string
-): void {
-  try {
-    record.socket.send(serializedEvent);
-  } catch (error) {
-    console.error("[WebSocket] Failed to send event:", error);
-  }
-}
-
-const dispatchToConnection: ConnectionDispatcher = (connectionId, event) => {
-	const connection = localConnections.get(connectionId);
-	if (!connection) {
-		return;
-	}
-
-	const serializedEvent = JSON.stringify(event);
-	sendEventToSocket(connection, serializedEvent);
-};
-
-const dispatchToVisitor: VisitorDispatcher = (visitorId, event, options) => {
-  const shouldExclude = createExcludePredicate(options);
-  const serializedEvent = JSON.stringify(event);
-
-	for (const [connectionId, connection] of localConnections) {
-		if (connection.visitorId !== visitorId) {
-			continue;
-		}
-
-		if (shouldExclude?.(connectionId)) {
-			continue;
-		}
-
-		console.log("[WebSocket] Dispatching visitor event", {
+export const sendEventToVisitor: VisitorDispatcher = (
+	visitorId,
+	event,
+	options
+) => {
+	publishToVisitor(visitorId, event, options).catch((error) => {
+		console.error("[RealtimePubSub] Failed to publish visitor event", {
 			visitorId,
-			connectionId,
-			eventType: event.type,
+			error,
 		});
-		sendEventToSocket(connection, serializedEvent);
-	}
+	});
 };
 
-const dispatchToWebsite: WebsiteDispatcher = (websiteId, event, options) => {
-	const shouldExclude = createExcludePredicate(options);
-	const serializedEvent = JSON.stringify(event);
-
-	for (const [connectionId, connection] of localConnections) {
-    if (connection.websiteId !== websiteId) {
-      continue;
-    }
-
-    // Only dashboard/user connections should receive website events
-    if (!connection.userId) {
-      continue;
-    }
-
-		if (shouldExclude?.(connectionId)) {
-			continue;
-		}
-
-		console.log("[WebSocket] Dispatching website event", {
+export const sendEventToWebsite: WebsiteDispatcher = (
+	websiteId,
+	event,
+	options
+) => {
+	publishToWebsite(websiteId, event, options).catch((error) => {
+		console.error("[RealtimePubSub] Failed to publish website event", {
 			websiteId,
-			connectionId,
-			eventType: event.type,
+			error,
 		});
-		sendEventToSocket(connection, serializedEvent);
-	}
+	});
 };
 
-export const sendEventToConnection = dispatchToConnection;
-export const sendEventToVisitor = dispatchToVisitor;
-export const sendEventToWebsite = dispatchToWebsite;
+type SocketContext = {
+	raw?: RawSocket;
+	send: (data: string) => void;
+};
+
+type ConnectionContextDetails = Pick<
+	EventContext,
+	"organizationId" | "userId" | "visitorId" | "websiteId"
+>;
+
+function resolveActiveConnection(
+	ws: SocketContext
+): { connectionId: string; record: LocalConnectionRecord } | null {
+	const connectionId = getConnectionIdFromSocket(ws);
+	const record = connectionId ? localConnections.get(connectionId) : undefined;
+
+	if (!(connectionId && record)) {
+		console.error("[WebSocket] No connection found");
+		sendError(ws, {
+			error: "Connection not authenticated",
+			message: "Please reconnect with valid authentication.",
+		});
+		return null;
+	}
+
+	return { connectionId, record };
+}
+
+function resolveConnectionContextDetails(
+	connectionId: string,
+	record: LocalConnectionRecord,
+	ws: SocketContext
+): ConnectionContextDetails | null {
+	const { userId, visitorId, websiteId, organizationId } = record;
+
+	if (!((userId || visitorId) && websiteId && organizationId)) {
+		console.error(
+			`[WebSocket] Missing connection metadata for ${connectionId}`
+		);
+		sendError(ws, {
+			error: "Connection context unavailable",
+			message: "Unable to determine connection context. Please reconnect.",
+		});
+		return null;
+	}
+
+	return { userId, visitorId, websiteId, organizationId };
+}
+
+function sendInvalidFormatResponse(ws: SocketContext, error: unknown): void {
+	ws.send(
+		JSON.stringify({
+			error: "Invalid message format",
+			details: error instanceof Error ? error.message : "Unknown error",
+		})
+	);
+}
+
+function parseRealtimeEventMessage(
+	rawMessage: unknown,
+	ws: SocketContext
+): RealtimeEvent | null {
+	let message: { data: unknown; type?: string };
+
+	try {
+		message = JSON.parse(String(rawMessage));
+	} catch (error) {
+		console.error("[WebSocket] Error parsing message:", error);
+		sendInvalidFormatResponse(ws, error);
+		return null;
+	}
+
+	if (!(message.type && isValidEventType(message.type))) {
+		console.error(`[WebSocket] Invalid event type: ${message.type}`);
+		sendError(ws, {
+			error: "Invalid event type",
+			message: `Invalid event type: ${message.type}`,
+		});
+		return null;
+	}
+
+	const validatedData = validateRealtimeEvent(message.type, message.data);
+
+	return {
+		type: message.type,
+		data: validatedData,
+		timestamp: Date.now(),
+	};
+}
 
 // Enable auth logging by setting ENABLE_AUTH_LOGS=true
 const AUTH_LOGS_ENABLED = process.env.ENABLE_AUTH_LOGS === "true";
@@ -154,324 +202,324 @@ const AUTH_LOGS_ENABLED = process.env.ENABLE_AUTH_LOGS === "true";
  * Generates a unique connection ID
  */
 export function generateConnectionId(): string {
-  return `conn_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+	return `conn_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 }
 
 /**
  * Handles WebSocket connection lifecycle
  */
 export const { websocket, upgradeWebSocket } =
-  createBunWebSocket<ServerWebSocket>();
+	createBunWebSocket<ServerWebSocket>();
 
 /**
  * Broadcast helpers are implemented via the router dispatch callbacks.
  */
 function cleanupConnection(connectionId: string): void {
-  localConnections.delete(connectionId);
-  console.log(`[WebSocket] Cleaned up connection: ${connectionId}`);
+	localConnections.delete(connectionId);
+	console.log(`[WebSocket] Cleaned up connection: ${connectionId}`);
 }
 
 export async function handleConnectionClose(
-  connectionId: string
+	connectionId: string
 ): Promise<void> {
-  try {
-    const localConnection = localConnections.get(connectionId);
-    const userId = localConnection?.userId;
-    const visitorId = localConnection?.visitorId;
-    const websiteId = localConnection?.websiteId;
-    const organizationId = localConnection?.organizationId;
+	try {
+		const localConnection = localConnections.get(connectionId);
+		const userId = localConnection?.userId;
+		const visitorId = localConnection?.visitorId;
+		const websiteId = localConnection?.websiteId;
+		const organizationId = localConnection?.organizationId;
 
-    if (!localConnection) {
-      console.error(
-        `[WebSocket] Missing local connection metadata for ${connectionId} on close`
-      );
-      return;
-    }
+		if (!localConnection) {
+			console.error(
+				`[WebSocket] Missing local connection metadata for ${connectionId} on close`
+			);
+			return;
+		}
 
-    const timestamp = Date.now();
-    const context: EventContext = {
-      connectionId,
-      userId,
-      visitorId,
-      websiteId,
-      organizationId,
-      sendToConnection: dispatchToConnection,
-      sendToVisitor: dispatchToVisitor,
-      sendToWebsite: dispatchToWebsite,
-      ws: undefined,
-    };
+		const timestamp = Date.now();
+		const context: EventContext = {
+			connectionId,
+			userId,
+			visitorId,
+			websiteId,
+			organizationId,
+			sendToConnection: sendEventToConnection,
+			sendToVisitor: sendEventToVisitor,
+			sendToWebsite: sendEventToWebsite,
+			ws: undefined,
+		};
 
-    if (userId) {
-      const disconnectEvent: RealtimeEvent<"USER_DISCONNECTED"> = {
-        type: "USER_DISCONNECTED",
-        data: {
-          userId,
-          connectionId,
-          timestamp,
-        },
-        timestamp,
-      };
+		if (userId) {
+			const disconnectEvent: RealtimeEvent<"USER_DISCONNECTED"> = {
+				type: "USER_DISCONNECTED",
+				data: {
+					userId,
+					connectionId,
+					timestamp,
+				},
+				timestamp,
+			};
 
-      await routeEvent(disconnectEvent, context);
-    } else if (visitorId) {
-      const disconnectEvent: RealtimeEvent<"VISITOR_DISCONNECTED"> = {
-        type: "VISITOR_DISCONNECTED",
-        data: {
-          visitorId,
-          connectionId,
-          timestamp,
-        },
-        timestamp,
-      };
+			await routeEvent(disconnectEvent, context);
+		} else if (visitorId) {
+			const disconnectEvent: RealtimeEvent<"VISITOR_DISCONNECTED"> = {
+				type: "VISITOR_DISCONNECTED",
+				data: {
+					visitorId,
+					connectionId,
+					timestamp,
+				},
+				timestamp,
+			};
 
-      await routeEvent(disconnectEvent, context);
-    } else {
-      // TODO: replace console.* with logger
-      console.error(
-        `[WebSocket] Missing connection metadata for ${connectionId} on close`
-      );
-    }
-  } finally {
-    cleanupConnection(connectionId);
-  }
+			await routeEvent(disconnectEvent, context);
+		} else {
+			// TODO: replace console.* with logger
+			console.error(
+				`[WebSocket] Missing connection metadata for ${connectionId} on close`
+			);
+		}
+	} finally {
+		cleanupConnection(connectionId);
+	}
 }
 
 /**
  * Extract authentication credentials from WebSocket context
  */
 function extractAuthCredentials(c: Context): {
-  privateKey: string | undefined;
-  publicKey: string | undefined;
-  actualOrigin: string | undefined;
-  visitorId: string | undefined;
+	privateKey: string | undefined;
+	publicKey: string | undefined;
+	actualOrigin: string | undefined;
+	visitorId: string | undefined;
 } {
-  // Try headers first (for non-browser clients)
-  const authHeader = c.req.header("Authorization");
-  let privateKey = authHeader?.split(" ")[1];
-  let publicKey = c.req.header("X-Public-Key");
-  let visitorId = c.req.header("X-Visitor-Id");
+	// Try headers first (for non-browser clients)
+	const authHeader = c.req.header("Authorization");
+	let privateKey = authHeader?.split(" ")[1];
+	let publicKey = c.req.header("X-Public-Key");
+	let visitorId = c.req.header("X-Visitor-Id");
 
-  // Fallback to URL parameters (for browser WebSocket clients)
-  // This is necessary because browsers can't set custom headers on WebSocket connections
-  if (!privateKey) {
-    privateKey = c.req.query("token");
-  }
-  if (!publicKey) {
-    publicKey = c.req.query("publicKey");
-  }
-  if (!visitorId) {
-    visitorId = c.req.query("visitorId");
-  }
+	// Fallback to URL parameters (for browser WebSocket clients)
+	// This is necessary because browsers can't set custom headers on WebSocket connections
+	if (!privateKey) {
+		privateKey = c.req.query("token");
+	}
+	if (!publicKey) {
+		publicKey = c.req.query("publicKey");
+	}
+	if (!visitorId) {
+		visitorId = c.req.query("visitorId");
+	}
 
-  // Extract origin from WebSocket-specific headers
-  // Priority: Origin > Sec-WebSocket-Origin > Referer
-  const origin = c.req.header("Origin");
-  const secWebSocketOrigin = c.req.header("Sec-WebSocket-Origin");
-  const referer = c.req.header("Referer");
+	// Extract origin from WebSocket-specific headers
+	// Priority: Origin > Sec-WebSocket-Origin > Referer
+	const origin = c.req.header("Origin");
+	const secWebSocketOrigin = c.req.header("Sec-WebSocket-Origin");
+	const referer = c.req.header("Referer");
 
-  let actualOrigin = origin || secWebSocketOrigin;
+	let actualOrigin = origin || secWebSocketOrigin;
 
-  // If no origin headers, try to extract from referer
-  if (!actualOrigin && referer) {
-    try {
-      const refererUrl = new URL(referer);
-      actualOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
-    } catch {
-      // Invalid referer URL, ignore
-    }
-  }
+	// If no origin headers, try to extract from referer
+	if (!actualOrigin && referer) {
+		try {
+			const refererUrl = new URL(referer);
+			actualOrigin = `${refererUrl.protocol}//${refererUrl.host}`;
+		} catch {
+			// Invalid referer URL, ignore
+		}
+	}
 
-  if (AUTH_LOGS_ENABLED) {
-    console.log("[WebSocket Auth] Extracted credentials:", {
-      hasPrivateKey: !!privateKey,
-      hasPublicKey: !!publicKey,
-      publicKey: publicKey ? `${publicKey.substring(0, 10)}...` : null,
-      origin,
-      secWebSocketOrigin,
-      referer,
-      actualOrigin,
-      visitorId: visitorId ? `${visitorId.substring(0, 8)}...` : null,
-    });
-  }
+	if (AUTH_LOGS_ENABLED) {
+		console.log("[WebSocket Auth] Extracted credentials:", {
+			hasPrivateKey: !!privateKey,
+			hasPublicKey: !!publicKey,
+			publicKey: publicKey ? `${publicKey.substring(0, 10)}...` : null,
+			origin,
+			secWebSocketOrigin,
+			referer,
+			actualOrigin,
+			visitorId: visitorId ? `${visitorId.substring(0, 8)}...` : null,
+		});
+	}
 
-  return { privateKey, publicKey, actualOrigin, visitorId };
+	return { privateKey, publicKey, actualOrigin, visitorId };
 }
 
 function extractSessionToken(c: Context): string | undefined {
-  const queryCandidates = [
-    c.req.query("sessionToken"),
-    c.req.query("sessionId"),
-    c.req.query("session"),
-  ];
+	const queryCandidates = [
+		c.req.query("sessionToken"),
+		c.req.query("sessionId"),
+		c.req.query("session"),
+	];
 
-  for (const candidate of queryCandidates) {
-    const normalized = normalizeSessionToken(candidate);
-    if (normalized) {
-      return normalized;
-    }
-  }
+	for (const candidate of queryCandidates) {
+		const normalized = normalizeSessionToken(candidate);
+		if (normalized) {
+			return normalized;
+		}
+	}
 
-  const headerToken = normalizeSessionToken(
-    c.req.header("x-user-session-token")
-  );
+	const headerToken = normalizeSessionToken(
+		c.req.header("x-user-session-token")
+	);
 
-  return headerToken;
+	return headerToken;
 }
 
 /**
  * Parse protocol and hostname from origin
  */
 function parseOriginDetails(actualOrigin: string | undefined): {
-  protocol: string | undefined;
-  hostname: string | undefined;
+	protocol: string | undefined;
+	hostname: string | undefined;
 } {
-  if (!actualOrigin) {
-    return { protocol: undefined, hostname: undefined };
-  }
+	if (!actualOrigin) {
+		return { protocol: undefined, hostname: undefined };
+	}
 
-  try {
-    const url = new URL(actualOrigin);
-    // Convert HTTP protocols to WebSocket protocols for validation
-    const protocol =
-      url.protocol === "https:"
-        ? "wss:"
-        : url.protocol === "http:"
-          ? "ws:"
-          : url.protocol;
-    return { protocol, hostname: url.hostname };
-  } catch (error) {
-    if (AUTH_LOGS_ENABLED) {
-      console.log("[WebSocket Auth] Failed to parse origin:", error);
-    }
-    return { protocol: undefined, hostname: undefined };
-  }
+	try {
+		const url = new URL(actualOrigin);
+		// Convert HTTP protocols to WebSocket protocols for validation
+		const protocol =
+			url.protocol === "https:"
+				? "wss:"
+				: url.protocol === "http:"
+					? "ws:"
+					: url.protocol;
+		return { protocol, hostname: url.hostname };
+	} catch (error) {
+		if (AUTH_LOGS_ENABLED) {
+			console.log("[WebSocket Auth] Failed to parse origin:", error);
+		}
+		return { protocol: undefined, hostname: undefined };
+	}
 }
 
 /**
  * Extract protocol and hostname from request if not available from origin
  */
 function extractFromRequest(c: Context): {
-  protocol: string | undefined;
-  hostname: string | undefined;
+	protocol: string | undefined;
+	hostname: string | undefined;
 } {
-  const hostHeader = c.req.header("Host");
-  if (!hostHeader) {
-    return { protocol: undefined, hostname: undefined };
-  }
+	const hostHeader = c.req.header("Host");
+	if (!hostHeader) {
+		return { protocol: undefined, hostname: undefined };
+	}
 
-  const hostname = hostHeader.split(":")[0];
-  const isSecure = c.req.url.startsWith("wss://");
-  const protocol = isSecure ? "wss:" : "ws:";
+	const hostname = hostHeader.split(":")[0];
+	const isSecure = c.req.url.startsWith("wss://");
+	const protocol = isSecure ? "wss:" : "ws:";
 
-  return { protocol, hostname };
+	return { protocol, hostname };
 }
 
 /**
  * Extract protocol and hostname from WebSocket context
  */
 function extractProtocolAndHostname(
-  c: Context,
-  actualOrigin: string | undefined
+	c: Context,
+	actualOrigin: string | undefined
 ): { protocol: string | undefined; hostname: string | undefined } {
-  if (actualOrigin) {
-    return parseOriginDetails(actualOrigin);
-  }
+	if (actualOrigin) {
+		return parseOriginDetails(actualOrigin);
+	}
 
-  // Fallback to extracting from the WebSocket request URL
-  const requestDetails = extractFromRequest(c);
+	// Fallback to extracting from the WebSocket request URL
+	const requestDetails = extractFromRequest(c);
 
-  if (AUTH_LOGS_ENABLED && requestDetails.hostname) {
-    console.log("[WebSocket Auth] No origin header, using request details:", {
-      protocol: requestDetails.protocol,
-      hostname: requestDetails.hostname,
-      url: c.req.url,
-    });
-  }
+	if (AUTH_LOGS_ENABLED && requestDetails.hostname) {
+		console.log("[WebSocket Auth] No origin header, using request details:", {
+			protocol: requestDetails.protocol,
+			hostname: requestDetails.hostname,
+			url: c.req.url,
+		});
+	}
 
-  return requestDetails;
+	return requestDetails;
 }
 
 /**
  * Log authentication attempt if logging is enabled
  */
 function logAuthAttempt({
-  hasPrivateKey,
-  hasPublicKey,
-  hasSessionToken,
-  actualOrigin,
-  url,
+	hasPrivateKey,
+	hasPublicKey,
+	hasSessionToken,
+	actualOrigin,
+	url,
 }: {
-  hasPrivateKey: boolean;
-  hasPublicKey: boolean;
-  hasSessionToken: boolean;
-  actualOrigin: string | undefined;
-  url: string;
+	hasPrivateKey: boolean;
+	hasPublicKey: boolean;
+	hasSessionToken: boolean;
+	actualOrigin: string | undefined;
+	url: string;
 }): void {
-  if (AUTH_LOGS_ENABLED) {
-    console.log("[WebSocket Auth] Authentication attempt:", {
-      hasPrivateKey,
-      hasPublicKey,
-      hasSessionToken,
-      origin: actualOrigin,
-      url,
-    });
-  }
+	if (AUTH_LOGS_ENABLED) {
+		console.log("[WebSocket Auth] Authentication attempt:", {
+			hasPrivateKey,
+			hasPublicKey,
+			hasSessionToken,
+			origin: actualOrigin,
+			url,
+		});
+	}
 }
 
 /**
  * Log authentication success if logging is enabled
  */
 function logAuthSuccess(result: WebSocketAuthSuccess): void {
-  if (AUTH_LOGS_ENABLED) {
-    console.log("[WebSocket Auth] Authentication successful:", {
-      hasApiKey: !!result.apiKey,
-      apiKeyId: result.apiKey?.id,
-      organizationId: result.organizationId,
-      websiteId: result.websiteId,
-      userId: result.userId,
-      visitorId: result.visitorId
-        ? `${result.visitorId.substring(0, 8)}...`
-        : null,
-      isTestKey: result.isTestKey,
-    });
-  }
+	if (AUTH_LOGS_ENABLED) {
+		console.log("[WebSocket Auth] Authentication successful:", {
+			hasApiKey: !!result.apiKey,
+			apiKeyId: result.apiKey?.id,
+			organizationId: result.organizationId,
+			websiteId: result.websiteId,
+			userId: result.userId,
+			visitorId: result.visitorId
+				? `${result.visitorId.substring(0, 8)}...`
+				: null,
+			isTestKey: result.isTestKey,
+		});
+	}
 }
 
 /**
  * Result of a successful WebSocket authentication
  */
 export type WebSocketAuthSuccess = {
-  organizationId?: string;
-  websiteId?: string;
-  userId?: string;
-  visitorId?: string;
-  apiKey?: ApiKeyWithWebsiteAndOrganization;
-  isTestKey?: boolean;
+	organizationId?: string;
+	websiteId?: string;
+	userId?: string;
+	visitorId?: string;
+	apiKey?: ApiKeyWithWebsiteAndOrganization;
+	isTestKey?: boolean;
 };
 
 /**
  * Perform WebSocket authentication with API key
  */
 async function performApiKeyAuthentication(
-  privateKey: string | undefined,
-  publicKey: string | undefined,
-  options: AuthValidationOptions
+	privateKey: string | undefined,
+	publicKey: string | undefined,
+	options: AuthValidationOptions
 ): Promise<WebSocketAuthSuccess | null> {
-  try {
-    const result = await authenticateWithApiKey(privateKey, publicKey, options);
-    return result;
-  } catch (error) {
-    if (error instanceof AuthValidationError) {
-      if (AUTH_LOGS_ENABLED) {
-        console.log("[WebSocket Auth] API key authentication failed:", {
-          error: error.message,
-          statusCode: error.statusCode,
-        });
-      }
-      throw error;
-    }
-    throw error;
-  }
+	try {
+		const result = await authenticateWithApiKey(privateKey, publicKey, options);
+		return result;
+	} catch (error) {
+		if (error instanceof AuthValidationError) {
+			if (AUTH_LOGS_ENABLED) {
+				console.log("[WebSocket Auth] API key authentication failed:", {
+					error: error.message,
+					statusCode: error.statusCode,
+				});
+			}
+			throw error;
+		}
+		throw error;
+	}
 }
 
 /**
@@ -479,333 +527,297 @@ async function performApiKeyAuthentication(
  * Accept either API keys (public/private) or a Better Auth session via cookies
  */
 async function authenticateWebSocketConnection(
-  c: Context
+	c: Context
 ): Promise<WebSocketAuthSuccess | null> {
-  try {
-    // Extract credentials
-    const { privateKey, publicKey, actualOrigin, visitorId } =
-      extractAuthCredentials(c);
-    const websiteIdParam = c.req.query("websiteId")?.trim() || undefined;
-    const sessionToken = extractSessionToken(c);
+	try {
+		// Extract credentials
+		const { privateKey, publicKey, actualOrigin, visitorId } =
+			extractAuthCredentials(c);
+		const websiteIdParam = c.req.query("websiteId")?.trim() || undefined;
+		const sessionToken = extractSessionToken(c);
 
-    logAuthAttempt({
-      hasPrivateKey: !!privateKey,
-      hasPublicKey: !!publicKey,
-      hasSessionToken: !!sessionToken,
-      actualOrigin,
-      url: c.req.url,
-    });
+		logAuthAttempt({
+			hasPrivateKey: !!privateKey,
+			hasPublicKey: !!publicKey,
+			hasSessionToken: !!sessionToken,
+			actualOrigin,
+			url: c.req.url,
+		});
 
-    // Extract protocol and hostname
-    const { protocol, hostname } = extractProtocolAndHostname(c, actualOrigin);
+		// Extract protocol and hostname
+		const { protocol, hostname } = extractProtocolAndHostname(c, actualOrigin);
 
-    // Build validation options
-    const options: AuthValidationOptions = {
-      origin: actualOrigin,
-      protocol,
-      hostname,
-    };
+		// Build validation options
+		const options: AuthValidationOptions = {
+			origin: actualOrigin,
+			protocol,
+			hostname,
+		};
 
-    // Authenticate with API key or session
-    let result: WebSocketAuthSuccess | null = null;
+		// Authenticate with API key or session
+		let result: WebSocketAuthSuccess | null = null;
 
-    if (privateKey || publicKey) {
-      result = await performApiKeyAuthentication(
-        privateKey,
-        publicKey,
-        options
-      );
-    } else {
-      result = await authenticateWithSession(c, sessionToken);
+		if (privateKey || publicKey) {
+			result = await performApiKeyAuthentication(
+				privateKey,
+				publicKey,
+				options
+			);
+		} else {
+			result = await authenticateWithSession(c, sessionToken);
 
-      if (!result && AUTH_LOGS_ENABLED) {
-        console.log("[WebSocket Auth] No valid authentication method provided");
-      }
-    }
+			if (!result && AUTH_LOGS_ENABLED) {
+				console.log("[WebSocket Auth] No valid authentication method provided");
+			}
+		}
 
-    // Add visitorId to the result if authentication was successful
-    if (result) {
-      result.visitorId = visitorId;
-      if (websiteIdParam) {
-        result.websiteId = websiteIdParam;
-      }
-      logAuthSuccess(result);
-    }
+		// Add visitorId to the result if authentication was successful
+		if (result) {
+			result.visitorId = visitorId;
+			if (websiteIdParam) {
+				result.websiteId = websiteIdParam;
+			}
+			logAuthSuccess(result);
+		}
 
-    return result;
-  } catch (error) {
-    if (AUTH_LOGS_ENABLED) {
-      console.error("[WebSocket Auth] Authentication failed:", error);
-    }
+		return result;
+	} catch (error) {
+		if (AUTH_LOGS_ENABLED) {
+			console.error("[WebSocket Auth] Authentication failed:", error);
+		}
 
-    if (error instanceof AuthValidationError) {
-      throw error;
-    }
+		if (error instanceof AuthValidationError) {
+			throw error;
+		}
 
-    // For any other errors, wrap them
-    throw new AuthValidationError(500, "Internal authentication error");
-  }
+		// For any other errors, wrap them
+		throw new AuthValidationError(500, "Internal authentication error");
+	}
 }
 
 async function authenticateWithApiKey(
-  privateKey: string | undefined,
-  publicKey: string | undefined,
-  options: AuthValidationOptions
+	privateKey: string | undefined,
+	publicKey: string | undefined,
+	options: AuthValidationOptions
 ): Promise<WebSocketAuthSuccess> {
-  const result = await performAuthentication(
-    privateKey,
-    publicKey,
-    db,
-    options
-  );
+	const result = await performAuthentication(
+		privateKey,
+		publicKey,
+		db,
+		options
+	);
 
-  const authSuccess: WebSocketAuthSuccess = {
-    apiKey: result.apiKey,
-    isTestKey: result.isTestKey,
-    organizationId: result.apiKey.organization.id,
-    websiteId: result.apiKey.website?.id,
-  };
+	const authSuccess: WebSocketAuthSuccess = {
+		apiKey: result.apiKey,
+		isTestKey: result.isTestKey,
+		organizationId: result.apiKey.organization.id,
+		websiteId: result.apiKey.website?.id,
+	};
 
-  return authSuccess;
+	return authSuccess;
 }
 
 async function authenticateWithSession(
-  c: Context,
-  sessionToken: string | undefined
+	c: Context,
+	sessionToken: string | undefined
 ): Promise<WebSocketAuthSuccess | null> {
-  const session = await resolveSession(db, {
-    headers: c.req.raw.headers,
-    sessionToken,
-  });
-  if (!session) {
-    if (AUTH_LOGS_ENABLED) {
-      console.log(
-        sessionToken
-          ? "[WebSocket Auth] Session token invalid or expired"
-          : "[WebSocket Auth] No API key or session provided"
-      );
-    }
-    return null;
-  }
+	const session = await resolveSession(db, {
+		headers: c.req.raw.headers,
+		sessionToken,
+	});
+	if (!session) {
+		if (AUTH_LOGS_ENABLED) {
+			console.log(
+				sessionToken
+					? "[WebSocket Auth] Session token invalid or expired"
+					: "[WebSocket Auth] No API key or session provided"
+			);
+		}
+		return null;
+	}
 
-  const organizationId = session.session.activeOrganizationId ?? null;
-  const activeTeamId = session.session.activeTeamId ?? null;
-  let websiteId: string | undefined;
+	const organizationId = session.session.activeOrganizationId ?? null;
+	const activeTeamId = session.session.activeTeamId ?? null;
+	let websiteId: string | undefined;
 
-  if (activeTeamId) {
-    const [site] = await db
-      .select({ id: websiteTable.id })
-      .from(websiteTable)
-      .where(eq(websiteTable.teamId, activeTeamId))
-      .limit(1);
-    websiteId = site?.id;
-  }
+	if (activeTeamId) {
+		const [site] = await db
+			.select({ id: websiteTable.id })
+			.from(websiteTable)
+			.where(eq(websiteTable.teamId, activeTeamId))
+			.limit(1);
+		websiteId = site?.id;
+	}
 
-  if (!organizationId && AUTH_LOGS_ENABLED) {
-    console.log(
-      "[WebSocket Auth] Session found but no active organization; proceeding without website context"
-    );
-  }
+	if (!organizationId && AUTH_LOGS_ENABLED) {
+		console.log(
+			"[WebSocket Auth] Session found but no active organization; proceeding without website context"
+		);
+	}
 
-  return {
-    organizationId: organizationId ?? undefined,
-    websiteId,
-    userId: session.user.id,
-  };
+	return {
+		organizationId: organizationId ?? undefined,
+		websiteId,
+		userId: session.user.id,
+	};
 }
 
 export const upgradedWebsocket = upgradeWebSocket(async (c) => {
-  let authResult: WebSocketAuthSuccess | null = null;
-  let authError: AuthValidationError | null = null;
+	let authResult: WebSocketAuthSuccess | null = null;
+	let authError: AuthValidationError | null = null;
 
-  try {
-    // Perform authentication during the upgrade phase
-    authResult = await authenticateWebSocketConnection(c);
-  } catch (error) {
-    if (error instanceof AuthValidationError) {
-      authError = error;
-    } else {
-      // Log unexpected errors but don't expose them to the client
-      console.error("[WebSocket] Unexpected authentication error:", error);
-      authError = new AuthValidationError(500, "Authentication failed");
-    }
-  }
+	try {
+		// Perform authentication during the upgrade phase
+		authResult = await authenticateWebSocketConnection(c);
+	} catch (error) {
+		if (error instanceof AuthValidationError) {
+			authError = error;
+		} else {
+			// Log unexpected errors but don't expose them to the client
+			console.error("[WebSocket] Unexpected authentication error:", error);
+			authError = new AuthValidationError(500, "Authentication failed");
+		}
+	}
 
-  return {
-    async onOpen(evt, ws) {
-      const connectionId = generateConnectionId();
+	return {
+		async onOpen(evt, ws) {
+			const connectionId = generateConnectionId();
 
-      // If we have an authentication error, send it and close the connection
-      if (authError) {
-        sendError(ws, {
-          error: "Authentication failed",
-          message: authError.message,
-          code: authError.statusCode,
-        });
-        ws.close(authError.statusCode === 403 ? 1008 : 1011, authError.message);
-        return;
-      }
+			// If we have an authentication error, send it and close the connection
+			if (authError) {
+				sendError(ws, {
+					error: "Authentication failed",
+					message: authError.message,
+					code: authError.statusCode,
+				});
+				ws.close(authError.statusCode === 403 ? 1008 : 1011, authError.message);
+				return;
+			}
 
-      // Check if authentication was successful
-      if (!authResult) {
-        await handleAuthenticationFailure(ws, connectionId);
-        return;
-      }
+			// Check if authentication was successful
+			if (!authResult) {
+				await handleAuthenticationFailure(ws, connectionId);
+				return;
+			}
 
-      // Check if we have either a user ID or visitor ID
-      if (!(authResult.userId || authResult.visitorId)) {
-        await handleIdentificationFailure(ws, connectionId);
-        return;
-      }
+			// Check if we have either a user ID or visitor ID
+			if (!(authResult.userId || authResult.visitorId)) {
+				await handleIdentificationFailure(ws, connectionId);
+				return;
+			}
 
-      // Track socket locally for this server instance
-      localConnections.set(connectionId, {
-        socket: ws.raw as RawSocket,
-        websiteId: authResult.websiteId,
-        organizationId: authResult.organizationId,
-        userId: authResult.userId,
-        visitorId: authResult.visitorId,
-      });
-      storeConnectionId(ws, connectionId);
+			// Track socket locally for this server instance
+			localConnections.set(connectionId, {
+				socket: ws.raw as RawSocket,
+				websiteId: authResult.websiteId,
+				organizationId: authResult.organizationId,
+				userId: authResult.userId,
+				visitorId: authResult.visitorId,
+			});
+			storeConnectionId(ws, connectionId);
 
-      console.log(
-        `[WebSocket] Connection opened: ${connectionId} for organization: ${authResult.organizationId}`
-      );
+			console.log(
+				`[WebSocket] Connection opened: ${connectionId} for organization: ${authResult.organizationId}`
+			);
 
-      // Send successful connection message
-      sendConnectionEstablishedMessage(ws, connectionId, authResult);
+			// Send successful connection message
+			sendConnectionEstablishedMessage(ws, connectionId, authResult);
 
-      // Emit USER_CONNECTED or VISITOR_CONNECTED event based on authentication type
-      try {
-        const event = createConnectionEvent(authResult, connectionId);
-        const context: EventContext = {
-          connectionId,
-          userId: authResult.userId,
-          visitorId: authResult.visitorId,
-          websiteId: authResult.websiteId,
-          organizationId: authResult.organizationId,
-          sendToConnection: dispatchToConnection,
-          sendToVisitor: dispatchToVisitor,
-          sendToWebsite: dispatchToWebsite,
-          ws: undefined,
-        };
-        await routeEvent(event, context);
-      } catch (error) {
-        console.error("[WebSocket] Error creating connection event:", error);
-        // Continue with connection setup even if event creation fails
-      }
+			// Emit USER_CONNECTED or VISITOR_CONNECTED event based on authentication type
+			try {
+				const event = createConnectionEvent(authResult, connectionId);
+				const context: EventContext = {
+					connectionId,
+					userId: authResult.userId,
+					visitorId: authResult.visitorId,
+					websiteId: authResult.websiteId,
+					organizationId: authResult.organizationId,
+					sendToConnection: sendEventToConnection,
+					sendToVisitor: sendEventToVisitor,
+					sendToWebsite: sendEventToWebsite,
+					ws: undefined,
+				};
+				await routeEvent(event, context);
+			} catch (error) {
+				console.error("[WebSocket] Error creating connection event:", error);
+				// Continue with connection setup even if event creation fails
+			}
 
-      console.log("[WebSocket] Connection established", {
-        connectionId,
-        websiteId: authResult.websiteId,
-        visitorId: authResult.visitorId,
-        userId: authResult.userId,
-        organizationId: authResult.organizationId,
-      });
+			console.log("[WebSocket] Connection established", {
+				connectionId,
+				websiteId: authResult.websiteId,
+				visitorId: authResult.visitorId,
+				userId: authResult.userId,
+				organizationId: authResult.organizationId,
+			});
 
-      await updatePresenceIfNeeded(authResult);
+			await updatePresenceIfNeeded(authResult);
 
-      // Update last seen timestamps
-      await updateLastSeenTimestamps({ db, authResult });
-    },
+			// Update last seen timestamps
+			await updateLastSeenTimestamps({ db, authResult });
+		},
 
-    async onMessage(evt, ws) {
-      // Get connectionId from the WebSocket
-      const connectionId = getConnectionIdFromSocket(ws);
-      const connection = connectionId
-        ? localConnections.get(connectionId)
-        : undefined;
+		async onMessage(evt, ws) {
+			const activeConnection = resolveActiveConnection(ws);
 
-      if (!(connectionId && connection)) {
-        console.error("[WebSocket] No connection found");
-        sendError(ws, {
-          error: "Connection not authenticated",
-          message: "Please reconnect with valid authentication.",
-        });
-        return;
-      }
+			if (!activeConnection) {
+				return;
+			}
 
-      try {
-        const message = JSON.parse(evt.data.toString());
+			const event = parseRealtimeEventMessage(evt.data, ws);
 
-        if (!(message.type && isValidEventType(message.type))) {
-          console.error(`[WebSocket] Invalid event type: ${message.type}`);
-          sendError(ws, {
-            error: "Invalid event type",
-            message: `Invalid event type: ${message.type}`,
-          });
-          return;
-        }
+			if (!event) {
+				return;
+			}
 
-        // Validate event data
-        const validatedData = validateRealtimeEvent(message.type, message.data);
+			const metadata = resolveConnectionContextDetails(
+				activeConnection.connectionId,
+				activeConnection.record,
+				ws
+			);
 
-        const event: RealtimeEvent = {
-          type: message.type,
-          data: validatedData,
-          timestamp: Date.now(),
-        };
+			if (!metadata) {
+				return;
+			}
 
-        // Gather connection metadata from local cache
-        const { userId, visitorId, websiteId, organizationId } = connection;
+			const context: EventContext = {
+				connectionId: activeConnection.connectionId,
+				...metadata,
+				sendToConnection: sendEventToConnection,
+				sendToVisitor: sendEventToVisitor,
+				sendToWebsite: sendEventToWebsite,
+				ws: undefined,
+			};
 
-        if (!((userId || visitorId) && websiteId && organizationId)) {
-          console.error(
-            `[WebSocket] Missing connection metadata for ${connectionId}`
-          );
-          sendError(ws, {
-            error: "Connection context unavailable",
-            message:
-              "Unable to determine connection context. Please reconnect.",
-          });
-          return;
-        }
+			try {
+				await routeEvent(event, context);
+			} catch (error) {
+				console.error("[WebSocket] Error processing message:", error);
+				sendInvalidFormatResponse(ws, error);
+			}
+		},
 
-        const context: EventContext = {
-          connectionId,
-          userId,
-          visitorId,
-          websiteId,
-          organizationId,
-          sendToConnection: dispatchToConnection,
-          sendToVisitor: dispatchToVisitor,
-          sendToWebsite: dispatchToWebsite,
-          ws: undefined,
-        };
+		async onClose(evt, ws) {
+			// Get connectionId from the WebSocket
+			const connectionId = ws.raw
+				? (ws.raw as ServerWebSocket & { connectionId?: string }).connectionId
+				: undefined;
 
-        await routeEvent(event, context);
-      } catch (error) {
-        console.error("[WebSocket] Error processing message:", error);
-        ws.send(
-          JSON.stringify({
-            error: "Invalid message format",
-            details: error instanceof Error ? error.message : "Unknown error",
-          })
-        );
-      }
-    },
+			if (!connectionId) {
+				console.error("[WebSocket] No connection ID found on close");
+				return;
+			}
 
-    async onClose(evt, ws) {
-      // Get connectionId from the WebSocket
-      const connectionId = ws.raw
-        ? (ws.raw as ServerWebSocket & { connectionId?: string }).connectionId
-        : undefined;
+			await handleConnectionClose(connectionId);
+		},
 
-      if (!connectionId) {
-        console.error("[WebSocket] No connection ID found on close");
-        return;
-      }
+		onError(evt, ws) {
+			// Get connectionId from the WebSocket
+			const connectionId = ws.raw
+				? (ws.raw as ServerWebSocket & { connectionId?: string }).connectionId
+				: undefined;
 
-      await handleConnectionClose(connectionId);
-    },
-
-    onError(evt, ws) {
-      // Get connectionId from the WebSocket
-      const connectionId = ws.raw
-        ? (ws.raw as ServerWebSocket & { connectionId?: string }).connectionId
-        : undefined;
-
-      console.error(`[WebSocket] Error on connection ${connectionId}:`, evt);
-    },
-  };
+			console.error(`[WebSocket] Error on connection ${connectionId}:`, evt);
+		},
+	};
 });


### PR DESCRIPTION
## Summary
- replace the websocket pub/sub layer with an ioredis-backed Redis Streams dispatcher that persists cursors and retries publishing
- update the realtime consumer loop to fan out events through the existing local dispatch helpers while validating payloads
- add a REDIS_URL env variable so deployments can point the API at a regional Redis instance

## Testing
- bunx biome check apps/api/src/ws
- bun test src/ws/socket.test.ts
- bun test src/ws/router.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdbe673b0c832bae5a672b89926ecd