### PR TITLE
Enable quick option auto-send and dedupe default messages

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -321,18 +321,19 @@ export class CossistantClient {
 
 		if (pending && createIfPending !== false) {
 			try {
-				const response = await this.restClient.createConversation({
-					conversationId: rest.conversationId,
-					defaultMessages: [...pending.initialMessages, optimisticMessage],
-				});
+                                const response = await this.restClient.createConversation({
+                                        conversationId: rest.conversationId,
+                                        defaultMessages: [...pending.initialMessages, optimisticMessage],
+                                });
 
-				this.conversationsStore.ingestConversation(response.conversation);
-				this.messagesStore.removeMessage(rest.conversationId, optimisticId);
-				this.messagesStore.ingestPage(rest.conversationId, {
-					messages: response.initialMessages,
-					hasNextPage: false,
-					nextCursor: undefined,
-				});
+                                this.conversationsStore.ingestConversation(response.conversation);
+                                this.messagesStore.removeMessage(rest.conversationId, optimisticId);
+                                this.messagesStore.clearConversation(rest.conversationId);
+                                this.messagesStore.ingestPage(rest.conversationId, {
+                                        messages: response.initialMessages,
+                                        hasNextPage: false,
+                                        nextCursor: undefined,
+                                });
 
 				this.pendingConversations.delete(rest.conversationId);
 

--- a/packages/core/src/store/messages-store.test.ts
+++ b/packages/core/src/store/messages-store.test.ts
@@ -89,16 +89,30 @@ describe("messages store", () => {
 		expect(conversation?.messages[0]).toEqual(message);
 	});
 
-	it("removes messages by id", () => {
-		const store = createMessagesStore();
-		const message = createMockMessage();
+        it("removes messages by id", () => {
+                const store = createMessagesStore();
+                const message = createMockMessage();
 
-		store.ingestMessage(message);
-		store.removeMessage(message.conversationId, message.id);
+                store.ingestMessage(message);
+                store.removeMessage(message.conversationId, message.id);
 
-		const conversation = store.getState().conversations[message.conversationId];
-		expect(conversation?.messages).toHaveLength(0);
-	});
+                const conversation = store.getState().conversations[message.conversationId];
+                expect(conversation?.messages).toHaveLength(0);
+        });
+
+        it("clears a conversation thread", () => {
+                const store = createMessagesStore();
+                const message = createMockMessage();
+
+                store.ingestMessage(message);
+                expect(store.getState().conversations[message.conversationId]).toBeDefined();
+
+                store.clearConversation(message.conversationId);
+
+                expect(
+                        store.getState().conversations[message.conversationId]
+                ).toBeUndefined();
+        });
 
 	it("finalizes optimistic messages by replacing them", () => {
 		const store = createMessagesStore();

--- a/packages/core/src/store/messages-store.ts
+++ b/packages/core/src/store/messages-store.ts
@@ -186,19 +186,20 @@ function normalizeRealtimeMessage(event: MessageCreatedEvent): Message {
 }
 
 export type MessagesStore = Store<MessagesState> & {
-	ingestPage(conversationId: string, page: ConversationMessagesState): void;
-	ingestMessage(message: Message): void;
-	ingestRealtime(event: MessageCreatedEvent): Message;
-	removeMessage(conversationId: string, messageId: string): void;
-	finalizeMessage(
-		conversationId: string,
-		optimisticId: string,
-		message: Message
-	): void;
+        ingestPage(conversationId: string, page: ConversationMessagesState): void;
+        ingestMessage(message: Message): void;
+        ingestRealtime(event: MessageCreatedEvent): Message;
+        removeMessage(conversationId: string, messageId: string): void;
+        finalizeMessage(
+                conversationId: string,
+                optimisticId: string,
+                message: Message
+        ): void;
+        clearConversation(conversationId: string): void;
 };
 
 export function createMessagesStore(
-	initialState: MessagesState = INITIAL_STATE
+        initialState: MessagesState = INITIAL_STATE
 ): MessagesStore {
 	const store = createStore<MessagesState>(initialState);
 
@@ -215,17 +216,32 @@ export function createMessagesStore(
 			store.setState((state) => applyMessage(state, message));
 			return message;
 		},
-		removeMessage(conversationId, messageId) {
-			store.setState((state) =>
-				removeMessage(state, conversationId, messageId)
-			);
-		},
-		finalizeMessage(conversationId, optimisticId, message) {
-			store.setState((state) =>
-				finalizeMessage(state, conversationId, optimisticId, message)
-			);
-		},
-	};
+                removeMessage(conversationId, messageId) {
+                        store.setState((state) =>
+                                removeMessage(state, conversationId, messageId)
+                        );
+                },
+                finalizeMessage(conversationId, optimisticId, message) {
+                        store.setState((state) =>
+                                finalizeMessage(state, conversationId, optimisticId, message)
+                        );
+                },
+                clearConversation(conversationId) {
+                        store.setState((state) => {
+                                if (!state.conversations[conversationId]) {
+                                        return state;
+                                }
+
+                                const { [conversationId]: _removed, ...rest } =
+                                        state.conversations;
+
+                                return {
+                                        ...state,
+                                        conversations: rest,
+                                } satisfies MessagesState;
+                        });
+                },
+        };
 }
 
 export function getConversationMessages(

--- a/packages/react/src/hooks/use-conversation-page.ts
+++ b/packages/react/src/hooks/use-conversation-page.ts
@@ -179,44 +179,50 @@ export function useConversationPage(
 		},
         });
 
-        const initialMessageSubmittedRef = useRef(false);
+const initialMessageSubmittedRef = useRef(false);
+const lastInitialMessageRef = useRef<string | null>(null);
 
-        useEffect(() => {
-                if (!hasInitialMessage) {
-                        initialMessageSubmittedRef.current = false;
-                        return;
-                }
+useEffect(() => {
+    if (!hasInitialMessage) {
+        initialMessageSubmittedRef.current = false;
+        lastInitialMessageRef.current = null;
+        return;
+    }
 
-                if (!lifecycle.isPending) {
-                        return;
-                }
+    if (lastInitialMessageRef.current !== trimmedInitialMessage) {
+        initialMessageSubmittedRef.current = false;
+        lastInitialMessageRef.current = trimmedInitialMessage;
+    }
 
-                if (composer.message !== trimmedInitialMessage) {
-                        composer.setMessage(trimmedInitialMessage);
-                        return;
-                }
+    if (!lifecycle.isPending) {
+        return;
+    }
 
-                if (
-                        initialMessageSubmittedRef.current ||
-                        composer.isSubmitting ||
-                        !composer.canSubmit
-                ) {
-                        return;
-                }
+    if (composer.message !== trimmedInitialMessage) {
+        composer.setMessage(trimmedInitialMessage);
+        return;
+    }
 
-                initialMessageSubmittedRef.current = true;
-                composer.submit();
-        }, [
-                hasInitialMessage,
-                lifecycle.isPending,
-                composer.message,
-                composer.setMessage,
-                composer.isSubmitting,
-                composer.canSubmit,
-                composer.submit,
-                trimmedInitialMessage,
-        ]);
+    if (
+        initialMessageSubmittedRef.current ||
+        composer.isSubmitting ||
+        !composer.canSubmit
+    ) {
+        return;
+    }
 
+    initialMessageSubmittedRef.current = true;
+    composer.submit();
+}, [
+    hasInitialMessage,
+    lifecycle.isPending,
+    composer.message,
+    composer.setMessage,
+    composer.isSubmitting,
+    composer.canSubmit,
+    composer.submit,
+    trimmedInitialMessage,
+]);
 	// 6. Auto-mark messages as seen
 	useConversationAutoSeen({
 		client,

--- a/packages/react/src/support/pages/conversation.tsx
+++ b/packages/react/src/support/pages/conversation.tsx
@@ -12,15 +12,20 @@ import { useSupportNavigation } from "../store";
 import { Text, useSupportText } from "../text";
 
 type ConversationPageProps = {
-	/**
-	 * The conversation ID to display (can be PENDING_CONVERSATION_ID or a real ID).
-	 */
-	conversationId: string;
+        /**
+         * The conversation ID to display (can be PENDING_CONVERSATION_ID or a real ID).
+         */
+        conversationId: string;
 
-	/**
-	 * Optional messages to display (for optimistic updates or initial state).
-	 */
-	messages?: MessageType[];
+        /**
+         * Optional initial message to send when opening the conversation.
+         */
+        initialMessage?: string;
+
+        /**
+         * Optional messages to display (for optimistic updates or initial state).
+         */
+        messages?: MessageType[];
 
 	/**
 	 * Optional events to display.
@@ -35,25 +40,27 @@ type ConversationPageProps = {
  * making this component focused purely on rendering and user interaction.
  */
 export const ConversationPage = ({
-	conversationId: initialConversationId,
-	messages: passedMessages = [],
-	events = [],
+        conversationId: initialConversationId,
+        initialMessage,
+        messages: passedMessages = [],
+        events = [],
 }: ConversationPageProps) => {
-	const { website, availableAIAgents, availableHumanAgents, visitor } =
-		useSupport();
+        const { website, availableAIAgents, availableHumanAgents, visitor } =
+                useSupport();
 	const { navigate, replace, goBack, canGoBack } = useSupportNavigation();
 	const text = useSupportText();
 
 	// Main conversation hook - handles all logic
-	const conversation = useConversationPage({
-		conversationId: initialConversationId,
-		messages: passedMessages,
-		events,
-		onConversationIdChange: (newConversationId) => {
-			// Update navigation when conversation is created
-			replace({
-				page: "CONVERSATION",
-				params: { conversationId: newConversationId },
+        const conversation = useConversationPage({
+                conversationId: initialConversationId,
+                messages: passedMessages,
+                events,
+                initialMessage,
+                onConversationIdChange: (newConversationId) => {
+                        // Update navigation when conversation is created
+                        replace({
+                                page: "CONVERSATION",
+                                params: { conversationId: newConversationId },
 			});
 		},
 	});

--- a/packages/react/src/support/router.tsx
+++ b/packages/react/src/support/router.tsx
@@ -21,13 +21,14 @@ export const SupportRouter: React.FC = () => {
 		case "ARTICLES":
 			return <ArticlesPage />;
 
-		case "CONVERSATION":
-			return (
-				<ConversationPage
-					conversationId={current.params.conversationId}
-					events={[]}
-				/>
-			);
+                case "CONVERSATION":
+                        return (
+                                <ConversationPage
+                                        conversationId={current.params.conversationId}
+                                        initialMessage={current.params.initialMessage}
+                                        events={[]}
+                                />
+                        );
 
 		case "CONVERSATION_HISTORY":
 			return <ConversationHistoryPage />;


### PR DESCRIPTION
## Summary
- prevent pending default messages from being duplicated when the first visitor reply creates a conversation
- expose a message-store reset helper with coverage to support clearing pending threads
- auto-send quick option selections without default greetings and wire the router to pass initial messages

## Testing
- bun test packages/core/src/store/messages-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e355b89af8832b8ac56153815688e4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Start a conversation with an initial message via prop or URL parameter; it auto-fills and submits during the pending state.
  * Pending conversation view shows only relevant default messages when an initial message exists.

* **Bug Fixes**
  * After creating a conversation from pending, the thread is fully cleared before initial messages are reloaded to avoid duplicates/stale messages.

* **Tests**
  * Added a test verifying a conversation thread can be cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->