### PR TITLE
fix: allow realtime visitor events without visitor ids

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/providers/events/handlers/message-created.ts
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/providers/events/handlers/message-created.ts
@@ -78,7 +78,8 @@ export const handleMessageCreated = ({
 }) => {
 	const { queryClient, website } = context;
 	const { payload } = event;
-	const { message } = payload;
+        const { message } = payload;
+        const conversationMessage = toConversationMessage(message);
 
 	// Clear typing state when a message is sent
 	clearTypingFromMessage(event);
@@ -109,7 +110,11 @@ export const handleMessageCreated = ({
 			continue;
 		}
 
-		upsertConversationMessageInCache(queryClient, queryKey, message);
+                upsertConversationMessageInCache(
+                        queryClient,
+                        queryKey,
+                        conversationMessage
+                );
 	}
 
 	const existingHeader =

--- a/packages/react/src/realtime/use-realtime.ts
+++ b/packages/react/src/realtime/use-realtime.ts
@@ -54,11 +54,10 @@ function shouldDeliverEvent(
 	}
 
 	if (visitorId) {
-		if (!event.payload.visitorId) {
-			return false;
-		}
-
-		if (event.payload.visitorId !== visitorId) {
+		if (
+			event.payload.visitorId &&
+			event.payload.visitorId !== visitorId
+		) {
 			return false;
 		}
 	}


### PR DESCRIPTION
## Summary
- accept realtime events without visitor identifiers in the widget filter so visitor messages reach the store

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ea5e58f3ec832b865c97ae739e5f2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Real-time events are no longer dropped when a visitor is identified but an event lacks a visitor ID, improving live updates across dashboards.
  * Conversation messages render more reliably by standardizing how incoming messages are processed before caching, reducing edge-case display issues.
  * Fewer missed notifications and state mismatches in message threads, leading to a more consistent chat experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->