### PR TITLE
fix: keep dashboard typing indicator visible

### DIFF
--- a/apps/web/src/components/conversation/messages/list.tsx
+++ b/apps/web/src/components/conversation/messages/list.tsx
@@ -14,7 +14,8 @@ import type {
 import { SenderType } from "@cossistant/types";
 import type { ConversationSeen } from "@cossistant/types/schemas";
 import { AnimatePresence } from "motion/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
+import type { RefObject } from "react";
 import type { ConversationHeader } from "@/contexts/inboxes";
 import { cn } from "@/lib/utils";
 import { ConversationEvent } from "./event";
@@ -48,6 +49,10 @@ export function MessagesList({
   onFetchMoreIfNeeded,
   visitor,
 }: Props) {
+  const fallbackRef = useRef<HTMLDivElement | null>(null);
+  const messageListRef =
+    (ref as RefObject<HTMLDivElement | null> | undefined) ?? fallbackRef;
+
   const {
     items,
     lastReadMessageMap,
@@ -102,11 +107,19 @@ export function MessagesList({
       );
   }, [typingEntries]);
 
+  useEffect(() => {
+    if (!messageListRef.current || activeTypingEntities.length === 0) {
+      return;
+    }
+
+    messageListRef.current.scrollTop = messageListRef.current.scrollHeight;
+  }, [activeTypingEntities, messageListRef]);
+
   return (
     <PrimitiveMessageList
       autoScroll={true}
       className={cn(
-        "overflow-y-auto scroll-smooth pt-20 pr-4 pb-48 pl-4",
+        "overflow-y-auto pt-20 pr-4 pb-48 pl-4",
         "scrollbar-thin scrollbar-thumb-background-300 scrollbar-track-transparent",
         "h-full w-full",
         className
@@ -115,7 +128,7 @@ export function MessagesList({
       id="message-list"
       messages={messages}
       onScrollStart={onFetchMoreIfNeeded}
-      ref={ref}
+      ref={ref ?? messageListRef}
     >
       <div className="mx-auto xl:max-w-xl 2xl:max-w-2xl">
         <MessageListContainer className="flex min-h-full w-full flex-col gap-3">

--- a/packages/react/src/primitives/message-list.tsx
+++ b/packages/react/src/primitives/message-list.tsx
@@ -84,16 +84,10 @@ export const MessageList = (() => {
 						events.length > previousEventCount.current;
 
 					// Only scroll if there are new messages or it's the first render
-					if (hasNewMessages || isInitialRender.current) {
-						// On first render, scroll instantly to avoid animation
-						// For new messages, scroll smoothly
-						const behavior = isInitialRender.current ? "instant" : "smooth";
-
-						scrollRef.current.scrollTo({
-							top: scrollRef.current.scrollHeight,
-							behavior,
-						});
-					}
+                                        if (hasNewMessages || isInitialRender.current) {
+                                                scrollRef.current.scrollTop =
+                                                        scrollRef.current.scrollHeight;
+                                        }
 
 					// Update refs for next render
 					previousMessageCount.current = messages.length;


### PR DESCRIPTION
## Summary
- ensure the dashboard message list scrolls to the bottom when participants are typing so indicators remain visible
- remove smooth scrolling behavior so conversation updates snap into place instantly

## Testing
- bun run lint *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e679e03cdc832baccb8b15df52028b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatically scrolls to the latest messages when participants are typing.
* Bug Fixes
  * Improves reliability of staying at the bottom on initial load and when new messages arrive, even in edge cases.
* Refactor
  * Simplifies scrolling behavior for consistency and performance; removes smooth scrolling animation for immediate updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->