### PR TITLE
Fix conversation history pagination ordering

### DIFF
--- a/apps/api/src/trpc/routers/conversation.ts
+++ b/apps/api/src/trpc/routers/conversation.ts
@@ -82,22 +82,22 @@ export const conversationRouter = createTRPCRouter({
 			};
 		}),
 
-	getConversationMessages: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				limit: z.number().int().min(1).max(100).optional().default(50),
-				cursor: z.date().nullable().optional(),
-			})
-		)
-		.output(
-			z.object({
-				items: z.array(messageSchema),
-				nextCursor: z.date().nullable(),
-				hasNextPage: z.boolean(),
-			})
-		)
+        getConversationMessages: protectedProcedure
+                .input(
+                        z.object({
+                                conversationId: z.string(),
+                                websiteSlug: z.string(),
+                                limit: z.number().int().min(1).max(100).optional().default(50),
+                                cursor: z.union([z.string(), z.date()]).nullable().optional(),
+                        })
+                )
+                .output(
+                        z.object({
+                                items: z.array(messageSchema),
+                                nextCursor: z.string().nullable(),
+                                hasNextPage: z.boolean(),
+                        })
+                )
 		.query(async ({ ctx: { db, user }, input }) => {
 			// Query website access and conversation in parallel
 			const [websiteData, conversation] = await Promise.all([
@@ -132,29 +132,29 @@ export const conversationRouter = createTRPCRouter({
 				cursor: input.cursor,
 			});
 
-			return {
-				items: result.messages,
-				nextCursor: result.nextCursor ? new Date(result.nextCursor) : null,
-				hasNextPage: result.hasNextPage,
-			};
-		}),
+                        return {
+                                items: result.messages,
+                                nextCursor: result.nextCursor,
+                                hasNextPage: result.hasNextPage,
+                        };
+                }),
 
-	getConversationEvents: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				limit: z.number().int().min(1).max(100).optional().default(50),
-				cursor: z.date().nullable().optional(),
-			})
-		)
-		.output(
-			z.object({
-				items: z.array(conversationEventSchema),
-				nextCursor: z.date().nullable(),
-				hasNextPage: z.boolean(),
-			})
-		)
+        getConversationEvents: protectedProcedure
+                .input(
+                        z.object({
+                                conversationId: z.string(),
+                                websiteSlug: z.string(),
+                                limit: z.number().int().min(1).max(100).optional().default(50),
+                                cursor: z.union([z.string(), z.date()]).nullable().optional(),
+                        })
+                )
+                .output(
+                        z.object({
+                                items: z.array(conversationEventSchema),
+                                nextCursor: z.string().nullable(),
+                                hasNextPage: z.boolean(),
+                        })
+                )
 		.query(async ({ ctx: { db, user }, input }) => {
 			// Query website access and conversation in parallel
 			const [websiteData, conversation] = await Promise.all([
@@ -189,18 +189,18 @@ export const conversationRouter = createTRPCRouter({
 				cursor: input.cursor,
 			});
 
-			return {
-				items: result.events.map((event) => ({
-					...event,
-					metadata: event.metadata as Record<string, unknown>,
-					updatedAt: event.createdAt,
-					deletedAt: null,
-					message: event.message ?? undefined,
-				})),
-				nextCursor: result.nextCursor ? new Date(result.nextCursor) : null,
-				hasNextPage: result.hasNextPage,
-			};
-		}),
+                        return {
+                                items: result.events.map((event) => ({
+                                        ...event,
+                                        metadata: event.metadata as Record<string, unknown>,
+                                        updatedAt: event.createdAt,
+                                        deletedAt: null,
+                                        message: event.message ?? undefined,
+                                })),
+                                nextCursor: result.nextCursor,
+                                hasNextPage: result.hasNextPage,
+                        };
+                }),
 
 	sendMessage: protectedProcedure
 		.input(

--- a/apps/web/src/data/use-conversation-events.tsx
+++ b/apps/web/src/data/use-conversation-events.tsx
@@ -51,7 +51,14 @@ export function useConversationEvents({
 		staleTime: STALE_TIME,
 	});
 
-	const events = query.data?.pages.flatMap((page) => page.items) ?? [];
+        const events =
+                query.data?.pages
+                        .flatMap((page) => page.items)
+                        .sort(
+                                (a, b) =>
+                                        new Date(a.createdAt).getTime() -
+                                        new Date(b.createdAt).getTime()
+                        ) ?? [];
 
 	return {
 		events,

--- a/apps/web/src/data/use-conversation-events.tsx
+++ b/apps/web/src/data/use-conversation-events.tsx
@@ -45,8 +45,8 @@ export function useConversationEvents({
 
 			return response;
 		},
-		getNextPageParam: (lastPage) => lastPage.nextCursor,
-		initialPageParam: null as Date | null,
+                getNextPageParam: (lastPage) => lastPage.nextCursor,
+                initialPageParam: null as string | null,
 		enabled: options?.enabled ?? true,
 		staleTime: STALE_TIME,
 	});

--- a/apps/web/src/data/use-conversation-messages.tsx
+++ b/apps/web/src/data/use-conversation-messages.tsx
@@ -47,8 +47,8 @@ export function useConversationMessages({
 
 			return response;
 		},
-		getNextPageParam: (lastPage) => lastPage.nextCursor,
-		initialPageParam: null as Date | null,
+                getNextPageParam: (lastPage) => lastPage.nextCursor,
+                initialPageParam: null as string | null,
 		enabled: options?.enabled ?? true,
 		staleTime: STALE_TIME,
 	});

--- a/apps/web/src/data/use-conversation-messages.tsx
+++ b/apps/web/src/data/use-conversation-messages.tsx
@@ -53,7 +53,14 @@ export function useConversationMessages({
 		staleTime: STALE_TIME,
 	});
 
-	const messages = query.data?.pages.flatMap((page) => page.items) ?? [];
+        const messages =
+                query.data?.pages
+                        .flatMap((page) => page.items)
+                        .sort(
+                                (a, b) =>
+                                        new Date(a.createdAt).getTime() -
+                                        new Date(b.createdAt).getTime()
+                        ) ?? [];
 
 	return {
 		messages,


### PR DESCRIPTION
## Summary
- update conversation message and event queries to paginate from the most recent entries while returning chronological results
- ensure conversation message and event infinite queries are sorted by creation date to maintain timeline order on the dashboard

## Testing
- bun run lint *(fails: turbo command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e36e71fa9c832b9e4b18aa420213c9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation messages and events now display in strict chronological order for consistent reading.
  * Backwards pagination is more reliable, ensuring infinite scroll loads the correct next set without duplicates or gaps.
  * Pagination indicators (e.g., next page) are more accurate, reducing unexpected stops or repeats.
  * Messages are correctly scoped to the selected website, preventing cross-website results and improving data relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->