### PR TITLE
fix: hide responsive support header close button

### DIFF
--- a/packages/react/src/support/components/header.tsx
+++ b/packages/react/src/support/components/header.tsx
@@ -16,7 +16,7 @@ export const Header: React.FC<HeaderProps> = ({
 	actions,
 	onGoBack,
 }) => {
-	const { close } = useSupportConfig();
+	const { close, mode } = useSupportConfig();
 
 	return (
 		<div className={cn("absolute inset-x-0 top-0 z-10 h-18", className)}>
@@ -35,9 +35,11 @@ export const Header: React.FC<HeaderProps> = ({
 					{children}
 				</div>
 				{actions && <div className="flex items-center gap-2">{actions}</div>}
-				<Button onClick={close} size="icon" type="button" variant="ghost">
-					<Icon name="close" />
-				</Button>
+				{mode !== "responsive" && (
+					<Button onClick={close} size="icon" type="button" variant="ghost">
+						<Icon name="close" />
+					</Button>
+				)}
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## Summary
- hide the support widget header close control when rendered in responsive mode to match the expected layout

## Testing
- bunx turbo run lint --filter=@cossistant/react

------
https://chatgpt.com/codex/tasks/task_e_68e2b4c9a334832bbd863aae10a7281c