### PR TITLE
Restore realtime conversation events across API and clients

### DIFF
--- a/apps/api/src/db/mutations/conversation.ts
+++ b/apps/api/src/db/mutations/conversation.ts
@@ -1,10 +1,7 @@
 import type { Database } from "@api/db";
-import {
-	conversation,
-	conversationEvent,
-	conversationSeen,
-} from "@api/db/schema";
+import { conversation, conversationSeen } from "@api/db/schema";
 import { generateULID } from "@api/utils/db/ids";
+import { createConversationEvent } from "@api/utils/conversation-event";
 import { ConversationEventType, ConversationStatus } from "@cossistant/types";
 import type { InferSelectModel } from "drizzle-orm";
 import { and, eq } from "drizzle-orm";
@@ -12,384 +9,374 @@ import { and, eq } from "drizzle-orm";
 export type ConversationRecord = InferSelectModel<typeof conversation>;
 
 function computeResolutionTime(
-	conversationRecord: ConversationRecord,
-	resolvedAt: string
+  conversationRecord: ConversationRecord,
+  resolvedAt: string,
 ): number | null {
-	if (!conversationRecord.startedAt) {
-		return conversationRecord.resolutionTime ?? null;
-	}
+  if (!conversationRecord.startedAt) {
+    return conversationRecord.resolutionTime ?? null;
+  }
 
-	const durationMs =
-		new Date(resolvedAt).getTime() -
-		new Date(conversationRecord.startedAt).getTime();
-	return durationMs > 0 ? Math.round(durationMs / 1000) : 0;
+  const durationMs =
+    new Date(resolvedAt).getTime() -
+    new Date(conversationRecord.startedAt).getTime();
+  return durationMs > 0 ? Math.round(durationMs / 1000) : 0;
 }
 
 export async function resolveConversation(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const resolvedAt = new Date().toISOString();
+  const resolvedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			status: ConversationStatus.RESOLVED,
-			resolvedAt,
-			resolvedByUserId: params.actorUserId,
-			resolvedByAiAgentId: null,
-			resolutionTime: computeResolutionTime(params.conversation, resolvedAt),
-			updatedAt: resolvedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      status: ConversationStatus.RESOLVED,
+      resolvedAt,
+      resolvedByUserId: params.actorUserId,
+      resolvedByAiAgentId: null,
+      resolutionTime: computeResolutionTime(params.conversation, resolvedAt),
+      updatedAt: resolvedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		organizationId: params.conversation.organizationId,
-		conversationId: params.conversation.id,
-		type: ConversationEventType.RESOLVED,
-		actorUserId: params.actorUserId,
-		actorAiAgentId: null,
-		targetUserId: null,
-		targetAiAgentId: null,
-		createdAt: resolvedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.RESOLVED,
+      actorUserId: params.actorUserId,
+      createdAt: resolvedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function reopenConversation(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const reopenedAt = new Date().toISOString();
+  const reopenedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			status: ConversationStatus.OPEN,
-			resolvedAt: null,
-			resolvedByUserId: null,
-			resolvedByAiAgentId: null,
-			resolutionTime: null,
-			updatedAt: reopenedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      status: ConversationStatus.OPEN,
+      resolvedAt: null,
+      resolvedByUserId: null,
+      resolvedByAiAgentId: null,
+      resolutionTime: null,
+      updatedAt: reopenedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		organizationId: params.conversation.organizationId,
-		conversationId: params.conversation.id,
-		type: ConversationEventType.REOPENED,
-		actorUserId: params.actorUserId,
-		actorAiAgentId: null,
-		targetUserId: null,
-		targetAiAgentId: null,
-		createdAt: reopenedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.REOPENED,
+      actorUserId: params.actorUserId,
+      createdAt: reopenedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function markConversationAsSpam(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const updatedAt = new Date().toISOString();
+  const updatedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			status: ConversationStatus.SPAM,
-			resolvedAt: null,
-			resolvedByUserId: null,
-			resolvedByAiAgentId: null,
-			updatedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      status: ConversationStatus.SPAM,
+      resolvedAt: null,
+      resolvedByUserId: null,
+      resolvedByAiAgentId: null,
+      updatedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		conversationId: params.conversation.id,
-		organizationId: params.conversation.organizationId,
-		type: ConversationEventType.STATUS_CHANGED,
-		actorUserId: params.actorUserId,
-		actorAiAgentId: null,
-		targetUserId: null,
-		targetAiAgentId: null,
-		metadata: {
-			previousStatus: params.conversation.status,
-			newStatus: ConversationStatus.SPAM,
-		},
-		createdAt: updatedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.STATUS_CHANGED,
+      actorUserId: params.actorUserId,
+      metadata: {
+        previousStatus: params.conversation.status,
+        newStatus: ConversationStatus.SPAM,
+      },
+      createdAt: updatedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function markConversationAsNotSpam(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const updatedAt = new Date().toISOString();
+  const updatedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			status: ConversationStatus.OPEN,
-			resolvedAt: null,
-			resolvedByUserId: null,
-			resolvedByAiAgentId: null,
-			resolutionTime: null,
-			updatedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      status: ConversationStatus.OPEN,
+      resolvedAt: null,
+      resolvedByUserId: null,
+      resolvedByAiAgentId: null,
+      resolutionTime: null,
+      updatedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		conversationId: params.conversation.id,
-		organizationId: params.conversation.organizationId,
-		type: ConversationEventType.STATUS_CHANGED,
-		actorUserId: params.actorUserId,
-		metadata: {
-			previousStatus: params.conversation.status,
-			newStatus: ConversationStatus.OPEN,
-		},
-		actorAiAgentId: null,
-		targetUserId: null,
-		targetAiAgentId: null,
-		createdAt: updatedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.STATUS_CHANGED,
+      actorUserId: params.actorUserId,
+      metadata: {
+        previousStatus: params.conversation.status,
+        newStatus: ConversationStatus.OPEN,
+      },
+      createdAt: updatedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function archiveConversation(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const archivedAt = new Date().toISOString();
+  const archivedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			deletedAt: archivedAt,
-			updatedAt: archivedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      deletedAt: archivedAt,
+      updatedAt: archivedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		conversationId: params.conversation.id,
-		organizationId: params.conversation.organizationId,
-		type: ConversationEventType.STATUS_CHANGED,
-		actorUserId: params.actorUserId,
-		metadata: {
-			archived: true,
-		},
-		createdAt: archivedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.STATUS_CHANGED,
+      actorUserId: params.actorUserId,
+      metadata: { archived: true },
+      createdAt: archivedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function unarchiveConversation(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	const unarchivedAt = new Date().toISOString();
+  const unarchivedAt = new Date().toISOString();
 
-	const [updated] = await db
-		.update(conversation)
-		.set({
-			deletedAt: null,
-			updatedAt: unarchivedAt,
-		})
-		.where(
-			and(
-				eq(conversation.id, params.conversation.id),
-				eq(conversation.organizationId, params.conversation.organizationId),
-				eq(conversation.websiteId, params.conversation.websiteId)
-			)
-		)
-		.returning();
+  const [updated] = await db
+    .update(conversation)
+    .set({
+      deletedAt: null,
+      updatedAt: unarchivedAt,
+    })
+    .where(
+      and(
+        eq(conversation.id, params.conversation.id),
+        eq(conversation.organizationId, params.conversation.organizationId),
+        eq(conversation.websiteId, params.conversation.websiteId),
+      ),
+    )
+    .returning();
 
-	if (!updated) {
-		return null;
-	}
+  if (!updated) {
+    return null;
+  }
 
-	await db.insert(conversationEvent).values({
-		id: generateULID(),
-		conversationId: params.conversation.id,
-		organizationId: params.conversation.organizationId,
-		type: ConversationEventType.STATUS_CHANGED,
-		actorUserId: params.actorUserId,
-		metadata: {
-			archived: false,
-		},
-		createdAt: unarchivedAt,
-	});
+  await createConversationEvent({
+    db,
+    conversation: params.conversation,
+    event: {
+      type: ConversationEventType.STATUS_CHANGED,
+      actorUserId: params.actorUserId,
+      metadata: { archived: false },
+      createdAt: unarchivedAt,
+    },
+  });
 
-	return updated;
+  return updated;
 }
 
 export async function markConversationAsRead(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ): Promise<{ conversation: ConversationRecord; lastSeenAt: string }> {
-	const lastSeenAt = new Date().toISOString();
+  const lastSeenAt = new Date().toISOString();
 
-	await db
-		.insert(conversationSeen)
-		.values({
-			id: generateULID(),
-			conversationId: params.conversation.id,
-			organizationId: params.conversation.organizationId,
-			userId: params.actorUserId,
-			visitorId: null,
-			aiAgentId: null,
-			lastSeenAt,
-			createdAt: lastSeenAt,
-			updatedAt: lastSeenAt,
-		})
-		.onConflictDoUpdate({
-			target: [conversationSeen.conversationId, conversationSeen.userId],
-			set: {
-				lastSeenAt,
-				updatedAt: lastSeenAt,
-			},
-		});
+  await db
+    .insert(conversationSeen)
+    .values({
+      id: generateULID(),
+      conversationId: params.conversation.id,
+      organizationId: params.conversation.organizationId,
+      userId: params.actorUserId,
+      visitorId: null,
+      aiAgentId: null,
+      lastSeenAt,
+      createdAt: lastSeenAt,
+      updatedAt: lastSeenAt,
+    })
+    .onConflictDoUpdate({
+      target: [conversationSeen.conversationId, conversationSeen.userId],
+      set: {
+        lastSeenAt,
+        updatedAt: lastSeenAt,
+      },
+    });
 
-	return {
-		conversation: params.conversation,
-		lastSeenAt,
-	};
+  return {
+    conversation: params.conversation,
+    lastSeenAt,
+  };
 }
 
 export async function markConversationAsSeenByVisitor(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		visitorId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    visitorId: string;
+  },
 ) {
-	const updatedAt = new Date().toISOString();
+  const updatedAt = new Date().toISOString();
 
-	await db
-		.insert(conversationSeen)
-		.values({
-			id: generateULID(),
-			conversationId: params.conversation.id,
-			organizationId: params.conversation.organizationId,
-			userId: null,
-			visitorId: params.visitorId,
-			aiAgentId: null,
-			lastSeenAt: updatedAt,
-			createdAt: updatedAt,
-			updatedAt,
-		})
-		.onConflictDoUpdate({
-			target: [conversationSeen.conversationId, conversationSeen.visitorId],
-			set: {
-				lastSeenAt: updatedAt,
-				updatedAt,
-			},
-		});
+  await db
+    .insert(conversationSeen)
+    .values({
+      id: generateULID(),
+      conversationId: params.conversation.id,
+      organizationId: params.conversation.organizationId,
+      userId: null,
+      visitorId: params.visitorId,
+      aiAgentId: null,
+      lastSeenAt: updatedAt,
+      createdAt: updatedAt,
+      updatedAt,
+    })
+    .onConflictDoUpdate({
+      target: [conversationSeen.conversationId, conversationSeen.visitorId],
+      set: {
+        lastSeenAt: updatedAt,
+        updatedAt,
+      },
+    });
 
-	return updatedAt;
+  return updatedAt;
 }
 
 export async function markConversationAsUnread(
-	db: Database,
-	params: {
-		conversation: ConversationRecord;
-		actorUserId: string;
-	}
+  db: Database,
+  params: {
+    conversation: ConversationRecord;
+    actorUserId: string;
+  },
 ) {
-	await db
-		.delete(conversationSeen)
-		.where(
-			and(
-				eq(conversationSeen.conversationId, params.conversation.id),
-				eq(conversationSeen.userId, params.actorUserId)
-			)
-		);
+  await db
+    .delete(conversationSeen)
+    .where(
+      and(
+        eq(conversationSeen.conversationId, params.conversation.id),
+        eq(conversationSeen.userId, params.actorUserId),
+      ),
+    );
 
-	return params.conversation;
+  return params.conversation;
 }

--- a/apps/api/src/db/queries/conversation.ts
+++ b/apps/api/src/db/queries/conversation.ts
@@ -3,827 +3,828 @@ import { DEFAULT_PAGE_LIMIT } from "@api/constants";
 import type { Database } from "@api/db";
 
 import {
-	contact,
-	conversation,
-	conversationEvent,
-	conversationSeen,
-	conversationView,
-	type MessageSelect,
-	message,
-	visitor,
+  contact,
+  conversation,
+  conversationEvent,
+  conversationSeen,
+  conversationView,
+  type MessageSelect,
+  message,
+  visitor,
 } from "@api/db/schema";
 import { generateShortPrimaryId } from "@api/utils/db/ids";
 
 import {
-	ConversationStatus,
-	MessageType,
-	MessageVisibility,
+  ConversationStatus,
+  MessageType,
+  MessageVisibility,
 } from "@cossistant/types";
 import type { ConversationSeen } from "@cossistant/types/schemas";
 import type { ConversationHeader } from "@cossistant/types/trpc/conversation";
 
 import {
-	and,
-	asc,
-	count,
-	desc,
-	eq,
-	inArray,
-	isNull,
-	lt,
-	or,
-	sql,
+  and,
+  asc,
+  count,
+  desc,
+  eq,
+  inArray,
+  isNull,
+  lt,
+  or,
+  sql,
 } from "drizzle-orm";
 
 export async function upsertConversation(
-	db: Database,
-	params: {
-		organizationId: string;
-		websiteId: string;
-		visitorId: string;
-		conversationId?: string;
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    websiteId: string;
+    visitorId: string;
+    conversationId?: string;
+  },
 ) {
-	const newConversationId = params.conversationId ?? generateShortPrimaryId();
-	const now = new Date().toISOString();
+  const newConversationId = params.conversationId ?? generateShortPrimaryId();
+  const now = new Date().toISOString();
 
-	// Upsert conversation
-	const [_conversation] = await db
-		.insert(conversation)
-		.values({
-			id: newConversationId,
-			organizationId: params.organizationId,
-			websiteId: params.websiteId,
-			visitorId: params.visitorId,
-			status: ConversationStatus.OPEN,
-			createdAt: now,
-		})
-		.onConflictDoNothing({
-			target: conversation.id,
-		})
-		.returning();
+  // Upsert conversation
+  const [_conversation] = await db
+    .insert(conversation)
+    .values({
+      id: newConversationId,
+      organizationId: params.organizationId,
+      websiteId: params.websiteId,
+      visitorId: params.visitorId,
+      status: ConversationStatus.OPEN,
+      createdAt: now,
+    })
+    .onConflictDoNothing({
+      target: conversation.id,
+    })
+    .returning();
 
-	return _conversation;
+  return _conversation;
 }
 
 export async function listConversations(
-	db: Database,
-	params: {
-		organizationId: string;
-		websiteId: string;
-		visitorId: string;
-		page?: number;
-		limit?: number;
-		status?: "open" | "closed";
-		orderBy?: "createdAt" | "updatedAt";
-		order?: "asc" | "desc";
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    websiteId: string;
+    visitorId: string;
+    page?: number;
+    limit?: number;
+    status?: "open" | "closed";
+    orderBy?: "createdAt" | "updatedAt";
+    order?: "asc" | "desc";
+  },
 ) {
-	const page = params.page ?? 1;
-	const limit = params.limit ?? 3;
-	const offset = (page - 1) * limit;
-	const orderBy = params.orderBy ?? "updatedAt";
-	const order = params.order ?? "desc";
+  const page = params.page ?? 1;
+  const limit = params.limit ?? 3;
+  const offset = (page - 1) * limit;
+  const orderBy = params.orderBy ?? "updatedAt";
+  const order = params.order ?? "desc";
 
-	// Build where conditions
-	const whereConditions = [
-		eq(conversation.organizationId, params.organizationId),
-		eq(conversation.websiteId, params.websiteId),
-		eq(conversation.visitorId, params.visitorId),
-	];
+  // Build where conditions
+  const whereConditions = [
+    eq(conversation.organizationId, params.organizationId),
+    eq(conversation.websiteId, params.websiteId),
+    eq(conversation.visitorId, params.visitorId),
+  ];
 
-	if (params.status) {
-		// Map API status to database status
-		const statusMap: Record<string, ConversationStatus> = {
-			open: ConversationStatus.OPEN,
-			closed: ConversationStatus.RESOLVED,
-		};
+  if (params.status) {
+    // Map API status to database status
+    const statusMap: Record<string, ConversationStatus> = {
+      open: ConversationStatus.OPEN,
+      closed: ConversationStatus.RESOLVED,
+    };
 
-		const dbStatus = statusMap[params.status];
-		if (dbStatus) {
-			whereConditions.push(eq(conversation.status, dbStatus));
-		}
-	}
+    const dbStatus = statusMap[params.status];
+    if (dbStatus) {
+      whereConditions.push(eq(conversation.status, dbStatus));
+    }
+  }
 
-	// Get total count
-	const [{ totalCount }] = await db
-		.select({ totalCount: count() })
-		.from(conversation)
-		.where(and(...whereConditions));
+  // Get total count
+  const [{ totalCount }] = await db
+    .select({ totalCount: count() })
+    .from(conversation)
+    .where(and(...whereConditions));
 
-	// Get paginated conversations
-	const orderColumn =
-		orderBy === "createdAt" ? conversation.createdAt : conversation.updatedAt;
-	const orderFn = order === "desc" ? desc : asc;
+  // Get paginated conversations
+  const orderColumn =
+    orderBy === "createdAt" ? conversation.createdAt : conversation.updatedAt;
+  const orderFn = order === "desc" ? desc : asc;
 
-	const conversations = await db
-		.select()
-		.from(conversation)
-		.where(and(...whereConditions))
-		.orderBy(orderFn(orderColumn))
-		.limit(limit)
-		.offset(offset);
+  const conversations = await db
+    .select()
+    .from(conversation)
+    .where(and(...whereConditions))
+    .orderBy(orderFn(orderColumn))
+    .limit(limit)
+    .offset(offset);
 
-	// Get conversation IDs for fetching last messages
-	const conversationIds = conversations.map((c) => c.id);
+  // Get conversation IDs for fetching last messages
+  const conversationIds = conversations.map((c) => c.id);
 
-	// Fetch last messages for each conversation if there are any conversations
-	const lastMessagesMap: Record<string, MessageSelect> = {};
+  // Fetch last messages for each conversation if there are any conversations
+  const lastMessagesMap: Record<string, MessageSelect> = {};
 
-	if (conversationIds.length > 0) {
-		// Get all messages for the conversations and group by conversation ID
-		const messages = await db
-			.select()
-			.from(message)
-			.where(
-				and(
-					eq(message.organizationId, params.organizationId),
-					inArray(message.conversationId, conversationIds),
-					eq(message.visibility, MessageVisibility.PUBLIC),
-					eq(message.type, MessageType.TEXT),
-					isNull(message.deletedAt)
-				)
-			)
-			.orderBy(desc(message.createdAt));
+  if (conversationIds.length > 0) {
+    // Get all messages for the conversations and group by conversation ID
+    const messages = await db
+      .select()
+      .from(message)
+      .where(
+        and(
+          eq(message.organizationId, params.organizationId),
+          inArray(message.conversationId, conversationIds),
+          eq(message.visibility, MessageVisibility.PUBLIC),
+          eq(message.type, MessageType.TEXT),
+          isNull(message.deletedAt),
+        ),
+      )
+      .orderBy(desc(message.createdAt));
 
-		// Group messages by conversation and take the first (latest) one for each
-		for (const msg of messages) {
-			if (!lastMessagesMap[msg.conversationId]) {
-				lastMessagesMap[msg.conversationId] = msg;
-			}
-		}
-	}
+    // Group messages by conversation and take the first (latest) one for each
+    for (const msg of messages) {
+      if (!lastMessagesMap[msg.conversationId]) {
+        lastMessagesMap[msg.conversationId] = msg;
+      }
+    }
+  }
 
-	// Add lastMessage to each conversation
-	const conversationsWithLastMessage = conversations.map((conv) => ({
-		...conv,
-		lastMessage: lastMessagesMap[conv.id] || undefined,
-	}));
+  // Add lastMessage to each conversation
+  const conversationsWithLastMessage = conversations.map((conv) => ({
+    ...conv,
+    lastMessage: lastMessagesMap[conv.id] || undefined,
+  }));
 
-	const totalPages = Math.ceil(totalCount / limit);
+  const totalPages = Math.ceil(totalCount / limit);
 
-	return {
-		conversations: conversationsWithLastMessage,
-		pagination: {
-			page,
-			limit,
-			total: totalCount,
-			totalPages,
-			hasMore: page < totalPages,
-		},
-	};
+  return {
+    conversations: conversationsWithLastMessage,
+    pagination: {
+      page,
+      limit,
+      total: totalCount,
+      totalPages,
+      hasMore: page < totalPages,
+    },
+  };
 }
 
 export async function getConversationByIdWithLastMessage(
-	db: Database,
-	params: {
-		organizationId: string;
-		websiteId: string;
-		conversationId: string;
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    websiteId: string;
+    conversationId: string;
+  },
 ) {
-	const [_conversation] = await db
-		.select()
-		.from(conversation)
-		.where(
-			and(
-				eq(conversation.id, params.conversationId),
-				eq(conversation.organizationId, params.organizationId),
-				eq(conversation.websiteId, params.websiteId)
-			)
-		);
+  const [_conversation] = await db
+    .select()
+    .from(conversation)
+    .where(
+      and(
+        eq(conversation.id, params.conversationId),
+        eq(conversation.organizationId, params.organizationId),
+        eq(conversation.websiteId, params.websiteId),
+      ),
+    );
 
-	if (!_conversation) {
-		return;
-	}
+  if (!_conversation) {
+    return;
+  }
 
-	// Fetch the last message for this conversation
-	const [lastMessage] = await db
-		.select()
-		.from(message)
-		.where(
-			and(
-				eq(message.conversationId, params.conversationId),
-				eq(message.organizationId, params.organizationId),
-				eq(message.visibility, MessageVisibility.PUBLIC),
-				eq(message.type, MessageType.TEXT),
-				isNull(message.deletedAt)
-			)
-		)
-		.orderBy(desc(message.createdAt))
-		.limit(1);
+  // Fetch the last message for this conversation
+  const [lastMessage] = await db
+    .select()
+    .from(message)
+    .where(
+      and(
+        eq(message.conversationId, params.conversationId),
+        eq(message.organizationId, params.organizationId),
+        eq(message.visibility, MessageVisibility.PUBLIC),
+        eq(message.type, MessageType.TEXT),
+        isNull(message.deletedAt),
+      ),
+    )
+    .orderBy(desc(message.createdAt))
+    .limit(1);
 
-	return {
-		..._conversation,
-		lastMessage: lastMessage || undefined,
-	};
+  return {
+    ..._conversation,
+    lastMessage: lastMessage || undefined,
+  };
 }
 
 export async function listConversationsHeaders(
-	db: Database,
-	params: {
-		organizationId: string;
-		websiteId: string;
-		userId: string;
-		limit?: number;
-		cursor?: string | null;
-		orderBy?: "createdAt" | "updatedAt";
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    websiteId: string;
+    userId: string;
+    limit?: number;
+    cursor?: string | null;
+    orderBy?: "createdAt" | "updatedAt";
+  },
 ) {
-	const limit = params.limit ?? DEFAULT_PAGE_LIMIT;
-	const orderBy = params.orderBy ?? "updatedAt";
+  const limit = params.limit ?? DEFAULT_PAGE_LIMIT;
+  const orderBy = params.orderBy ?? "updatedAt";
 
-	// Create a subquery for the last message per conversation using window function
-	const lastMessageSubquery = db
-		.select({
-			conversationId: message.conversationId,
-			id: message.id,
-			bodyMd: message.bodyMd,
-			type: message.type,
-			userId: message.userId,
-			visitorId: message.visitorId,
-			websiteId: message.websiteId,
-			organizationId: message.organizationId,
-			aiAgentId: message.aiAgentId,
-			modelUsed: message.modelUsed,
-			visibility: message.visibility,
-			createdAt: message.createdAt,
-			updatedAt: message.updatedAt,
-			deletedAt: message.deletedAt,
-			parentMessageId: message.parentMessageId,
-			// Use ROW_NUMBER() to get only the latest message per conversation
-			rn: sql<number>`ROW_NUMBER() OVER (
+  // Create a subquery for the last message per conversation using window function
+  const lastMessageSubquery = db
+    .select({
+      conversationId: message.conversationId,
+      id: message.id,
+      bodyMd: message.bodyMd,
+      type: message.type,
+      userId: message.userId,
+      visitorId: message.visitorId,
+      websiteId: message.websiteId,
+      organizationId: message.organizationId,
+      aiAgentId: message.aiAgentId,
+      modelUsed: message.modelUsed,
+      visibility: message.visibility,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+      deletedAt: message.deletedAt,
+      parentMessageId: message.parentMessageId,
+      // Use ROW_NUMBER() to get only the latest message per conversation
+      rn: sql<number>`ROW_NUMBER() OVER (
 				PARTITION BY ${message.conversationId}
 				ORDER BY ${message.createdAt} DESC
 			)`.as("rn"),
-		})
-		.from(message)
-		.where(
-			and(
-				eq(message.organizationId, params.organizationId),
-				eq(message.visibility, MessageVisibility.PUBLIC),
-				eq(message.type, MessageType.TEXT),
-				isNull(message.deletedAt)
-			)
-		)
-		.as("last_msg");
+    })
+    .from(message)
+    .where(
+      and(
+        eq(message.organizationId, params.organizationId),
+        eq(message.visibility, MessageVisibility.PUBLIC),
+        eq(message.type, MessageType.TEXT),
+        isNull(message.deletedAt),
+      ),
+    )
+    .as("last_msg");
 
-	// Create a subquery for aggregated views per conversation
-	const viewsSubquery = db
-		.select({
-			conversationId: conversationView.conversationId,
-			viewIds: sql<string[]>`ARRAY_AGG(${conversationView.viewId})`.as(
-				"view_ids"
-			),
-		})
-		.from(conversationView)
-		.where(
-			and(
-				eq(conversationView.organizationId, params.organizationId),
-				isNull(conversationView.deletedAt)
-			)
-		)
-		.groupBy(conversationView.conversationId)
-		.as("conv_views");
+  // Create a subquery for aggregated views per conversation
+  const viewsSubquery = db
+    .select({
+      conversationId: conversationView.conversationId,
+      viewIds: sql<string[]>`ARRAY_AGG(${conversationView.viewId})`.as(
+        "view_ids",
+      ),
+    })
+    .from(conversationView)
+    .where(
+      and(
+        eq(conversationView.organizationId, params.organizationId),
+        isNull(conversationView.deletedAt),
+      ),
+    )
+    .groupBy(conversationView.conversationId)
+    .as("conv_views");
 
-	// Build where conditions
-	const whereConditions = [
-		eq(conversation.organizationId, params.organizationId),
-		eq(conversation.websiteId, params.websiteId),
-	];
+  // Build where conditions
+  const whereConditions = [
+    eq(conversation.organizationId, params.organizationId),
+    eq(conversation.websiteId, params.websiteId),
+  ];
 
-	// Handle cursor-based pagination more efficiently
-	if (params.cursor) {
-		// Decode cursor to get the timestamp and ID (format: timestamp_id)
-		const cursorParts = params.cursor.split("_");
-		if (cursorParts.length === 2) {
-			const [cursorTimestamp, cursorId] = cursorParts;
-			const cursorDate = new Date(cursorTimestamp).toISOString();
+  // Handle cursor-based pagination more efficiently
+  if (params.cursor) {
+    // Decode cursor to get the timestamp and ID (format: timestamp_id)
+    const cursorParts = params.cursor.split("_");
+    if (cursorParts.length === 2) {
+      const [cursorTimestamp, cursorId] = cursorParts;
+      const cursorDate = new Date(cursorTimestamp).toISOString();
 
-			// Use composite cursor for stable pagination
-			const cursorCondition = or(
-				lt(conversation[orderBy], cursorDate),
-				and(
-					eq(conversation[orderBy], cursorDate),
-					lt(conversation.id, cursorId)
-				)
-			);
-			if (cursorCondition) {
-				whereConditions.push(cursorCondition);
-			}
-		} else {
-			// Fallback to old cursor format (just ID)
-			const [cursorConversation] = await db
-				.select()
-				.from(conversation)
-				.where(eq(conversation.id, params.cursor))
-				.limit(1);
+      // Use composite cursor for stable pagination
+      const cursorCondition = or(
+        lt(conversation[orderBy], cursorDate),
+        and(
+          eq(conversation[orderBy], cursorDate),
+          lt(conversation.id, cursorId),
+        ),
+      );
+      if (cursorCondition) {
+        whereConditions.push(cursorCondition);
+      }
+    } else {
+      // Fallback to old cursor format (just ID)
+      const [cursorConversation] = await db
+        .select()
+        .from(conversation)
+        .where(eq(conversation.id, params.cursor))
+        .limit(1);
 
-			if (cursorConversation) {
-				whereConditions.push(
-					lt(conversation[orderBy], cursorConversation[orderBy])
-				);
-			}
-		}
-	}
+      if (cursorConversation) {
+        whereConditions.push(
+          lt(conversation[orderBy], cursorConversation[orderBy]),
+        );
+      }
+    }
+  }
 
-	// Main query - single execution with all data
-	const results = await db
-		.select({
-			// All conversation fields
-			conversation,
-			// Visitor fields (only what we need for the header)
-			visitorId: visitor.id,
-			visitorLastSeenAt: visitor.lastSeenAt,
-			visitorBlockedAt: visitor.blockedAt,
-			visitorBlockedByUserId: visitor.blockedByUserId,
-			// Contact fields (if visitor is identified)
-			contactId: contact.id,
-			contactName: contact.name,
-			contactEmail: contact.email,
-			contactImage: contact.image,
-			// Last message fields (filtered by ROW_NUMBER = 1)
-			lastMessageId: lastMessageSubquery.id,
-			lastMessageBodyMd: lastMessageSubquery.bodyMd,
-			lastMessageType: lastMessageSubquery.type,
-			lastMessageUserId: lastMessageSubquery.userId,
-			lastMessageVisitorId: lastMessageSubquery.visitorId,
-			lastMessageWebsiteId: lastMessageSubquery.websiteId,
-			lastMessageOrganizationId: lastMessageSubquery.organizationId,
-			lastMessageAiAgentId: lastMessageSubquery.aiAgentId,
-			lastMessageModelUsed: lastMessageSubquery.modelUsed,
-			lastMessageVisibility: lastMessageSubquery.visibility,
-			lastMessageCreatedAt: lastMessageSubquery.createdAt,
-			lastMessageUpdatedAt: lastMessageSubquery.updatedAt,
-			lastMessageDeletedAt: lastMessageSubquery.deletedAt,
-			lastMessageParentMessageId: lastMessageSubquery.parentMessageId,
-			// Aggregated view IDs
-			viewIds: viewsSubquery.viewIds,
-			userLastSeenAt: conversationSeen.lastSeenAt,
-		})
-		.from(conversation)
-		.innerJoin(visitor, eq(conversation.visitorId, visitor.id))
-		.leftJoin(contact, eq(visitor.contactId, contact.id))
-		.leftJoin(
-			lastMessageSubquery,
-			and(
-				eq(lastMessageSubquery.conversationId, conversation.id),
-				eq(lastMessageSubquery.rn, 1) // Only get the first (latest) message
-			)
-		)
-		.leftJoin(
-			conversationSeen,
-			and(
-				eq(conversationSeen.conversationId, conversation.id),
-				eq(conversationSeen.userId, params.userId)
-			)
-		)
-		.leftJoin(viewsSubquery, eq(viewsSubquery.conversationId, conversation.id))
-		.where(and(...whereConditions))
-		.orderBy(
-			desc(conversation[orderBy]),
-			desc(conversation.id) // Secondary sort for stable pagination
-		)
-		.limit(limit + 1);
+  // Main query - single execution with all data
+  const results = await db
+    .select({
+      // All conversation fields
+      conversation,
+      // Visitor fields (only what we need for the header)
+      visitorId: visitor.id,
+      visitorLastSeenAt: visitor.lastSeenAt,
+      visitorBlockedAt: visitor.blockedAt,
+      visitorBlockedByUserId: visitor.blockedByUserId,
+      // Contact fields (if visitor is identified)
+      contactId: contact.id,
+      contactName: contact.name,
+      contactEmail: contact.email,
+      contactImage: contact.image,
+      // Last message fields (filtered by ROW_NUMBER = 1)
+      lastMessageId: lastMessageSubquery.id,
+      lastMessageBodyMd: lastMessageSubquery.bodyMd,
+      lastMessageType: lastMessageSubquery.type,
+      lastMessageUserId: lastMessageSubquery.userId,
+      lastMessageVisitorId: lastMessageSubquery.visitorId,
+      lastMessageWebsiteId: lastMessageSubquery.websiteId,
+      lastMessageOrganizationId: lastMessageSubquery.organizationId,
+      lastMessageAiAgentId: lastMessageSubquery.aiAgentId,
+      lastMessageModelUsed: lastMessageSubquery.modelUsed,
+      lastMessageVisibility: lastMessageSubquery.visibility,
+      lastMessageCreatedAt: lastMessageSubquery.createdAt,
+      lastMessageUpdatedAt: lastMessageSubquery.updatedAt,
+      lastMessageDeletedAt: lastMessageSubquery.deletedAt,
+      lastMessageParentMessageId: lastMessageSubquery.parentMessageId,
+      // Aggregated view IDs
+      viewIds: viewsSubquery.viewIds,
+      userLastSeenAt: conversationSeen.lastSeenAt,
+    })
+    .from(conversation)
+    .innerJoin(visitor, eq(conversation.visitorId, visitor.id))
+    .leftJoin(contact, eq(visitor.contactId, contact.id))
+    .leftJoin(
+      lastMessageSubquery,
+      and(
+        eq(lastMessageSubquery.conversationId, conversation.id),
+        eq(lastMessageSubquery.rn, 1), // Only get the first (latest) message
+      ),
+    )
+    .leftJoin(
+      conversationSeen,
+      and(
+        eq(conversationSeen.conversationId, conversation.id),
+        eq(conversationSeen.userId, params.userId),
+      ),
+    )
+    .leftJoin(viewsSubquery, eq(viewsSubquery.conversationId, conversation.id))
+    .where(and(...whereConditions))
+    .orderBy(
+      desc(conversation[orderBy]),
+      desc(conversation.id), // Secondary sort for stable pagination
+    )
+    .limit(limit + 1);
 
-	// Process results for pagination
-	let nextCursor: string | null = null;
-	let items = results;
+  // Process results for pagination
+  let nextCursor: string | null = null;
+  let items = results;
 
-	if (results.length > limit) {
-		items = results.slice(0, limit);
-		const lastItem = items.at(-1);
-		if (lastItem) {
-			// Create composite cursor with timestamp and ID
-			const timestamp = lastItem.conversation[orderBy];
-			nextCursor = `${timestamp}_${lastItem.conversation.id}`;
-		}
-	}
+  if (results.length > limit) {
+    items = results.slice(0, limit);
+    const lastItem = items.at(-1);
+    if (lastItem) {
+      // Create composite cursor with timestamp and ID
+      const timestamp = lastItem.conversation[orderBy];
+      nextCursor = `${timestamp}_${lastItem.conversation.id}`;
+    }
+  }
 
-	const conversationIds = items.map((row) => row.conversation.id);
+  const conversationIds = items.map((row) => row.conversation.id);
 
-	const seenDataMap = new Map<string, ConversationSeen[]>();
+  const seenDataMap = new Map<string, ConversationSeen[]>();
 
-	if (conversationIds.length > 0) {
-		const seenRows = await db
-			.select({
-				id: conversationSeen.id,
-				conversationId: conversationSeen.conversationId,
-				userId: conversationSeen.userId,
-				visitorId: conversationSeen.visitorId,
-				aiAgentId: conversationSeen.aiAgentId,
-				lastSeenAt: conversationSeen.lastSeenAt,
-				createdAt: conversationSeen.createdAt,
-				updatedAt: conversationSeen.updatedAt,
-			})
-			.from(conversationSeen)
-			.where(
-				and(
-					eq(conversationSeen.organizationId, params.organizationId),
-					inArray(conversationSeen.conversationId, conversationIds)
-				)
-			)
-			.orderBy(desc(conversationSeen.lastSeenAt));
+  if (conversationIds.length > 0) {
+    const seenRows = await db
+      .select({
+        id: conversationSeen.id,
+        conversationId: conversationSeen.conversationId,
+        userId: conversationSeen.userId,
+        visitorId: conversationSeen.visitorId,
+        aiAgentId: conversationSeen.aiAgentId,
+        lastSeenAt: conversationSeen.lastSeenAt,
+        createdAt: conversationSeen.createdAt,
+        updatedAt: conversationSeen.updatedAt,
+      })
+      .from(conversationSeen)
+      .where(
+        and(
+          eq(conversationSeen.organizationId, params.organizationId),
+          inArray(conversationSeen.conversationId, conversationIds),
+        ),
+      )
+      .orderBy(desc(conversationSeen.lastSeenAt));
 
-		for (const seen of seenRows) {
-			const collection = seenDataMap.get(seen.conversationId) ?? [];
-			collection.push({
-				...seen,
-				lastSeenAt: seen.lastSeenAt,
-				createdAt: seen.createdAt,
-				updatedAt: seen.updatedAt,
-				deletedAt: null,
-			});
-			seenDataMap.set(seen.conversationId, collection);
-		}
-	}
+    for (const seen of seenRows) {
+      const collection = seenDataMap.get(seen.conversationId) ?? [];
+      collection.push({
+        ...seen,
+        lastSeenAt: seen.lastSeenAt,
+        createdAt: seen.createdAt,
+        updatedAt: seen.updatedAt,
+        deletedAt: null,
+      });
+      seenDataMap.set(seen.conversationId, collection);
+    }
+  }
 
-	// Transform results (much simpler now!)
-	const conversationsWithDetails = items.map((row) => {
-		// Build last message object if it exists
-		const lastMessage =
-			row.lastMessageId &&
-			row.lastMessageBodyMd !== null &&
-			row.lastMessageType &&
-			row.lastMessageWebsiteId &&
-			row.lastMessageOrganizationId &&
-			row.lastMessageVisibility &&
-			row.lastMessageCreatedAt &&
-			row.lastMessageUpdatedAt
-				? {
-						id: row.lastMessageId,
-						bodyMd: row.lastMessageBodyMd,
-						type: row.lastMessageType,
-						userId: row.lastMessageUserId,
-						visitorId: row.lastMessageVisitorId,
-						websiteId: row.lastMessageWebsiteId,
-						organizationId: row.lastMessageOrganizationId,
-						aiAgentId: row.lastMessageAiAgentId,
-						modelUsed: row.lastMessageModelUsed,
-						visibility: row.lastMessageVisibility,
-						createdAt: row.lastMessageCreatedAt,
-						updatedAt: row.lastMessageUpdatedAt,
-						deletedAt: row.lastMessageDeletedAt,
-						parentMessageId: row.lastMessageParentMessageId,
-						conversationId: row.conversation.id,
-					}
-				: null;
+  // Transform results (much simpler now!)
+  const conversationsWithDetails = items.map((row) => {
+    // Build last message object if it exists
+    const lastMessage =
+      row.lastMessageId &&
+      row.lastMessageBodyMd !== null &&
+      row.lastMessageType &&
+      row.lastMessageWebsiteId &&
+      row.lastMessageOrganizationId &&
+      row.lastMessageVisibility &&
+      row.lastMessageCreatedAt &&
+      row.lastMessageUpdatedAt
+        ? {
+            id: row.lastMessageId,
+            bodyMd: row.lastMessageBodyMd,
+            type: row.lastMessageType,
+            userId: row.lastMessageUserId,
+            visitorId: row.lastMessageVisitorId,
+            websiteId: row.lastMessageWebsiteId,
+            organizationId: row.lastMessageOrganizationId,
+            aiAgentId: row.lastMessageAiAgentId,
+            modelUsed: row.lastMessageModelUsed,
+            visibility: row.lastMessageVisibility,
+            createdAt: row.lastMessageCreatedAt,
+            updatedAt: row.lastMessageUpdatedAt,
+            deletedAt: row.lastMessageDeletedAt,
+            parentMessageId: row.lastMessageParentMessageId,
+            conversationId: row.conversation.id,
+          }
+        : null;
 
-		return {
-			...row.conversation,
-			visitor: {
-				id: row.visitorId,
-				lastSeenAt: row.visitorLastSeenAt ?? null,
-				blockedAt: row.visitorBlockedAt ?? null,
-				blockedByUserId: row.visitorBlockedByUserId,
-				isBlocked: Boolean(row.visitorBlockedAt),
-				contact: row.contactId
-					? {
-							id: row.contactId,
-							name: row.contactName,
-							email: row.contactEmail,
-							image: row.contactImage,
-						}
-					: null,
-			},
-			// Include contact information if visitor is identified
-			viewIds: row.viewIds || [],
-			lastMessageAt: row.lastMessageCreatedAt ?? null,
-			lastSeenAt: row.userLastSeenAt ?? null,
-			lastMessagePreview: lastMessage,
-			seenData: seenDataMap.get(row.conversation.id) ?? [],
-		};
-	});
+    return {
+      ...row.conversation,
+      visitor: {
+        id: row.visitorId,
+        lastSeenAt: row.visitorLastSeenAt ?? null,
+        blockedAt: row.visitorBlockedAt ?? null,
+        blockedByUserId: row.visitorBlockedByUserId,
+        isBlocked: Boolean(row.visitorBlockedAt),
+        contact: row.contactId
+          ? {
+              id: row.contactId,
+              name: row.contactName,
+              email: row.contactEmail,
+              image: row.contactImage,
+            }
+          : null,
+      },
+      // Include contact information if visitor is identified
+      viewIds: row.viewIds || [],
+      lastMessageAt: row.lastMessageCreatedAt ?? null,
+      lastSeenAt: row.userLastSeenAt ?? null,
+      lastMessagePreview: lastMessage,
+      seenData: seenDataMap.get(row.conversation.id) ?? [],
+    };
+  });
 
-	return {
-		items: conversationsWithDetails,
-		nextCursor,
-	};
+  return {
+    items: conversationsWithDetails,
+    nextCursor,
+  };
 }
 
 export async function getConversationHeader(
-	db: Database,
-	params: {
-		organizationId: string;
-		websiteId: string;
-		conversationId: string;
-		userId?: string | null;
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    websiteId: string;
+    conversationId: string;
+    userId?: string | null;
+  },
 ): Promise<ConversationHeader | null> {
-	const lastMessageSubquery = db
-		.select({
-			conversationId: message.conversationId,
-			id: message.id,
-			bodyMd: message.bodyMd,
-			type: message.type,
-			userId: message.userId,
-			visitorId: message.visitorId,
-			websiteId: message.websiteId,
-			organizationId: message.organizationId,
-			aiAgentId: message.aiAgentId,
-			modelUsed: message.modelUsed,
-			visibility: message.visibility,
-			createdAt: message.createdAt,
-			updatedAt: message.updatedAt,
-			deletedAt: message.deletedAt,
-			parentMessageId: message.parentMessageId,
-		})
-		.from(message)
-		.where(
-			and(
-				eq(message.organizationId, params.organizationId),
-				eq(message.conversationId, params.conversationId),
-				eq(message.visibility, MessageVisibility.PUBLIC),
-				isNull(message.deletedAt)
-			)
-		)
-		.orderBy(desc(message.createdAt))
-		.limit(1)
-		.as("last_msg_single");
+  const lastMessageSubquery = db
+    .select({
+      conversationId: message.conversationId,
+      id: message.id,
+      bodyMd: message.bodyMd,
+      type: message.type,
+      userId: message.userId,
+      visitorId: message.visitorId,
+      websiteId: message.websiteId,
+      organizationId: message.organizationId,
+      aiAgentId: message.aiAgentId,
+      modelUsed: message.modelUsed,
+      visibility: message.visibility,
+      createdAt: message.createdAt,
+      updatedAt: message.updatedAt,
+      deletedAt: message.deletedAt,
+      parentMessageId: message.parentMessageId,
+    })
+    .from(message)
+    .where(
+      and(
+        eq(message.organizationId, params.organizationId),
+        eq(message.conversationId, params.conversationId),
+        eq(message.visibility, MessageVisibility.PUBLIC),
+        isNull(message.deletedAt),
+      ),
+    )
+    .orderBy(desc(message.createdAt))
+    .limit(1)
+    .as("last_msg_single");
 
-	const viewsSubquery = db
-		.select({
-			conversationId: conversationView.conversationId,
-			viewIds: sql<string[]>`ARRAY_AGG(${conversationView.viewId})`.as(
-				"view_ids"
-			),
-		})
-		.from(conversationView)
-		.where(
-			and(
-				eq(conversationView.organizationId, params.organizationId),
-				eq(conversationView.conversationId, params.conversationId),
-				isNull(conversationView.deletedAt)
-			)
-		)
-		.groupBy(conversationView.conversationId)
-		.as("conv_views_single");
+  const viewsSubquery = db
+    .select({
+      conversationId: conversationView.conversationId,
+      viewIds: sql<string[]>`ARRAY_AGG(${conversationView.viewId})`.as(
+        "view_ids",
+      ),
+    })
+    .from(conversationView)
+    .where(
+      and(
+        eq(conversationView.organizationId, params.organizationId),
+        eq(conversationView.conversationId, params.conversationId),
+        isNull(conversationView.deletedAt),
+      ),
+    )
+    .groupBy(conversationView.conversationId)
+    .as("conv_views_single");
 
-	const userJoinCondition = params.userId
-		? eq(conversationSeen.userId, params.userId)
-		: sql`1=0`;
+  const userJoinCondition = params.userId
+    ? eq(conversationSeen.userId, params.userId)
+    : sql`1=0`;
 
-	const [row] = await db
-		.select({
-			conversation,
-			visitorId: visitor.id,
-			visitorLastSeenAt: visitor.lastSeenAt,
-			visitorBlockedAt: visitor.blockedAt,
-			visitorBlockedByUserId: visitor.blockedByUserId,
-			contactId: contact.id,
-			contactName: contact.name,
-			contactEmail: contact.email,
-			contactImage: contact.image,
-			lastMessageId: lastMessageSubquery.id,
-			lastMessageBodyMd: lastMessageSubquery.bodyMd,
-			lastMessageType: lastMessageSubquery.type,
-			lastMessageUserId: lastMessageSubquery.userId,
-			lastMessageVisitorId: lastMessageSubquery.visitorId,
-			lastMessageWebsiteId: lastMessageSubquery.websiteId,
-			lastMessageOrganizationId: lastMessageSubquery.organizationId,
-			lastMessageAiAgentId: lastMessageSubquery.aiAgentId,
-			lastMessageModelUsed: lastMessageSubquery.modelUsed,
-			lastMessageVisibility: lastMessageSubquery.visibility,
-			lastMessageCreatedAt: lastMessageSubquery.createdAt,
-			lastMessageUpdatedAt: lastMessageSubquery.updatedAt,
-			lastMessageDeletedAt: lastMessageSubquery.deletedAt,
-			lastMessageParentMessageId: lastMessageSubquery.parentMessageId,
-			viewIds: viewsSubquery.viewIds,
-			userLastSeenAt: params.userId
-				? conversationSeen.lastSeenAt
-				: sql<string | null>`NULL`,
-		})
-		.from(conversation)
-		.innerJoin(visitor, eq(conversation.visitorId, visitor.id))
-		.leftJoin(contact, eq(visitor.contactId, contact.id))
-		.leftJoin(
-			lastMessageSubquery,
-			eq(lastMessageSubquery.conversationId, conversation.id)
-		)
-		.leftJoin(viewsSubquery, eq(viewsSubquery.conversationId, conversation.id))
-		.leftJoin(
-			conversationSeen,
-			and(
-				eq(conversationSeen.conversationId, conversation.id),
-				userJoinCondition
-			)
-		)
-		.where(
-			and(
-				eq(conversation.organizationId, params.organizationId),
-				eq(conversation.websiteId, params.websiteId),
-				eq(conversation.id, params.conversationId)
-			)
-		)
-		.limit(1);
+  const [row] = await db
+    .select({
+      conversation,
+      visitorId: visitor.id,
+      visitorLastSeenAt: visitor.lastSeenAt,
+      visitorBlockedAt: visitor.blockedAt,
+      visitorBlockedByUserId: visitor.blockedByUserId,
+      contactId: contact.id,
+      contactName: contact.name,
+      contactEmail: contact.email,
+      contactImage: contact.image,
+      lastMessageId: lastMessageSubquery.id,
+      lastMessageBodyMd: lastMessageSubquery.bodyMd,
+      lastMessageType: lastMessageSubquery.type,
+      lastMessageUserId: lastMessageSubquery.userId,
+      lastMessageVisitorId: lastMessageSubquery.visitorId,
+      lastMessageWebsiteId: lastMessageSubquery.websiteId,
+      lastMessageOrganizationId: lastMessageSubquery.organizationId,
+      lastMessageAiAgentId: lastMessageSubquery.aiAgentId,
+      lastMessageModelUsed: lastMessageSubquery.modelUsed,
+      lastMessageVisibility: lastMessageSubquery.visibility,
+      lastMessageCreatedAt: lastMessageSubquery.createdAt,
+      lastMessageUpdatedAt: lastMessageSubquery.updatedAt,
+      lastMessageDeletedAt: lastMessageSubquery.deletedAt,
+      lastMessageParentMessageId: lastMessageSubquery.parentMessageId,
+      viewIds: viewsSubquery.viewIds,
+      userLastSeenAt: params.userId
+        ? conversationSeen.lastSeenAt
+        : sql<string | null>`NULL`,
+    })
+    .from(conversation)
+    .innerJoin(visitor, eq(conversation.visitorId, visitor.id))
+    .leftJoin(contact, eq(visitor.contactId, contact.id))
+    .leftJoin(
+      lastMessageSubquery,
+      eq(lastMessageSubquery.conversationId, conversation.id),
+    )
+    .leftJoin(viewsSubquery, eq(viewsSubquery.conversationId, conversation.id))
+    .leftJoin(
+      conversationSeen,
+      and(
+        eq(conversationSeen.conversationId, conversation.id),
+        userJoinCondition,
+      ),
+    )
+    .where(
+      and(
+        eq(conversation.organizationId, params.organizationId),
+        eq(conversation.websiteId, params.websiteId),
+        eq(conversation.id, params.conversationId),
+      ),
+    )
+    .limit(1);
 
-	if (!row) {
-		return null;
-	}
+  if (!row) {
+    return null;
+  }
 
-	const seenRows = await db
-		.select({
-			id: conversationSeen.id,
-			conversationId: conversationSeen.conversationId,
-			userId: conversationSeen.userId,
-			visitorId: conversationSeen.visitorId,
-			aiAgentId: conversationSeen.aiAgentId,
-			lastSeenAt: conversationSeen.lastSeenAt,
-			createdAt: conversationSeen.createdAt,
-			updatedAt: conversationSeen.updatedAt,
-		})
-		.from(conversationSeen)
-		.where(
-			and(
-				eq(conversationSeen.organizationId, params.organizationId),
-				eq(conversationSeen.conversationId, params.conversationId)
-			)
-		)
-		.orderBy(desc(conversationSeen.lastSeenAt));
+  const seenRows = await db
+    .select({
+      id: conversationSeen.id,
+      conversationId: conversationSeen.conversationId,
+      userId: conversationSeen.userId,
+      visitorId: conversationSeen.visitorId,
+      aiAgentId: conversationSeen.aiAgentId,
+      lastSeenAt: conversationSeen.lastSeenAt,
+      createdAt: conversationSeen.createdAt,
+      updatedAt: conversationSeen.updatedAt,
+    })
+    .from(conversationSeen)
+    .where(
+      and(
+        eq(conversationSeen.organizationId, params.organizationId),
+        eq(conversationSeen.conversationId, params.conversationId),
+      ),
+    )
+    .orderBy(desc(conversationSeen.lastSeenAt));
 
-	const seenData: ConversationSeen[] = seenRows.map((seen) => ({
-		...seen,
-		deletedAt: null,
-	}));
+  const seenData: ConversationSeen[] = seenRows.map((seen) => ({
+    ...seen,
+    deletedAt: null,
+  }));
 
-	const lastMessage =
-		row.lastMessageId &&
-		row.lastMessageBodyMd !== null &&
-		row.lastMessageType &&
-		row.lastMessageWebsiteId &&
-		row.lastMessageOrganizationId &&
-		row.lastMessageVisibility &&
-		row.lastMessageCreatedAt &&
-		row.lastMessageUpdatedAt
-			? {
-					id: row.lastMessageId,
-					bodyMd: row.lastMessageBodyMd,
-					type: row.lastMessageType,
-					userId: row.lastMessageUserId,
-					visitorId: row.lastMessageVisitorId,
-					websiteId: row.lastMessageWebsiteId,
-					organizationId: row.lastMessageOrganizationId,
-					aiAgentId: row.lastMessageAiAgentId,
-					modelUsed: row.lastMessageModelUsed,
-					visibility: row.lastMessageVisibility,
-					createdAt: row.lastMessageCreatedAt,
-					updatedAt: row.lastMessageUpdatedAt,
-					deletedAt: row.lastMessageDeletedAt,
-					parentMessageId: row.lastMessageParentMessageId,
-					conversationId: row.conversation.id,
-				}
-			: null;
+  const lastMessage =
+    row.lastMessageId &&
+    row.lastMessageBodyMd !== null &&
+    row.lastMessageType &&
+    row.lastMessageWebsiteId &&
+    row.lastMessageOrganizationId &&
+    row.lastMessageVisibility &&
+    row.lastMessageCreatedAt &&
+    row.lastMessageUpdatedAt
+      ? {
+          id: row.lastMessageId,
+          bodyMd: row.lastMessageBodyMd,
+          type: row.lastMessageType,
+          userId: row.lastMessageUserId,
+          visitorId: row.lastMessageVisitorId,
+          websiteId: row.lastMessageWebsiteId,
+          organizationId: row.lastMessageOrganizationId,
+          aiAgentId: row.lastMessageAiAgentId,
+          modelUsed: row.lastMessageModelUsed,
+          visibility: row.lastMessageVisibility,
+          createdAt: row.lastMessageCreatedAt,
+          updatedAt: row.lastMessageUpdatedAt,
+          deletedAt: row.lastMessageDeletedAt,
+          parentMessageId: row.lastMessageParentMessageId,
+          conversationId: row.conversation.id,
+        }
+      : null;
 
-	return {
-		...row.conversation,
-		visitor: {
-			id: row.visitorId,
-			lastSeenAt: row.visitorLastSeenAt ?? null,
-			blockedAt: row.visitorBlockedAt ?? null,
-			blockedByUserId: row.visitorBlockedByUserId,
-			isBlocked: Boolean(row.visitorBlockedAt),
-			contact: row.contactId
-				? {
-						id: row.contactId,
-						name: row.contactName,
-						email: row.contactEmail,
-						image: row.contactImage,
-					}
-				: null,
-		},
-		viewIds: row.viewIds ?? [],
-		lastMessageAt: row.conversation.lastMessageAt ?? null,
-		lastSeenAt: row.userLastSeenAt ?? null,
-		lastMessagePreview: lastMessage,
-		seenData,
-	} satisfies ConversationHeader;
+  return {
+    ...row.conversation,
+    visitor: {
+      id: row.visitorId,
+      lastSeenAt: row.visitorLastSeenAt ?? null,
+      blockedAt: row.visitorBlockedAt ?? null,
+      blockedByUserId: row.visitorBlockedByUserId,
+      isBlocked: Boolean(row.visitorBlockedAt),
+      contact: row.contactId
+        ? {
+            id: row.contactId,
+            name: row.contactName,
+            email: row.contactEmail,
+            image: row.contactImage,
+          }
+        : null,
+    },
+    viewIds: row.viewIds ?? [],
+    lastMessageAt: row.conversation.lastMessageAt ?? null,
+    lastSeenAt: row.userLastSeenAt ?? null,
+    lastMessagePreview: lastMessage,
+    seenData,
+  } satisfies ConversationHeader;
 }
 
 export async function getConversationById(
-	db: Database,
-	params: {
-		conversationId: string;
-	}
+  db: Database,
+  params: {
+    conversationId: string;
+  },
 ) {
-	const [_conversation] = await db
-		.select()
-		.from(conversation)
-		.where(eq(conversation.id, params.conversationId))
-		.limit(1);
+  const [_conversation] = await db
+    .select()
+    .from(conversation)
+    .where(eq(conversation.id, params.conversationId))
+    .limit(1);
 
-	return _conversation;
+  return _conversation;
 }
 
 export async function getConversationEvents(
-	db: Database,
-	params: {
-		conversationId: string;
-		websiteId: string;
-		limit?: number;
-		cursor?: string | Date | null;
-	}
+  db: Database,
+  params: {
+    organizationId: string;
+    conversationId: string;
+    limit?: number;
+    cursor?: string | Date | null;
+  },
 ) {
-	const limit = params.limit ?? DEFAULT_PAGE_LIMIT;
+  const limit = params.limit ?? DEFAULT_PAGE_LIMIT;
 
-	// Build where clause scoped to the conversation
-	const whereConditions = [
-		eq(conversationEvent.conversationId, params.conversationId),
-	];
+  // Build where clause scoped to the conversation
+  const whereConditions = [
+    eq(conversationEvent.organizationId, params.organizationId),
+    eq(conversationEvent.conversationId, params.conversationId),
+  ];
 
-	// When paginating fetch events older than the current batch.
-	if (params.cursor) {
-		const cursorValue = params.cursor;
-		const cursorParts =
-			typeof cursorValue === "string" ? cursorValue.split("_") : [];
+  // When paginating fetch events older than the current batch.
+  if (params.cursor) {
+    const cursorValue = params.cursor;
+    const cursorParts =
+      typeof cursorValue === "string" ? cursorValue.split("_") : [];
 
-		if (cursorParts.length === 2) {
-			const [cursorTimestamp, cursorId] = cursorParts;
-			const cursorDate = new Date(cursorTimestamp);
+    if (cursorParts.length === 2) {
+      const [cursorTimestamp, cursorId] = cursorParts;
+      const cursorDate = new Date(cursorTimestamp);
 
-			if (!Number.isNaN(cursorDate.getTime())) {
-				const cursorIso = cursorDate.toISOString();
-				whereConditions.push(
-					or(
-						lt(conversationEvent.createdAt, cursorIso),
-						and(
-							eq(conversationEvent.createdAt, cursorIso),
-							lt(conversationEvent.id, cursorId)
-						)
-					)!
-				);
-			}
-		} else {
-			const cursorDate =
-				cursorValue instanceof Date
-					? cursorValue
-					: new Date(cursorValue as string);
+      if (!Number.isNaN(cursorDate.getTime())) {
+        const cursorIso = cursorDate.toISOString();
+        whereConditions.push(
+          or(
+            lt(conversationEvent.createdAt, cursorIso),
+            and(
+              eq(conversationEvent.createdAt, cursorIso),
+              lt(conversationEvent.id, cursorId),
+            ),
+          )!,
+        );
+      }
+    } else {
+      const cursorDate =
+        cursorValue instanceof Date
+          ? cursorValue
+          : new Date(cursorValue as string);
 
-			if (!Number.isNaN(cursorDate.getTime())) {
-				whereConditions.push(
-					lt(conversationEvent.createdAt, cursorDate.toISOString())
-				);
-			}
-		}
-	}
+      if (!Number.isNaN(cursorDate.getTime())) {
+        whereConditions.push(
+          lt(conversationEvent.createdAt, cursorDate.toISOString()),
+        );
+      }
+    }
+  }
 
-	// Fetch newest events first for efficient backwards pagination.
-	const rows = await db
-		.select()
-		.from(conversationEvent)
-		.where(and(...whereConditions))
-		.orderBy(desc(conversationEvent.createdAt), desc(conversationEvent.id))
-		.limit(limit + 1);
+  // Fetch newest events first for efficient backwards pagination.
+  const rows = await db
+    .select()
+    .from(conversationEvent)
+    .where(and(...whereConditions))
+    .orderBy(desc(conversationEvent.createdAt), desc(conversationEvent.id))
+    .limit(limit + 1);
 
-	const hasNextPage = rows.length > limit;
-	const limitedRows = hasNextPage ? rows.slice(0, limit) : rows;
-	const nextCursor = hasNextPage
-		? (() => {
-				const lastRow = limitedRows.at(-1);
-				if (!lastRow) {
-					return null;
-				}
+  const hasNextPage = rows.length > limit;
+  const limitedRows = hasNextPage ? rows.slice(0, limit) : rows;
+  const nextCursor = hasNextPage
+    ? (() => {
+        const lastRow = limitedRows.at(-1);
+        if (!lastRow) {
+          return null;
+        }
 
-				const timestamp = new Date(lastRow.createdAt).toISOString();
-				return `${timestamp}_${lastRow.id}`;
-			})()
-		: null;
+        const timestamp = new Date(lastRow.createdAt).toISOString();
+        return `${timestamp}_${lastRow.id}`;
+      })()
+    : null;
 
-	return {
-		events: [...limitedRows].reverse(),
-		nextCursor,
-		hasNextPage,
-	};
+  return {
+    events: [...limitedRows].reverse(),
+    nextCursor,
+    hasNextPage,
+  };
 }
 
 export async function getConversationSeenData(
-	db: Database,
-	params: {
-		conversationId: string;
-		organizationId: string;
-	}
+  db: Database,
+  params: {
+    conversationId: string;
+    organizationId: string;
+  },
 ) {
-	const seenRows = await db
-		.select({
-			id: conversationSeen.id,
-			conversationId: conversationSeen.conversationId,
-			userId: conversationSeen.userId,
-			visitorId: conversationSeen.visitorId,
-			aiAgentId: conversationSeen.aiAgentId,
-			lastSeenAt: conversationSeen.lastSeenAt,
-			createdAt: conversationSeen.createdAt,
-			updatedAt: conversationSeen.updatedAt,
-		})
-		.from(conversationSeen)
-		.where(
-			and(
-				eq(conversationSeen.organizationId, params.organizationId),
-				eq(conversationSeen.conversationId, params.conversationId)
-			)
-		)
-		.orderBy(desc(conversationSeen.lastSeenAt));
+  const seenRows = await db
+    .select({
+      id: conversationSeen.id,
+      conversationId: conversationSeen.conversationId,
+      userId: conversationSeen.userId,
+      visitorId: conversationSeen.visitorId,
+      aiAgentId: conversationSeen.aiAgentId,
+      lastSeenAt: conversationSeen.lastSeenAt,
+      createdAt: conversationSeen.createdAt,
+      updatedAt: conversationSeen.updatedAt,
+    })
+    .from(conversationSeen)
+    .where(
+      and(
+        eq(conversationSeen.organizationId, params.organizationId),
+        eq(conversationSeen.conversationId, params.conversationId),
+      ),
+    )
+    .orderBy(desc(conversationSeen.lastSeenAt));
 
-	return seenRows.map((seen) => ({
-		...seen,
-		deletedAt: null,
-	}));
+  return seenRows.map((seen) => ({
+    ...seen,
+    deletedAt: null,
+  }));
 }

--- a/apps/api/src/rest/routers/conversation.ts
+++ b/apps/api/src/rest/routers/conversation.ts
@@ -1,34 +1,37 @@
 import { markConversationAsSeenByVisitor } from "@api/db/mutations/conversation";
 import { getVisitor } from "@api/db/queries";
 import {
-	getConversationByIdWithLastMessage,
-	getConversationHeader,
-	getConversationSeenData,
-	listConversations,
-	upsertConversation,
+  getConversationByIdWithLastMessage,
+  getConversationEvents,
+  getConversationHeader,
+  getConversationSeenData,
+  listConversations,
+  upsertConversation,
 } from "@api/db/queries/conversation";
 import {
-	emitConversationCreatedEvent,
-	emitConversationSeenEvent,
-	emitConversationTypingEvent,
+  emitConversationCreatedEvent,
+  emitConversationSeenEvent,
+  emitConversationTypingEvent,
 } from "@api/utils/conversation-realtime";
 import { createMessage } from "@api/utils/message";
 import {
-	safelyExtractRequestData,
-	safelyExtractRequestQuery,
-	validateResponse,
+  safelyExtractRequestData,
+  safelyExtractRequestQuery,
+  validateResponse,
 } from "@api/utils/validate";
 import {
-	createConversationRequestSchema,
-	createConversationResponseSchema,
-	getConversationRequestSchema,
-	getConversationResponseSchema,
-	listConversationsRequestSchema,
-	listConversationsResponseSchema,
-	markConversationSeenRequestSchema,
-	markConversationSeenResponseSchema,
-	setConversationTypingRequestSchema,
-	setConversationTypingResponseSchema,
+  createConversationRequestSchema,
+  createConversationResponseSchema,
+  getConversationEventsRequestSchema,
+  getConversationEventsResponseSchema,
+  getConversationRequestSchema,
+  getConversationResponseSchema,
+  listConversationsRequestSchema,
+  listConversationsResponseSchema,
+  markConversationSeenRequestSchema,
+  markConversationSeenResponseSchema,
+  setConversationTypingRequestSchema,
+  setConversationTypingResponseSchema,
 } from "@cossistant/types/api/conversation";
 import type { Message } from "@cossistant/types/schemas";
 import { conversationSeenSchema } from "@cossistant/types/schemas";
@@ -42,808 +45,907 @@ export const conversationRouter = new OpenAPIHono<RestContext>();
 conversationRouter.use("/*", ...protectedPublicApiKeyMiddleware);
 
 conversationRouter.openapi(
-	{
-		method: "post",
-		path: "/",
-		summary: "Create a conversation with or without initial messages",
-		description:
-			"Create a conversation, accepts a conversation id or not and a set of default messages.",
-		tags: ["Conversations"],
-		request: {
-			body: {
-				required: true,
-				content: {
-					"application/json": {
-						schema: createConversationRequestSchema,
-					},
-				},
-			},
-		},
-		responses: {
-			200: {
-				description: "Conversation created",
-				content: {
-					"application/json": {
-						schema: createConversationResponseSchema,
-					},
-				},
-			},
-			400: {
-				description: "Invalid request",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-			{
-				"Private API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "Authorization",
-				in: "header",
-				description:
-					"Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description:
-					"Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Visitor-Id",
-				in: "header",
-				description: "Visitor ID from localStorage.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
-					example: "01JG000000000000000000000",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization, body, visitorIdHeader } =
-			await safelyExtractRequestData(c, createConversationRequestSchema);
+  {
+    method: "post",
+    path: "/",
+    summary: "Create a conversation with or without initial messages",
+    description:
+      "Create a conversation, accepts a conversation id or not and a set of default messages.",
+    tags: ["Conversations"],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: createConversationRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Conversation created",
+        content: {
+          "application/json": {
+            schema: createConversationResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+      {
+        "Private API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "Authorization",
+        in: "header",
+        description:
+          "Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Visitor-Id",
+        in: "header",
+        description: "Visitor ID from localStorage.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
+          example: "01JG000000000000000000000",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization, body, visitorIdHeader } =
+      await safelyExtractRequestData(c, createConversationRequestSchema);
 
-		const visitor = await getVisitor(db, {
-			visitorId: body.visitorId || visitorIdHeader,
-		});
+    const visitor = await getVisitor(db, {
+      visitorId: body.visitorId || visitorIdHeader,
+    });
 
-		if (!visitor) {
-			return c.json(
-				{
-					error: "Visitor not found, please pass a valid visitorId",
-				},
-				400
-			);
-		}
+    if (!visitor) {
+      return c.json(
+        {
+          error: "Visitor not found, please pass a valid visitorId",
+        },
+        400,
+      );
+    }
 
-		const conversation = await upsertConversation(db, {
-			organizationId: organization.id,
-			websiteId: website.id,
-			visitorId: visitor.id,
-			conversationId: body.conversationId,
-		});
+    const conversation = await upsertConversation(db, {
+      organizationId: organization.id,
+      websiteId: website.id,
+      visitorId: visitor.id,
+      conversationId: body.conversationId,
+    });
 
-		let initialMessages: Message[] = [];
+    let initialMessages: Message[] = [];
 
-		const defaults = body.defaultMessages ?? [];
-		if (defaults.length > 0) {
-			initialMessages = await Promise.all(
-				defaults.map((msg) =>
-					createMessage({
-						db,
-						organizationId: organization.id,
-						websiteId: website.id,
-						conversationId: conversation.id,
-						conversationOwnerVisitorId: conversation.visitorId,
-						message: {
-							bodyMd: msg.bodyMd,
-							type: msg.type ?? undefined,
-							userId: msg.userId ?? null,
-							aiAgentId: msg.aiAgentId ?? null,
-							visitorId: msg.visitorId ?? null,
-							visibility: msg.visibility ?? undefined,
-							createdAt: new Date(msg.createdAt),
-						},
-					})
-				)
-			);
-		}
+    const defaults = body.defaultMessages ?? [];
+    if (defaults.length > 0) {
+      initialMessages = await Promise.all(
+        defaults.map((msg) =>
+          createMessage({
+            db,
+            organizationId: organization.id,
+            websiteId: website.id,
+            conversationId: conversation.id,
+            conversationOwnerVisitorId: conversation.visitorId,
+            message: {
+              bodyMd: msg.bodyMd,
+              type: msg.type ?? undefined,
+              userId: msg.userId ?? null,
+              aiAgentId: msg.aiAgentId ?? null,
+              visitorId: msg.visitorId ?? null,
+              visibility: msg.visibility ?? undefined,
+              createdAt: new Date(msg.createdAt),
+            },
+          }),
+        ),
+      );
+    }
 
-		// Get the last message if any were sent
-		const lastMessage =
-			initialMessages.length > 0 ? initialMessages.at(-1) : undefined;
+    // Get the last message if any were sent
+    const lastMessage =
+      initialMessages.length > 0 ? initialMessages.at(-1) : undefined;
 
-		const header = await getConversationHeader(db, {
-			organizationId: organization.id,
-			websiteId: website.id,
-			conversationId: conversation.id,
-			userId: null,
-		});
+    const header = await getConversationHeader(db, {
+      organizationId: organization.id,
+      websiteId: website.id,
+      conversationId: conversation.id,
+      userId: null,
+    });
 
-		if (header) {
-			await emitConversationCreatedEvent({
-				conversation,
-				header,
-			});
-		}
+    if (header) {
+      await emitConversationCreatedEvent({
+        conversation,
+        header,
+      });
+    }
 
-		return c.json(
-			validateResponse(
-				{
-					initialMessages,
-					conversation: {
-						id: conversation.id,
-						createdAt: conversation.createdAt,
-						updatedAt: conversation.updatedAt,
-						visitorId: conversation.visitorId,
-						websiteId: conversation.websiteId,
-						status: conversation.status,
-						lastMessage,
-					},
-				},
-				createConversationResponseSchema
-			)
-		);
-	}
+    return c.json(
+      validateResponse(
+        {
+          initialMessages,
+          conversation: {
+            id: conversation.id,
+            createdAt: conversation.createdAt,
+            updatedAt: conversation.updatedAt,
+            visitorId: conversation.visitorId,
+            websiteId: conversation.websiteId,
+            status: conversation.status,
+            lastMessage,
+          },
+        },
+        createConversationResponseSchema,
+      ),
+    );
+  },
 );
 
 conversationRouter.openapi(
-	{
-		method: "get",
-		path: "/",
-		summary: "List conversations for a visitor",
-		description:
-			"Fetch paginated list of conversations for a specific visitor with optional filters.",
-		tags: ["Conversations"],
-		request: {
-			query: listConversationsRequestSchema,
-		},
-		responses: {
-			200: {
-				description: "List of conversations retrieved successfully",
-				content: {
-					"application/json": {
-						schema: listConversationsResponseSchema,
-					},
-				},
-			},
-			400: {
-				description: "Invalid request",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-			{
-				"Private API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "Authorization",
-				in: "header",
-				description:
-					"Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description:
-					"Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Visitor-Id",
-				in: "header",
-				description: "Visitor ID from localStorage.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
-					example: "01JG000000000000000000000",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization, query, visitorIdHeader } =
-			await safelyExtractRequestQuery(c, listConversationsRequestSchema);
+  {
+    method: "get",
+    path: "/",
+    summary: "List conversations for a visitor",
+    description:
+      "Fetch paginated list of conversations for a specific visitor with optional filters.",
+    tags: ["Conversations"],
+    request: {
+      query: listConversationsRequestSchema,
+    },
+    responses: {
+      200: {
+        description: "List of conversations retrieved successfully",
+        content: {
+          "application/json": {
+            schema: listConversationsResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+      {
+        "Private API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "Authorization",
+        in: "header",
+        description:
+          "Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Visitor-Id",
+        in: "header",
+        description: "Visitor ID from localStorage.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
+          example: "01JG000000000000000000000",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization, query, visitorIdHeader } =
+      await safelyExtractRequestQuery(c, listConversationsRequestSchema);
 
-		const visitor = await getVisitor(db, {
-			visitorId: query.visitorId || visitorIdHeader,
-		});
+    const visitor = await getVisitor(db, {
+      visitorId: query.visitorId || visitorIdHeader,
+    });
 
-		if (!visitor) {
-			return c.json(
-				{
-					error: "Visitor not found, please pass a valid visitorId",
-				},
-				400
-			);
-		}
+    if (!visitor) {
+      return c.json(
+        {
+          error: "Visitor not found, please pass a valid visitorId",
+        },
+        400,
+      );
+    }
 
-		const result = await listConversations(db, {
-			organizationId: organization.id,
-			websiteId: website.id,
-			visitorId: visitor.id,
-			page: query.page,
-			limit: query.limit,
-			status: query.status,
-			orderBy: query.orderBy,
-			order: query.order,
-		});
+    const result = await listConversations(db, {
+      organizationId: organization.id,
+      websiteId: website.id,
+      visitorId: visitor.id,
+      page: query.page,
+      limit: query.limit,
+      status: query.status,
+      orderBy: query.orderBy,
+      order: query.order,
+    });
 
-		// Transform database response to match API schema
-		const apiResponse = {
-			conversations: result.conversations.map((conv) => ({
-				id: conv.id,
-				title: conv.title ?? undefined,
-				createdAt: conv.createdAt,
-				updatedAt: conv.updatedAt,
-				visitorId: conv.visitorId,
-				websiteId: conv.websiteId,
-				status: conv.status,
-				lastMessage: conv.lastMessage,
-			})),
-			pagination: result.pagination,
-		};
+    // Transform database response to match API schema
+    const apiResponse = {
+      conversations: result.conversations.map((conv) => ({
+        id: conv.id,
+        title: conv.title ?? undefined,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+        visitorId: conv.visitorId,
+        websiteId: conv.websiteId,
+        status: conv.status,
+        lastMessage: conv.lastMessage,
+      })),
+      pagination: result.pagination,
+    };
 
-		return c.json(
-			validateResponse(apiResponse, listConversationsResponseSchema)
-		);
-	}
+    return c.json(
+      validateResponse(apiResponse, listConversationsResponseSchema),
+    );
+  },
 );
 
 conversationRouter.openapi(
-	{
-		method: "get",
-		path: "/{conversationId}",
-		summary: "Get a single conversation by ID",
-		description: "Fetch a specific conversation by its ID.",
-		tags: ["Conversations"],
-		request: {
-			params: getConversationRequestSchema,
-		},
-		responses: {
-			200: {
-				description: "Conversation retrieved successfully",
-				content: {
-					"application/json": {
-						schema: getConversationResponseSchema,
-					},
-				},
-			},
-			404: {
-				description: "Conversation not found",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-			{
-				"Private API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "conversationId",
-				in: "path",
-				description: "The ID of the conversation to retrieve",
-				required: true,
-				schema: {
-					type: "string",
-				},
-			},
-			{
-				name: "Authorization",
-				in: "header",
-				description:
-					"Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description:
-					"Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Visitor-Id",
-				in: "header",
-				description: "Visitor ID from localStorage.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
-					example: "01JG000000000000000000000",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization } = await safelyExtractRequestData(c);
+  {
+    method: "get",
+    path: "/{conversationId}",
+    summary: "Get a single conversation by ID",
+    description: "Fetch a specific conversation by its ID.",
+    tags: ["Conversations"],
+    request: {
+      params: getConversationRequestSchema,
+    },
+    responses: {
+      200: {
+        description: "Conversation retrieved successfully",
+        content: {
+          "application/json": {
+            schema: getConversationResponseSchema,
+          },
+        },
+      },
+      404: {
+        description: "Conversation not found",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+      {
+        "Private API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "conversationId",
+        in: "path",
+        description: "The ID of the conversation to retrieve",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "Authorization",
+        in: "header",
+        description:
+          "Private API key in Bearer token format. Use this for server-to-server authentication. Format: `Bearer sk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Visitor-Id",
+        in: "header",
+        description: "Visitor ID from localStorage.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
+          example: "01JG000000000000000000000",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization } = await safelyExtractRequestData(c);
 
-		// Validate path params manually for now
-		const params = getConversationRequestSchema.parse({
-			conversationId: c.req.param("conversationId"),
-		});
+    // Validate path params manually for now
+    const params = getConversationRequestSchema.parse({
+      conversationId: c.req.param("conversationId"),
+    });
 
-		const conversation = await getConversationByIdWithLastMessage(db, {
-			organizationId: organization.id,
-			websiteId: website.id,
-			conversationId: params.conversationId,
-		});
+    const conversation = await getConversationByIdWithLastMessage(db, {
+      organizationId: organization.id,
+      websiteId: website.id,
+      conversationId: params.conversationId,
+    });
 
-		if (!conversation) {
-			return c.json(
-				{
-					error: "Conversation not found",
-				},
-				404
-			);
-		}
+    if (!conversation) {
+      return c.json(
+        {
+          error: "Conversation not found",
+        },
+        404,
+      );
+    }
 
-		// Transform database response to match API schema
-		const apiResponse = {
-			conversation: {
-				id: conversation.id,
-				title: conversation.title ?? undefined,
-				createdAt: conversation.createdAt,
-				updatedAt: conversation.updatedAt,
-				visitorId: conversation.visitorId,
-				websiteId: conversation.websiteId,
-				status: conversation.status,
-				lastMessage: conversation.lastMessage,
-			},
-		};
+    // Transform database response to match API schema
+    const apiResponse = {
+      conversation: {
+        id: conversation.id,
+        title: conversation.title ?? undefined,
+        createdAt: conversation.createdAt,
+        updatedAt: conversation.updatedAt,
+        visitorId: conversation.visitorId,
+        websiteId: conversation.websiteId,
+        status: conversation.status,
+        lastMessage: conversation.lastMessage,
+      },
+    };
 
-		return c.json(validateResponse(apiResponse, getConversationResponseSchema));
-	}
+    return c.json(validateResponse(apiResponse, getConversationResponseSchema));
+  },
 );
 
 conversationRouter.openapi(
-	{
-		method: "post",
-		path: "/{conversationId}/seen",
-		summary: "Mark a conversation as seen by the visitor",
-		description:
-			"Record a visitor's last seen timestamp for a specific conversation.",
-		tags: ["Conversations"],
-		request: {
-			body: {
-				required: false,
-				content: {
-					"application/json": {
-						schema: markConversationSeenRequestSchema,
-					},
-				},
-			},
-		},
-		responses: {
-			200: {
-				description: "Conversation seen timestamp recorded",
-				content: {
-					"application/json": {
-						schema: markConversationSeenResponseSchema,
-					},
-				},
-			},
-			400: {
-				description: "Invalid request",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-			404: {
-				description: "Conversation not found",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "conversationId",
-				in: "path",
-				description: "The ID of the conversation to mark as seen",
-				required: true,
-				schema: {
-					type: "string",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description:
-					"Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-					example:
-						"pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
-				},
-			},
-			{
-				name: "X-Visitor-Id",
-				in: "header",
-				description: "Visitor ID from localStorage.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
-					example: "01JG000000000000000000000",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization, body, visitorIdHeader } =
-			await safelyExtractRequestData(c, markConversationSeenRequestSchema);
+  {
+    method: "get",
+    path: "/events",
+    summary: "List conversation events",
+    description:
+      "Fetch timeline events for a conversation with cursor-based pagination.",
+    tags: ["Conversations"],
+    request: {
+      query: getConversationEventsRequestSchema,
+    },
+    responses: {
+      200: {
+        description: "Conversation events retrieved successfully",
+        content: {
+          "application/json": {
+            schema: getConversationEventsResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+      {
+        "Private API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "Authorization",
+        in: "header",
+        description:
+          "Private API key in Bearer token format. Format: `Bearer sk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^Bearer sk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "Bearer sk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, organization, query } = await safelyExtractRequestQuery(
+      c,
+      getConversationEventsRequestSchema,
+    );
 
-		const params = getConversationRequestSchema.parse({
-			conversationId: c.req.param("conversationId"),
-		});
+    const result = await getConversationEvents(db, {
+      organizationId: organization.id,
+      conversationId: query.conversationId,
+      limit: query.limit,
+      cursor: query.cursor ?? null,
+    });
 
-		const [visitor, conversationRecord] = await Promise.all([
-			getVisitor(db, {
-				visitorId: body.visitorId || visitorIdHeader,
-			}),
-			getConversationByIdWithLastMessage(db, {
-				organizationId: organization.id,
-				websiteId: website.id,
-				conversationId: params.conversationId,
-			}),
-		]);
+    const response = {
+      events: result.events.map((event) => ({
+        ...event,
+        metadata: event.metadata
+          ? (event.metadata as Record<string, unknown>)
+          : undefined,
+        message: event.message ?? undefined,
+        updatedAt: event.createdAt,
+        deletedAt: null,
+      })),
+      nextCursor: result.nextCursor,
+      hasNextPage: result.hasNextPage,
+    };
 
-		if (!visitor || visitor.websiteId !== website.id) {
-			return c.json(
-				{
-					error: "Visitor not found, please pass a valid visitorId",
-				},
-				400
-			);
-		}
-
-		if (!conversationRecord || conversationRecord.visitorId !== visitor.id) {
-			return c.json(
-				{
-					error: "Conversation not found",
-				},
-				404
-			);
-		}
-
-		const lastSeenAt = await markConversationAsSeenByVisitor(db, {
-			conversation: conversationRecord,
-			visitorId: visitor.id,
-		});
-
-		await emitConversationSeenEvent({
-			conversation: conversationRecord,
-			actor: { type: "visitor", visitorId: visitor.id },
-			lastSeenAt,
-		});
-
-		const response = {
-			conversationId: conversationRecord.id,
-			lastSeenAt,
-		};
-
-		return c.json(
-			validateResponse(response, markConversationSeenResponseSchema),
-			200
-		);
-	}
+    return c.json(
+      validateResponse(response, getConversationEventsResponseSchema),
+    );
+  },
 );
 
 conversationRouter.openapi(
-	{
-		method: "post",
-		path: "/{conversationId}/typing",
-		summary: "Report a visitor typing state",
-		description:
-			"Emit a typing indicator event for the visitor. Either visitorId must be provided via body or headers.",
-		tags: ["Conversations"],
-		request: {
-			body: {
-				required: true,
-				content: {
-					"application/json": {
-						schema: setConversationTypingRequestSchema,
-					},
-				},
-			},
-		},
-		responses: {
-			200: {
-				description: "Typing state recorded",
-				content: {
-					"application/json": {
-						schema: setConversationTypingResponseSchema,
-					},
-				},
-			},
-			400: {
-				description: "Invalid request",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-			404: {
-				description: "Conversation not found",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "conversationId",
-				in: "path",
-				description: "The ID of the conversation receiving the typing update",
-				required: true,
-				schema: {
-					type: "string",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description:
-					"Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-				},
-			},
-			{
-				name: "X-Visitor-Id",
-				in: "header",
-				description: "Visitor ID from localStorage.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization, body, visitorIdHeader } =
-			await safelyExtractRequestData(c, setConversationTypingRequestSchema);
+  {
+    method: "post",
+    path: "/{conversationId}/seen",
+    summary: "Mark a conversation as seen by the visitor",
+    description:
+      "Record a visitor's last seen timestamp for a specific conversation.",
+    tags: ["Conversations"],
+    request: {
+      body: {
+        required: false,
+        content: {
+          "application/json": {
+            schema: markConversationSeenRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Conversation seen timestamp recorded",
+        content: {
+          "application/json": {
+            schema: markConversationSeenResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+      404: {
+        description: "Conversation not found",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "conversationId",
+        in: "path",
+        description: "The ID of the conversation to mark as seen",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+          example:
+            "pk_test_1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+      },
+      {
+        name: "X-Visitor-Id",
+        in: "header",
+        description: "Visitor ID from localStorage.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
+          example: "01JG000000000000000000000",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization, body, visitorIdHeader } =
+      await safelyExtractRequestData(c, markConversationSeenRequestSchema);
 
-		const params = getConversationRequestSchema.parse({
-			conversationId: c.req.param("conversationId"),
-		});
+    const params = getConversationRequestSchema.parse({
+      conversationId: c.req.param("conversationId"),
+    });
 
-		const [visitor, conversationRecord] = await Promise.all([
-			getVisitor(db, {
-				visitorId: body.visitorId || visitorIdHeader,
-			}),
-			getConversationByIdWithLastMessage(db, {
-				organizationId: organization.id,
-				websiteId: website.id,
-				conversationId: params.conversationId,
-			}),
-		]);
+    const [visitor, conversationRecord] = await Promise.all([
+      getVisitor(db, {
+        visitorId: body.visitorId || visitorIdHeader,
+      }),
+      getConversationByIdWithLastMessage(db, {
+        organizationId: organization.id,
+        websiteId: website.id,
+        conversationId: params.conversationId,
+      }),
+    ]);
 
-		if (!visitor || visitor.websiteId !== website.id) {
-			return c.json(
-				{
-					error: "Visitor not found, please pass a valid visitorId",
-				},
-				400
-			);
-		}
+    if (!visitor || visitor.websiteId !== website.id) {
+      return c.json(
+        {
+          error: "Visitor not found, please pass a valid visitorId",
+        },
+        400,
+      );
+    }
 
-		if (!conversationRecord || conversationRecord.visitorId !== visitor.id) {
-			return c.json(
-				{
-					error: "Conversation not found",
-				},
-				404
-			);
-		}
+    if (!conversationRecord || conversationRecord.visitorId !== visitor.id) {
+      return c.json(
+        {
+          error: "Conversation not found",
+        },
+        404,
+      );
+    }
 
-		const trimmedPreview = body.visitorPreview?.trim() ?? "";
-		const effectivePreview =
-			body.isTyping && trimmedPreview.length > 0
-				? trimmedPreview.slice(0, 2000)
-				: null;
+    const lastSeenAt = await markConversationAsSeenByVisitor(db, {
+      conversation: conversationRecord,
+      visitorId: visitor.id,
+    });
 
-		await emitConversationTypingEvent({
-			conversation: conversationRecord,
-			actor: { type: "visitor", visitorId: visitor.id },
-			isTyping: body.isTyping,
-			visitorPreview: effectivePreview ?? undefined,
-		});
+    await emitConversationSeenEvent({
+      conversation: conversationRecord,
+      actor: { type: "visitor", visitorId: visitor.id },
+      lastSeenAt,
+    });
 
-		const sentAt = new Date();
+    const response = {
+      conversationId: conversationRecord.id,
+      lastSeenAt,
+    };
 
-		const response = {
-			conversationId: conversationRecord.id,
-			isTyping: body.isTyping,
-			visitorPreview: effectivePreview,
-			sentAt: sentAt.toISOString(),
-		};
+    return c.json(
+      validateResponse(response, markConversationSeenResponseSchema),
+      200,
+    );
+  },
+);
 
-		return c.json(
-			validateResponse(response, setConversationTypingResponseSchema),
-			200
-		);
-	}
+conversationRouter.openapi(
+  {
+    method: "post",
+    path: "/{conversationId}/typing",
+    summary: "Report a visitor typing state",
+    description:
+      "Emit a typing indicator event for the visitor. Either visitorId must be provided via body or headers.",
+    tags: ["Conversations"],
+    request: {
+      body: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: setConversationTypingRequestSchema,
+          },
+        },
+      },
+    },
+    responses: {
+      200: {
+        description: "Typing state recorded",
+        content: {
+          "application/json": {
+            schema: setConversationTypingResponseSchema,
+          },
+        },
+      },
+      400: {
+        description: "Invalid request",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+      404: {
+        description: "Conversation not found",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "conversationId",
+        in: "path",
+        description: "The ID of the conversation receiving the typing update",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description:
+          "Public API key for browser-based authentication. Can only be used from whitelisted domains. Format: `pk_[live|test]_...`",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+        },
+      },
+      {
+        name: "X-Visitor-Id",
+        in: "header",
+        description: "Visitor ID from localStorage.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^[0-9A-HJKMNP-TV-Z]{26}$",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization, body, visitorIdHeader } =
+      await safelyExtractRequestData(c, setConversationTypingRequestSchema);
+
+    const params = getConversationRequestSchema.parse({
+      conversationId: c.req.param("conversationId"),
+    });
+
+    const [visitor, conversationRecord] = await Promise.all([
+      getVisitor(db, {
+        visitorId: body.visitorId || visitorIdHeader,
+      }),
+      getConversationByIdWithLastMessage(db, {
+        organizationId: organization.id,
+        websiteId: website.id,
+        conversationId: params.conversationId,
+      }),
+    ]);
+
+    if (!visitor || visitor.websiteId !== website.id) {
+      return c.json(
+        {
+          error: "Visitor not found, please pass a valid visitorId",
+        },
+        400,
+      );
+    }
+
+    if (!conversationRecord || conversationRecord.visitorId !== visitor.id) {
+      return c.json(
+        {
+          error: "Conversation not found",
+        },
+        404,
+      );
+    }
+
+    const trimmedPreview = body.visitorPreview?.trim() ?? "";
+    const effectivePreview =
+      body.isTyping && trimmedPreview.length > 0
+        ? trimmedPreview.slice(0, 2000)
+        : null;
+
+    await emitConversationTypingEvent({
+      conversation: conversationRecord,
+      actor: { type: "visitor", visitorId: visitor.id },
+      isTyping: body.isTyping,
+      visitorPreview: effectivePreview ?? undefined,
+    });
+
+    const sentAt = new Date();
+
+    const response = {
+      conversationId: conversationRecord.id,
+      isTyping: body.isTyping,
+      visitorPreview: effectivePreview,
+      sentAt: sentAt.toISOString(),
+    };
+
+    return c.json(
+      validateResponse(response, setConversationTypingResponseSchema),
+      200,
+    );
+  },
 );
 
 // GET /conversations/:conversationId/seen - Fetch seen data for a conversation
 conversationRouter.openapi(
-	{
-		method: "get",
-		path: "/{conversationId}/seen",
-		summary: "Get conversation seen data",
-		description:
-			"Fetch the seen data (read receipts) for a conversation, showing who has seen messages and when.",
-		tags: ["Conversations"],
-		responses: {
-			200: {
-				description: "Seen data retrieved successfully",
-				content: {
-					"application/json": {
-						schema: z.object({
-							seenData: z.array(conversationSeenSchema),
-						}),
-					},
-				},
-			},
-			404: {
-				description: "Conversation not found",
-				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
-				},
-			},
-		},
-		security: [
-			{
-				"Public API Key": [],
-			},
-		],
-		parameters: [
-			{
-				name: "conversationId",
-				in: "path",
-				description: "The ID of the conversation",
-				required: true,
-				schema: {
-					type: "string",
-				},
-			},
-			{
-				name: "X-Public-Key",
-				in: "header",
-				description: "Public API key for browser-based authentication.",
-				required: false,
-				schema: {
-					type: "string",
-					pattern: "^pk_(live|test)_[a-f0-9]{64}$",
-				},
-			},
-		],
-	},
-	async (c) => {
-		const { db, website, organization } = await safelyExtractRequestQuery(
-			c,
-			z.object({})
-		);
+  {
+    method: "get",
+    path: "/{conversationId}/seen",
+    summary: "Get conversation seen data",
+    description:
+      "Fetch the seen data (read receipts) for a conversation, showing who has seen messages and when.",
+    tags: ["Conversations"],
+    responses: {
+      200: {
+        description: "Seen data retrieved successfully",
+        content: {
+          "application/json": {
+            schema: z.object({
+              seenData: z.array(conversationSeenSchema),
+            }),
+          },
+        },
+      },
+      404: {
+        description: "Conversation not found",
+        content: {
+          "application/json": {
+            schema: z.object({ error: z.string() }),
+          },
+        },
+      },
+    },
+    security: [
+      {
+        "Public API Key": [],
+      },
+    ],
+    parameters: [
+      {
+        name: "conversationId",
+        in: "path",
+        description: "The ID of the conversation",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "X-Public-Key",
+        in: "header",
+        description: "Public API key for browser-based authentication.",
+        required: false,
+        schema: {
+          type: "string",
+          pattern: "^pk_(live|test)_[a-f0-9]{64}$",
+        },
+      },
+    ],
+  },
+  async (c) => {
+    const { db, website, organization } = await safelyExtractRequestQuery(
+      c,
+      z.object({}),
+    );
 
-		const params = getConversationRequestSchema.parse({
-			conversationId: c.req.param("conversationId"),
-		});
+    const params = getConversationRequestSchema.parse({
+      conversationId: c.req.param("conversationId"),
+    });
 
-		const conversationRecord = await getConversationByIdWithLastMessage(db, {
-			organizationId: organization.id,
-			websiteId: website.id,
-			conversationId: params.conversationId,
-		});
+    const conversationRecord = await getConversationByIdWithLastMessage(db, {
+      organizationId: organization.id,
+      websiteId: website.id,
+      conversationId: params.conversationId,
+    });
 
-		if (!conversationRecord) {
-			return c.json(
-				{
-					error: "Conversation not found",
-				},
-				404
-			);
-		}
+    if (!conversationRecord) {
+      return c.json(
+        {
+          error: "Conversation not found",
+        },
+        404,
+      );
+    }
 
-		const seenData = await getConversationSeenData(db, {
-			conversationId: params.conversationId,
-			organizationId: organization.id,
-		});
+    const seenData = await getConversationSeenData(db, {
+      conversationId: params.conversationId,
+      organizationId: organization.id,
+    });
 
-		return c.json({ seenData }, 200);
-	}
+    return c.json({ seenData }, 200);
+  },
 );

--- a/apps/api/src/trpc/routers/conversation.ts
+++ b/apps/api/src/trpc/routers/conversation.ts
@@ -1,36 +1,36 @@
 import {
-	archiveConversation,
-	type ConversationRecord,
-	markConversationAsNotSpam,
-	markConversationAsRead,
-	markConversationAsSpam,
-	markConversationAsUnread,
-	reopenConversation,
-	resolveConversation,
-	unarchiveConversation,
+  archiveConversation,
+  type ConversationRecord,
+  markConversationAsNotSpam,
+  markConversationAsRead,
+  markConversationAsSpam,
+  markConversationAsUnread,
+  reopenConversation,
+  resolveConversation,
+  unarchiveConversation,
 } from "@api/db/mutations/conversation";
 import {
-	getConversationById,
-	getConversationEvents,
-	listConversationsHeaders,
+  getConversationById,
+  getConversationEvents,
+  listConversationsHeaders,
 } from "@api/db/queries/conversation";
 import { getConversationMessages } from "@api/db/queries/message";
 import { getCompleteVisitorWithContact } from "@api/db/queries/visitor";
 import { getWebsiteBySlugWithAccess } from "@api/db/queries/website";
 import {
-	emitConversationSeenEvent,
-	emitConversationTypingEvent,
+  emitConversationSeenEvent,
+  emitConversationTypingEvent,
 } from "@api/utils/conversation-realtime";
 import { createMessage } from "@api/utils/message";
 import {
-	type ContactMetadata,
-	conversationEventSchema,
-	conversationMutationResponseSchema,
-	listConversationHeadersResponseSchema,
-	MessageType,
-	MessageVisibility,
-	messageSchema,
-	visitorResponseSchema,
+  type ContactMetadata,
+  conversationEventSchema,
+  conversationMutationResponseSchema,
+  listConversationHeadersResponseSchema,
+  MessageType,
+  MessageVisibility,
+  messageSchema,
+  visitorResponseSchema,
 } from "@cossistant/types";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
@@ -38,536 +38,538 @@ import { createTRPCRouter, protectedProcedure } from "../init";
 import { loadConversationContext } from "../utils/conversation";
 
 function toConversationOutput(record: ConversationRecord) {
-	return {
-		...record,
-	};
+  return {
+    ...record,
+  };
 }
 
 export const conversationRouter = createTRPCRouter({
-	listConversationsHeaders: protectedProcedure
-		.input(
-			z.object({
-				websiteSlug: z.string(),
-				limit: z.number().int().min(1).max(500).optional(),
-				cursor: z.string().nullable().optional(),
-			})
-		)
-		.output(listConversationHeadersResponseSchema)
-		.query(async ({ ctx: { db, user }, input }) => {
-			const websiteData = await getWebsiteBySlugWithAccess(db, {
-				userId: user.id,
-				websiteSlug: input.websiteSlug,
-			});
+  listConversationsHeaders: protectedProcedure
+    .input(
+      z.object({
+        websiteSlug: z.string(),
+        limit: z.number().int().min(1).max(500).optional(),
+        cursor: z.string().nullable().optional(),
+      }),
+    )
+    .output(listConversationHeadersResponseSchema)
+    .query(async ({ ctx: { db, user }, input }) => {
+      const websiteData = await getWebsiteBySlugWithAccess(db, {
+        userId: user.id,
+        websiteSlug: input.websiteSlug,
+      });
 
-			if (!websiteData) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Website not found or access denied",
-				});
-			}
+      if (!websiteData) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Website not found or access denied",
+        });
+      }
 
-			// Fetch conversations for the website
-			const result = await listConversationsHeaders(db, {
-				organizationId: websiteData.organizationId,
-				websiteId: websiteData.id,
-				userId: user.id,
-				limit: input.limit,
-				cursor: input.cursor,
-			});
+      // Fetch conversations for the website
+      const result = await listConversationsHeaders(db, {
+        organizationId: websiteData.organizationId,
+        websiteId: websiteData.id,
+        userId: user.id,
+        limit: input.limit,
+        cursor: input.cursor,
+      });
 
-			return {
-				items: result.items,
-				nextCursor: result.nextCursor,
-			};
-		}),
+      return {
+        items: result.items,
+        nextCursor: result.nextCursor,
+      };
+    }),
 
-	getConversationMessages: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				limit: z.number().int().min(1).max(100).optional().default(50),
-				cursor: z.union([z.string(), z.date()]).nullable().optional(),
-			})
-		)
-		.output(
-			z.object({
-				items: z.array(messageSchema),
-				nextCursor: z.string().nullable(),
-				hasNextPage: z.boolean(),
-			})
-		)
-		.query(async ({ ctx: { db, user }, input }) => {
-			// Query website access and conversation in parallel
-			const [websiteData, conversation] = await Promise.all([
-				getWebsiteBySlugWithAccess(db, {
-					userId: user.id,
-					websiteSlug: input.websiteSlug,
-				}),
-				getConversationById(db, {
-					conversationId: input.conversationId,
-				}),
-			]);
+  getConversationMessages: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+        limit: z.number().int().min(1).max(100).optional().default(50),
+        cursor: z.union([z.string(), z.date()]).nullable().optional(),
+      }),
+    )
+    .output(
+      z.object({
+        items: z.array(messageSchema),
+        nextCursor: z.string().nullable(),
+        hasNextPage: z.boolean(),
+      }),
+    )
+    .query(async ({ ctx: { db, user }, input }) => {
+      // Query website access and conversation in parallel
+      const [websiteData, conversation] = await Promise.all([
+        getWebsiteBySlugWithAccess(db, {
+          userId: user.id,
+          websiteSlug: input.websiteSlug,
+        }),
+        getConversationById(db, {
+          conversationId: input.conversationId,
+        }),
+      ]);
 
-			if (!websiteData) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Website not found or access denied",
-				});
-			}
+      if (!websiteData) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Website not found or access denied",
+        });
+      }
 
-			if (!conversation || conversation.websiteId !== websiteData.id) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Conversation not found",
-				});
-			}
+      if (!conversation || conversation.websiteId !== websiteData.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Conversation not found",
+        });
+      }
 
-			// Get messages
-			const result = await getConversationMessages(db, {
-				conversationId: input.conversationId,
-				websiteId: websiteData.id,
-				limit: input.limit,
-				cursor: input.cursor,
-			});
+      // Get messages
+      const result = await getConversationMessages(db, {
+        conversationId: input.conversationId,
+        websiteId: websiteData.id,
+        limit: input.limit,
+        cursor: input.cursor,
+      });
 
-			return {
-				items: result.messages,
-				nextCursor: result.nextCursor,
-				hasNextPage: result.hasNextPage,
-			};
-		}),
+      return {
+        items: result.messages,
+        nextCursor: result.nextCursor,
+        hasNextPage: result.hasNextPage,
+      };
+    }),
 
-	getConversationEvents: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				limit: z.number().int().min(1).max(100).optional().default(50),
-				cursor: z.union([z.string(), z.date()]).nullable().optional(),
-			})
-		)
-		.output(
-			z.object({
-				items: z.array(conversationEventSchema),
-				nextCursor: z.string().nullable(),
-				hasNextPage: z.boolean(),
-			})
-		)
-		.query(async ({ ctx: { db, user }, input }) => {
-			// Query website access and conversation in parallel
-			const [websiteData, conversation] = await Promise.all([
-				getWebsiteBySlugWithAccess(db, {
-					userId: user.id,
-					websiteSlug: input.websiteSlug,
-				}),
-				getConversationById(db, {
-					conversationId: input.conversationId,
-				}),
-			]);
+  getConversationEvents: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+        limit: z.number().int().min(1).max(100).optional().default(50),
+        cursor: z.union([z.string(), z.date()]).nullable().optional(),
+      }),
+    )
+    .output(
+      z.object({
+        items: z.array(conversationEventSchema),
+        nextCursor: z.string().nullable(),
+        hasNextPage: z.boolean(),
+      }),
+    )
+    .query(async ({ ctx: { db, user }, input }) => {
+      // Query website access and conversation in parallel
+      const [websiteData, conversation] = await Promise.all([
+        getWebsiteBySlugWithAccess(db, {
+          userId: user.id,
+          websiteSlug: input.websiteSlug,
+        }),
+        getConversationById(db, {
+          conversationId: input.conversationId,
+        }),
+      ]);
 
-			if (!websiteData) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Website not found or access denied",
-				});
-			}
+      if (!websiteData) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Website not found or access denied",
+        });
+      }
 
-			if (!conversation || conversation.websiteId !== websiteData.id) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Conversation not found",
-				});
-			}
+      if (!conversation || conversation.websiteId !== websiteData.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Conversation not found",
+        });
+      }
 
-			// Get events
-			const result = await getConversationEvents(db, {
-				conversationId: input.conversationId,
-				websiteId: websiteData.id,
-				limit: input.limit,
-				cursor: input.cursor,
-			});
+      // Get events
+      const result = await getConversationEvents(db, {
+        organizationId: websiteData.organizationId,
+        conversationId: input.conversationId,
+        limit: input.limit,
+        cursor: input.cursor,
+      });
 
-			return {
-				items: result.events.map((event) => ({
-					...event,
-					metadata: event.metadata as Record<string, unknown>,
-					updatedAt: event.createdAt,
-					deletedAt: null,
-					message: event.message ?? undefined,
-				})),
-				nextCursor: result.nextCursor,
-				hasNextPage: result.hasNextPage,
-			};
-		}),
+      return {
+        items: result.events.map((event) => ({
+          ...event,
+          metadata: event.metadata
+            ? (event.metadata as Record<string, unknown>)
+            : undefined,
+          updatedAt: event.createdAt,
+          deletedAt: null,
+          message: event.message ?? undefined,
+        })),
+        nextCursor: result.nextCursor,
+        hasNextPage: result.hasNextPage,
+      };
+    }),
 
-	sendMessage: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				bodyMd: z.string().min(1),
-				type: z
-					.enum([MessageType.TEXT, MessageType.IMAGE, MessageType.FILE])
-					.default(MessageType.TEXT),
-				visibility: z
-					.enum([MessageVisibility.PUBLIC, MessageVisibility.PRIVATE])
-					.default(MessageVisibility.PUBLIC),
-			})
-		)
-		.output(z.object({ message: messageSchema }))
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const [websiteData, conversation] = await Promise.all([
-				getWebsiteBySlugWithAccess(db, {
-					userId: user.id,
-					websiteSlug: input.websiteSlug,
-				}),
-				getConversationById(db, {
-					conversationId: input.conversationId,
-				}),
-			]);
+  sendMessage: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+        bodyMd: z.string().min(1),
+        type: z
+          .enum([MessageType.TEXT, MessageType.IMAGE, MessageType.FILE])
+          .default(MessageType.TEXT),
+        visibility: z
+          .enum([MessageVisibility.PUBLIC, MessageVisibility.PRIVATE])
+          .default(MessageVisibility.PUBLIC),
+      }),
+    )
+    .output(z.object({ message: messageSchema }))
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const [websiteData, conversation] = await Promise.all([
+        getWebsiteBySlugWithAccess(db, {
+          userId: user.id,
+          websiteSlug: input.websiteSlug,
+        }),
+        getConversationById(db, {
+          conversationId: input.conversationId,
+        }),
+      ]);
 
-			if (!websiteData) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Website not found or access denied",
-				});
-			}
+      if (!websiteData) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Website not found or access denied",
+        });
+      }
 
-			if (!conversation || conversation.websiteId !== websiteData.id) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Conversation not found",
-				});
-			}
+      if (!conversation || conversation.websiteId !== websiteData.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Conversation not found",
+        });
+      }
 
-			const createdMessage = await createMessage({
-				db,
-				organizationId: websiteData.organizationId,
-				websiteId: websiteData.id,
-				conversationId: input.conversationId,
-				conversationOwnerVisitorId: conversation.visitorId,
-				message: {
-					bodyMd: input.bodyMd,
-					type: input.type,
-					visibility: input.visibility,
-					userId: user.id,
-					visitorId: null,
-					aiAgentId: null,
-				},
-			});
+      const createdMessage = await createMessage({
+        db,
+        organizationId: websiteData.organizationId,
+        websiteId: websiteData.id,
+        conversationId: input.conversationId,
+        conversationOwnerVisitorId: conversation.visitorId,
+        message: {
+          bodyMd: input.bodyMd,
+          type: input.type,
+          visibility: input.visibility,
+          userId: user.id,
+          visitorId: null,
+          aiAgentId: null,
+        },
+      });
 
-			// Mark conversation as read by user after sending message
-			const { lastSeenAt } = await markConversationAsRead(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+      // Mark conversation as read by user after sending message
+      const { lastSeenAt } = await markConversationAsRead(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			await emitConversationSeenEvent({
-				conversation,
-				actor: { type: "user", userId: user.id },
-				lastSeenAt,
-			});
+      await emitConversationSeenEvent({
+        conversation,
+        actor: { type: "user", userId: user.id },
+        lastSeenAt,
+      });
 
-			return { message: createdMessage };
-		}),
+      return { message: createdMessage };
+    }),
 
-	markResolved: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await resolveConversation(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markResolved: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await resolveConversation(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to resolve conversation",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to resolve conversation",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markOpen: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await reopenConversation(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markOpen: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await reopenConversation(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to reopen conversation",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to reopen conversation",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markSpam: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await markConversationAsSpam(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markSpam: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await markConversationAsSpam(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to mark conversation as spam",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to mark conversation as spam",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markNotSpam: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await markConversationAsNotSpam(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markNotSpam: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await markConversationAsNotSpam(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to mark conversation as not spam",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to mark conversation as not spam",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markArchived: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await archiveConversation(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markArchived: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await archiveConversation(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to archive conversation",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to archive conversation",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markUnarchived: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await unarchiveConversation(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markUnarchived: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await unarchiveConversation(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			if (!updatedConversation) {
-				throw new TRPCError({
-					code: "INTERNAL_SERVER_ERROR",
-					message: "Unable to unarchive conversation",
-				});
-			}
+      if (!updatedConversation) {
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Unable to unarchive conversation",
+        });
+      }
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markRead: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const { conversation: updatedConversation, lastSeenAt } =
-				await markConversationAsRead(db, {
-					conversation,
-					actorUserId: user.id,
-				});
+  markRead: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const { conversation: updatedConversation, lastSeenAt } =
+        await markConversationAsRead(db, {
+          conversation,
+          actorUserId: user.id,
+        });
 
-			await emitConversationSeenEvent({
-				conversation: updatedConversation,
-				actor: { type: "user", userId: user.id },
-				lastSeenAt,
-			});
+      await emitConversationSeenEvent({
+        conversation: updatedConversation,
+        actor: { type: "user", userId: user.id },
+        lastSeenAt,
+      });
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	markUnread: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(conversationMutationResponseSchema)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(
-				db,
-				user.id,
-				input
-			);
-			const updatedConversation = await markConversationAsUnread(db, {
-				conversation,
-				actorUserId: user.id,
-			});
+  markUnread: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(conversationMutationResponseSchema)
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(
+        db,
+        user.id,
+        input,
+      );
+      const updatedConversation = await markConversationAsUnread(db, {
+        conversation,
+        actorUserId: user.id,
+      });
 
-			return { conversation: toConversationOutput(updatedConversation) };
-		}),
+      return { conversation: toConversationOutput(updatedConversation) };
+    }),
 
-	setTyping: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				isTyping: z.boolean(),
-			})
-		)
-		.output(
-			z.object({
-				success: z.literal(true),
-			})
-		)
-		.mutation(async ({ ctx: { db, user }, input }) => {
-			const { conversation } = await loadConversationContext(db, user.id, {
-				websiteSlug: input.websiteSlug,
-				conversationId: input.conversationId,
-			});
+  setTyping: protectedProcedure
+    .input(
+      z.object({
+        conversationId: z.string(),
+        websiteSlug: z.string(),
+        isTyping: z.boolean(),
+      }),
+    )
+    .output(
+      z.object({
+        success: z.literal(true),
+      }),
+    )
+    .mutation(async ({ ctx: { db, user }, input }) => {
+      const { conversation } = await loadConversationContext(db, user.id, {
+        websiteSlug: input.websiteSlug,
+        conversationId: input.conversationId,
+      });
 
-			await emitConversationTypingEvent({
-				conversation,
-				actor: { type: "user", userId: user.id },
-				isTyping: input.isTyping,
-			});
+      await emitConversationTypingEvent({
+        conversation,
+        actor: { type: "user", userId: user.id },
+        isTyping: input.isTyping,
+      });
 
-			return { success: true } as const;
-		}),
+      return { success: true } as const;
+    }),
 
-	getVisitorById: protectedProcedure
-		.input(
-			z.object({
-				visitorId: z.string(),
-				websiteSlug: z.string(),
-			})
-		)
-		.output(visitorResponseSchema.nullable())
-		.query(async ({ ctx: { db, user }, input }) => {
-			// Query website access and visitor in parallel
-			const [websiteData, visitor] = await Promise.all([
-				getWebsiteBySlugWithAccess(db, {
-					userId: user.id,
-					websiteSlug: input.websiteSlug,
-				}),
-				getCompleteVisitorWithContact(db, {
-					visitorId: input.visitorId,
-				}),
-			]);
+  getVisitorById: protectedProcedure
+    .input(
+      z.object({
+        visitorId: z.string(),
+        websiteSlug: z.string(),
+      }),
+    )
+    .output(visitorResponseSchema.nullable())
+    .query(async ({ ctx: { db, user }, input }) => {
+      // Query website access and visitor in parallel
+      const [websiteData, visitor] = await Promise.all([
+        getWebsiteBySlugWithAccess(db, {
+          userId: user.id,
+          websiteSlug: input.websiteSlug,
+        }),
+        getCompleteVisitorWithContact(db, {
+          visitorId: input.visitorId,
+        }),
+      ]);
 
-			if (!websiteData) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Website not found or access denied",
-				});
-			}
+      if (!websiteData) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Website not found or access denied",
+        });
+      }
 
-			if (!visitor || visitor.websiteId !== websiteData.id) {
-				throw new TRPCError({
-					code: "NOT_FOUND",
-					message: "Visitor not found",
-				});
-			}
+      if (!visitor || visitor.websiteId !== websiteData.id) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Visitor not found",
+        });
+      }
 
-			return {
-				...visitor,
-				contact: visitor.contact
-					? {
-							...visitor.contact,
-							metadata: visitor.contact.metadata as ContactMetadata,
-						}
-					: null,
-				isBlocked: Boolean(visitor.blockedAt),
-			};
-		}),
+      return {
+        ...visitor,
+        contact: visitor.contact
+          ? {
+              ...visitor.contact,
+              metadata: visitor.contact.metadata as ContactMetadata,
+            }
+          : null,
+        isBlocked: Boolean(visitor.blockedAt),
+      };
+    }),
 });

--- a/apps/api/src/utils/conversation-event.ts
+++ b/apps/api/src/utils/conversation-event.ts
@@ -1,0 +1,62 @@
+import type { ConversationRecord } from "@api/db/mutations/conversation";
+import type { Database } from "@api/db";
+import { conversationEvent } from "@api/db/schema";
+import { generateULID } from "@api/utils/db/ids";
+import { emitConversationEventCreated } from "@api/utils/conversation-realtime";
+import type { ConversationEventType } from "@cossistant/types";
+import type { InferSelectModel } from "drizzle-orm";
+
+export type ConversationEventRecord = InferSelectModel<
+  typeof conversationEvent
+>;
+
+type CreateConversationEventInput = {
+  db: Database;
+  conversation: ConversationRecord;
+  event: {
+    type: ConversationEventType;
+    actorUserId?: string | null;
+    actorAiAgentId?: string | null;
+    targetUserId?: string | null;
+    targetAiAgentId?: string | null;
+    metadata?: Record<string, unknown> | null;
+    message?: string | null;
+    createdAt?: string;
+  };
+};
+
+export async function createConversationEvent({
+  db,
+  conversation,
+  event,
+}: CreateConversationEventInput): Promise<ConversationEventRecord> {
+  const createdAt = event.createdAt ?? new Date().toISOString();
+
+  const [created] = await db
+    .insert(conversationEvent)
+    .values({
+      id: generateULID(),
+      organizationId: conversation.organizationId,
+      conversationId: conversation.id,
+      type: event.type,
+      actorUserId: event.actorUserId ?? null,
+      actorAiAgentId: event.actorAiAgentId ?? null,
+      targetUserId: event.targetUserId ?? null,
+      targetAiAgentId: event.targetAiAgentId ?? null,
+      metadata: event.metadata ?? null,
+      message: event.message ?? null,
+      createdAt,
+    })
+    .returning();
+
+  if (!created) {
+    throw new Error("Failed to create conversation event");
+  }
+
+  await emitConversationEventCreated({
+    conversation,
+    event: created,
+  });
+
+  return created;
+}

--- a/apps/api/src/utils/conversation-realtime.ts
+++ b/apps/api/src/utils/conversation-realtime.ts
@@ -7,125 +7,158 @@ import type { InferSelectModel } from "drizzle-orm";
 type ConversationEventRecord = InferSelectModel<typeof conversationEvent>;
 
 export type ConversationRealtimeActor =
-	| { type: "visitor"; visitorId: string }
-	| { type: "user"; userId: string }
-	| { type: "ai_agent"; aiAgentId: string };
+  | { type: "visitor"; visitorId: string }
+  | { type: "user"; userId: string }
+  | { type: "ai_agent"; aiAgentId: string };
 
 type BaseRealtimeContext = {
-	conversation: ConversationRecord;
+  conversation: ConversationRecord;
 };
 
 type SeenEventParams = BaseRealtimeContext & {
-	actor: ConversationRealtimeActor;
-	lastSeenAt: string;
+  actor: ConversationRealtimeActor;
+  lastSeenAt: string;
 };
 
 type TypingEventParams = BaseRealtimeContext & {
-	actor: ConversationRealtimeActor;
-	isTyping: boolean;
-	visitorPreview?: string | null;
+  actor: ConversationRealtimeActor;
+  isTyping: boolean;
+  visitorPreview?: string | null;
 };
 
 type TimelineEventParams = BaseRealtimeContext & {
-	event: ConversationEventRecord;
+  event: ConversationEventRecord;
 };
 
 type ConversationCreatedEventParams = {
-	conversation: ConversationRecord;
-	header: ConversationHeader;
+  conversation: ConversationRecord;
+  header: ConversationHeader;
 };
 
 function mapActor(actor: ConversationRealtimeActor) {
-	switch (actor.type) {
-		case "visitor":
-			return {
-				actorType: "visitor" as const,
-				actorId: actor.visitorId,
-				visitorId: actor.visitorId,
-				userId: null,
-				aiAgentId: null,
-			};
-		case "user":
-			return {
-				actorType: "user" as const,
-				actorId: actor.userId,
-				visitorId: null,
-				userId: actor.userId,
-				aiAgentId: null,
-			};
-		case "ai_agent":
-			return {
-				actorType: "ai_agent" as const,
-				actorId: actor.aiAgentId,
-				visitorId: null,
-				userId: null,
-				aiAgentId: actor.aiAgentId,
-			};
-		default:
-			throw new Error("Unknown actor type");
-	}
+  switch (actor.type) {
+    case "visitor":
+      return {
+        actorType: "visitor" as const,
+        actorId: actor.visitorId,
+        visitorId: actor.visitorId,
+        userId: null,
+        aiAgentId: null,
+      };
+    case "user":
+      return {
+        actorType: "user" as const,
+        actorId: actor.userId,
+        visitorId: null,
+        userId: actor.userId,
+        aiAgentId: null,
+      };
+    case "ai_agent":
+      return {
+        actorType: "ai_agent" as const,
+        actorId: actor.aiAgentId,
+        visitorId: null,
+        userId: null,
+        aiAgentId: actor.aiAgentId,
+      };
+    default:
+      throw new Error("Unknown actor type");
+  }
 }
 
 export async function emitConversationSeenEvent({
-	conversation,
-	actor,
-	lastSeenAt,
+  conversation,
+  actor,
+  lastSeenAt,
 }: SeenEventParams) {
-	const actorPayload = mapActor(actor);
+  const actorPayload = mapActor(actor);
 
-	await realtime.emit("conversationSeen", {
-		conversationId: conversation.id,
-		organizationId: conversation.organizationId,
-		websiteId: conversation.websiteId,
-		lastSeenAt,
-		...actorPayload,
-		visitorId: actorPayload.visitorId ?? conversation.visitorId ?? null,
-	});
+  await realtime.emit("conversationSeen", {
+    conversationId: conversation.id,
+    organizationId: conversation.organizationId,
+    websiteId: conversation.websiteId,
+    lastSeenAt,
+    ...actorPayload,
+    visitorId: actorPayload.visitorId ?? conversation.visitorId ?? null,
+  });
 }
 
 export async function emitConversationTypingEvent({
-	conversation,
-	actor,
-	isTyping,
-	visitorPreview,
+  conversation,
+  actor,
+  isTyping,
+  visitorPreview,
 }: TypingEventParams) {
-	const actorPayload = mapActor(actor);
-	const previewForEvent =
-		actor.type === "visitor" && isTyping && visitorPreview
-			? visitorPreview.slice(0, 2000)
-			: null;
+  const actorPayload = mapActor(actor);
+  const previewForEvent =
+    actor.type === "visitor" && isTyping && visitorPreview
+      ? visitorPreview.slice(0, 2000)
+      : null;
 
-	await realtime.emit("conversationTyping", {
-		conversationId: conversation.id,
-		websiteId: conversation.websiteId,
-		organizationId: conversation.organizationId,
-		isTyping,
-		visitorPreview: previewForEvent,
-		...actorPayload,
-		visitorId: actorPayload.visitorId ?? conversation.visitorId ?? null,
-	});
+  await realtime.emit("conversationTyping", {
+    conversationId: conversation.id,
+    websiteId: conversation.websiteId,
+    organizationId: conversation.organizationId,
+    isTyping,
+    visitorPreview: previewForEvent,
+    ...actorPayload,
+    visitorId: actorPayload.visitorId ?? conversation.visitorId ?? null,
+  });
 }
 
 export async function emitConversationCreatedEvent({
-	conversation,
-	header,
+  conversation,
+  header,
 }: ConversationCreatedEventParams) {
-	await realtime.emit("conversationCreated", {
-		conversationId: conversation.id,
-		websiteId: conversation.websiteId,
-		organizationId: conversation.organizationId,
-		visitorId: conversation.visitorId ?? null,
-		userId: null,
-		conversation: {
-			id: conversation.id,
-			title: conversation.title ?? undefined,
-			createdAt: conversation.createdAt,
-			updatedAt: conversation.updatedAt,
-			visitorId: conversation.visitorId,
-			websiteId: conversation.websiteId,
-			status: conversation.status,
-			lastMessage: header.lastMessagePreview ?? undefined,
-		},
-		header,
-	});
+  await realtime.emit("conversationCreated", {
+    conversationId: conversation.id,
+    websiteId: conversation.websiteId,
+    organizationId: conversation.organizationId,
+    visitorId: conversation.visitorId ?? null,
+    userId: null,
+    conversation: {
+      id: conversation.id,
+      title: conversation.title ?? undefined,
+      createdAt: conversation.createdAt,
+      updatedAt: conversation.updatedAt,
+      visitorId: conversation.visitorId,
+      websiteId: conversation.websiteId,
+      status: conversation.status,
+      lastMessage: header.lastMessagePreview ?? undefined,
+    },
+    header,
+  });
+}
+
+export async function emitConversationEventCreated({
+  conversation,
+  event,
+}: TimelineEventParams) {
+  const metadata = event.metadata
+    ? (event.metadata as Record<string, unknown>)
+    : undefined;
+
+  await realtime.emit("conversationEventCreated", {
+    conversationId: conversation.id,
+    websiteId: conversation.websiteId,
+    organizationId: conversation.organizationId,
+    visitorId: conversation.visitorId ?? null,
+    userId: event.actorUserId ?? null,
+    aiAgentId: event.actorAiAgentId ?? null,
+    event: {
+      id: event.id,
+      conversationId: event.conversationId,
+      organizationId: event.organizationId,
+      type: event.type,
+      actorUserId: event.actorUserId,
+      actorAiAgentId: event.actorAiAgentId,
+      targetUserId: event.targetUserId,
+      targetAiAgentId: event.targetAiAgentId,
+      metadata,
+      message: event.message ?? undefined,
+      createdAt: event.createdAt,
+      updatedAt: event.createdAt,
+      deletedAt: null,
+    },
+  });
 }

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/providers/events/handlers/conversation-event-created.ts
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/providers/events/handlers/conversation-event-created.ts
@@ -1,0 +1,102 @@
+import type { RouterOutputs } from "@api/trpc/types";
+import { upsertConversationEventInCache } from "@/data/conversation-event-cache";
+import type { RealtimeEvent } from "@cossistant/types/realtime-events";
+import type { DashboardRealtimeContext } from "../types";
+
+type ConversationEventCreatedEvent = RealtimeEvent<"conversationEventCreated">;
+
+type ConversationEventsQueryInput = {
+  conversationId?: string;
+  websiteSlug?: string;
+};
+
+type QueryKeyInput = {
+  input?: ConversationEventsQueryInput;
+  type?: string;
+};
+
+type ConversationEventItem =
+  RouterOutputs["conversation"]["getConversationEvents"]["items"][number];
+
+function toConversationEvent(
+  payload: ConversationEventCreatedEvent["payload"],
+): ConversationEventItem {
+  return {
+    ...payload.event,
+    metadata: payload.event.metadata
+      ? (payload.event.metadata as Record<string, unknown>)
+      : undefined,
+    message: payload.event.message ?? undefined,
+    updatedAt: payload.event.updatedAt ?? payload.event.createdAt,
+    deletedAt: payload.event.deletedAt ?? null,
+  } satisfies ConversationEventItem;
+}
+
+function extractQueryInput(
+  queryKey: readonly unknown[],
+): ConversationEventsQueryInput | null {
+  if (queryKey.length < 2) {
+    return null;
+  }
+
+  const maybeInput = queryKey[1];
+  if (!maybeInput || typeof maybeInput !== "object") {
+    return null;
+  }
+
+  const input = (maybeInput as QueryKeyInput).input;
+  if (!input || typeof input !== "object") {
+    return null;
+  }
+
+  return input;
+}
+
+function isInfiniteQueryKey(queryKey: readonly unknown[]): boolean {
+  const marker = queryKey[2];
+  return Boolean(
+    marker &&
+      typeof marker === "object" &&
+      "type" in marker &&
+      (marker as QueryKeyInput).type === "infinite",
+  );
+}
+
+export const handleConversationEventCreated = ({
+  event,
+  context,
+}: {
+  event: ConversationEventCreatedEvent;
+  context: DashboardRealtimeContext;
+}) => {
+  const { queryClient, website } = context;
+  const payload = event.payload;
+  const normalizedEvent = toConversationEvent(payload);
+
+  const queries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: [["conversation", "getConversationEvents"]] });
+
+  for (const query of queries) {
+    const queryKey = query.queryKey as readonly unknown[];
+
+    if (!isInfiniteQueryKey(queryKey)) {
+      continue;
+    }
+
+    const input = extractQueryInput(queryKey);
+    if (!input) {
+      continue;
+    }
+
+    if (input.conversationId !== payload.conversationId) {
+      continue;
+    }
+
+    if (input.websiteSlug !== website.slug) {
+      continue;
+    }
+
+    upsertConversationEventInCache(queryClient, queryKey, normalizedEvent);
+  }
+};

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/providers/realtime.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/providers/realtime.tsx
@@ -1,87 +1,95 @@
 "use client";
 
 import {
-	type RealtimeEventHandlersMap,
-	useRealtime,
+  type RealtimeEventHandlersMap,
+  useRealtime,
 } from "@cossistant/next/realtime";
 import { useQueryNormalizer } from "@normy/react-query";
 import { useQueryClient } from "@tanstack/react-query";
 import { type ReactNode, useMemo } from "react";
 import { useUserSession, useWebsite } from "@/contexts/website";
 import { handleConversationCreated } from "./events/handlers/conversation-created";
+import { handleConversationEventCreated } from "./events/handlers/conversation-event-created";
 import { handleConversationSeen } from "./events/handlers/conversation-seen";
 import { handleConversationTyping } from "./events/handlers/conversation-typing";
 import { handleMessageCreated } from "./events/handlers/message-created";
 import type { DashboardRealtimeContext } from "./events/types";
 
 export function Realtime({ children }: { children: ReactNode }) {
-	const queryClient = useQueryClient();
-	const queryNormalizer = useQueryNormalizer();
-	const website = useWebsite();
-	const { user } = useUserSession();
+  const queryClient = useQueryClient();
+  const queryNormalizer = useQueryNormalizer();
+  const website = useWebsite();
+  const { user } = useUserSession();
 
-	const realtimeContext = useMemo<DashboardRealtimeContext>(
-		() => ({
-			queryClient,
-			queryNormalizer,
-			website: {
-				id: website.id,
-				slug: website.slug,
-			},
-			userId: user?.id ?? null,
-		}),
-		[queryClient, queryNormalizer, website.id, website.slug, user?.id]
-	);
+  const realtimeContext = useMemo<DashboardRealtimeContext>(
+    () => ({
+      queryClient,
+      queryNormalizer,
+      website: {
+        id: website.id,
+        slug: website.slug,
+      },
+      userId: user?.id ?? null,
+    }),
+    [queryClient, queryNormalizer, website.id, website.slug, user?.id],
+  );
 
-	const events = useMemo<RealtimeEventHandlersMap<DashboardRealtimeContext>>(
-		() => ({
-			conversationCreated: [
-				(_data, meta) => {
-					handleConversationCreated({
-						event: meta.event,
-						context: meta.context,
-					});
-				},
-			],
-			messageCreated: [
-				(_data, meta) => {
-					handleMessageCreated({
-						event: meta.event,
-						context: meta.context,
-					});
-				},
-			],
-			conversationSeen: [
-				(_data, meta) => {
-					void handleConversationSeen({
-						event: meta.event,
-						context: meta.context,
-					});
-				},
-			],
-			conversationTyping: [
-				(_data, meta) => {
-					handleConversationTyping({
-						event: meta.event,
-						context: meta.context,
-					});
-				},
-			],
-		}),
-		[]
-	);
+  const events = useMemo<RealtimeEventHandlersMap<DashboardRealtimeContext>>(
+    () => ({
+      conversationCreated: [
+        (_data, meta) => {
+          handleConversationCreated({
+            event: meta.event,
+            context: meta.context,
+          });
+        },
+      ],
+      conversationEventCreated: [
+        (_data, meta) => {
+          handleConversationEventCreated({
+            event: meta.event,
+            context: meta.context,
+          });
+        },
+      ],
+      messageCreated: [
+        (_data, meta) => {
+          handleMessageCreated({
+            event: meta.event,
+            context: meta.context,
+          });
+        },
+      ],
+      conversationSeen: [
+        (_data, meta) => {
+          void handleConversationSeen({
+            event: meta.event,
+            context: meta.context,
+          });
+        },
+      ],
+      conversationTyping: [
+        (_data, meta) => {
+          handleConversationTyping({
+            event: meta.event,
+            context: meta.context,
+          });
+        },
+      ],
+    }),
+    [],
+  );
+  useRealtime<DashboardRealtimeContext>({
+    context: realtimeContext,
+    websiteId: website.id,
+    events,
+    onEventError: (error, event) => {
+      console.error("[DashboardRealtime] handler failed", {
+        error,
+        eventType: event.type,
+      });
+    },
+  });
 
-	useRealtime<DashboardRealtimeContext>({
-		context: realtimeContext,
-		websiteId: website.id,
-		events,
-		onEventError: (error, event) => {
-			console.error("[DashboardRealtime] handler failed", {
-				error,
-				eventType: event.type,
-			});
-		},
-	});
-
-	return children;
+  return children;
 }

--- a/apps/web/src/data/conversation-event-cache.ts
+++ b/apps/web/src/data/conversation-event-cache.ts
@@ -1,0 +1,91 @@
+import type { RouterOutputs } from "@api/trpc/types";
+import type { InfiniteData, QueryClient } from "@tanstack/react-query";
+
+export type ConversationEventsPage =
+  RouterOutputs["conversation"]["getConversationEvents"];
+export type ConversationEventItem = ConversationEventsPage["items"][number];
+
+function sortEventsByCreatedAt(
+  events: ConversationEventItem[],
+): ConversationEventItem[] {
+  return [...events].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+}
+
+function initializeInfiniteData(
+  event: ConversationEventItem,
+  existing?: InfiniteData<ConversationEventsPage>,
+): InfiniteData<ConversationEventsPage> {
+  const firstPageParam =
+    existing && existing.pageParams.length > 0 ? existing.pageParams[0] : null;
+
+  return {
+    pages: [
+      {
+        items: [event],
+        nextCursor: null,
+        hasNextPage: false,
+      },
+    ],
+    pageParams: [firstPageParam],
+  };
+}
+
+function upsertEventInInfiniteData(
+  existing: InfiniteData<ConversationEventsPage> | undefined,
+  event: ConversationEventItem,
+): InfiniteData<ConversationEventsPage> {
+  if (!existing || existing.pages.length === 0) {
+    return initializeInfiniteData(event, existing);
+  }
+
+  let eventExists = false;
+
+  const pages = existing.pages.map((page, pageIndex) => {
+    const currentItems = [...page.items];
+    const existingIndex = currentItems.findIndex(
+      (item) => item.id === event.id,
+    );
+
+    if (existingIndex !== -1) {
+      eventExists = true;
+      currentItems[existingIndex] = event;
+      return {
+        ...page,
+        items: sortEventsByCreatedAt(currentItems),
+      };
+    }
+
+    if (!eventExists && pageIndex === existing.pages.length - 1) {
+      return {
+        ...page,
+        items: sortEventsByCreatedAt([...currentItems, event]),
+      };
+    }
+
+    return page;
+  });
+
+  return {
+    pages,
+    pageParams: [...existing.pageParams],
+  };
+}
+
+export function createConversationEventsInfiniteQueryKey(
+  baseQueryKey: readonly unknown[],
+) {
+  return [...baseQueryKey, { type: "infinite" }] as const;
+}
+
+export function upsertConversationEventInCache(
+  queryClient: QueryClient,
+  queryKey: readonly unknown[],
+  event: ConversationEventItem,
+) {
+  queryClient.setQueryData<InfiniteData<ConversationEventsPage>>(
+    queryKey,
+    (existing) => upsertEventInInfiniteData(existing, event),
+  );
+}

--- a/apps/web/src/data/use-conversation-events.tsx
+++ b/apps/web/src/data/use-conversation-events.tsx
@@ -4,8 +4,8 @@ import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
 import { useTRPC } from "@/lib/trpc/client";
 
 type UseConversationHeadersOptions = {
-	limit?: number;
-	enabled?: boolean;
+  limit?: number;
+  enabled?: boolean;
 };
 
 const DEFAULT_PAGE_LIMIT = 500;
@@ -14,59 +14,59 @@ const DEFAULT_PAGE_LIMIT = 500;
 const STALE_TIME = 300_000_000;
 
 export function useConversationEvents({
-	websiteSlug,
-	conversationId,
-	options,
+  websiteSlug,
+  conversationId,
+  options,
 }: {
-	websiteSlug: string;
-	conversationId: string;
-	options?: UseConversationHeadersOptions;
+  websiteSlug: string;
+  conversationId: string;
+  options?: UseConversationHeadersOptions;
 }) {
-	const trpc = useTRPC();
-	const queryClient = useQueryClient();
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
 
-	const query = useInfiniteQuery({
-		queryKey: [
-			...trpc.conversation.getConversationEvents.queryOptions({
-				websiteSlug,
-				conversationId,
-			}).queryKey,
-			{ type: "infinite" },
-		],
-		queryFn: async ({ pageParam }) => {
-			const response = await queryClient.fetchQuery(
-				trpc.conversation.getConversationEvents.queryOptions({
-					websiteSlug,
-					conversationId,
-					limit: options?.limit ?? DEFAULT_PAGE_LIMIT,
-					cursor: pageParam ?? null,
-				})
-			);
+  const query = useInfiniteQuery({
+    queryKey: [
+      ...trpc.conversation.getConversationEvents.queryOptions({
+        websiteSlug,
+        conversationId,
+      }).queryKey,
+      { type: "infinite" },
+    ],
+    queryFn: async ({ pageParam }) => {
+      const response = await queryClient.fetchQuery(
+        trpc.conversation.getConversationEvents.queryOptions({
+          websiteSlug,
+          conversationId,
+          limit: options?.limit ?? DEFAULT_PAGE_LIMIT,
+          cursor: pageParam ?? null,
+        }),
+      );
 
-			return response;
-		},
-		getNextPageParam: (lastPage) => lastPage.nextCursor,
-		initialPageParam: null as string | null,
-		enabled: options?.enabled ?? true,
-		staleTime: STALE_TIME,
-	});
+      return response;
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    initialPageParam: null as string | null,
+    enabled: options?.enabled ?? true,
+    staleTime: STALE_TIME,
+  });
 
-	const events =
-		query.data?.pages
-			.flatMap((page) => page.items)
-			.sort(
-				(a, b) =>
-					new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-			) ?? [];
+  const events =
+    query.data?.pages
+      .flatMap((page) => page.items)
+      .sort(
+        (a, b) =>
+          new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+      ) ?? [];
 
-	return {
-		events,
-		isLoading: query.isLoading,
-		isFetching: query.isFetching,
-		isFetchingNextPage: query.isFetchingNextPage,
-		hasNextPage: query.hasNextPage,
-		fetchNextPage: query.fetchNextPage,
-		error: query.error,
-		refetch: query.refetch,
-	};
+  return {
+    events,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+    error: query.error,
+    refetch: query.refetch,
+  };
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,476 +1,507 @@
 import {
-	type AnyRealtimeEvent,
-	type DefaultMessage,
-	getEventPayload,
-	type IdentifyContactResponse,
-	type RealtimeEvent,
+  type AnyRealtimeEvent,
+  type DefaultMessage,
+  getEventPayload,
+  type IdentifyContactResponse,
+  type RealtimeEvent,
 } from "@cossistant/types";
 import type {
-	CreateConversationRequestBody,
-	CreateConversationResponseBody,
-	GetConversationRequest,
-	GetConversationResponse,
-	ListConversationsRequest,
-	ListConversationsResponse,
-	MarkConversationSeenRequestBody,
-	MarkConversationSeenResponseBody,
-	SetConversationTypingResponseBody,
+  CreateConversationRequestBody,
+  CreateConversationResponseBody,
+  GetConversationEventsRequest,
+  GetConversationEventsResponse,
+  GetConversationRequest,
+  GetConversationResponse,
+  ListConversationsRequest,
+  ListConversationsResponse,
+  MarkConversationSeenRequestBody,
+  MarkConversationSeenResponseBody,
+  SetConversationTypingResponseBody,
 } from "@cossistant/types/api/conversation";
 import type {
-	GetMessagesRequest,
-	GetMessagesResponse,
-	SendMessageRequest,
-	SendMessageResponse,
+  GetMessagesRequest,
+  GetMessagesResponse,
+  SendMessageRequest,
+  SendMessageResponse,
 } from "@cossistant/types/api/message";
 import {
-	ConversationStatus,
-	MessageType,
-	MessageVisibility,
-	SenderType,
+  ConversationStatus,
+  MessageType,
+  MessageVisibility,
+  SenderType,
 } from "@cossistant/types/enums";
 import type { Conversation, Message } from "@cossistant/types/schemas";
 import { CossistantRestClient } from "./rest-client";
 import {
-	type ConversationsStore,
-	createConversationsStore,
+  type ConversationsStore,
+  createConversationsStore,
 } from "./store/conversations-store";
 import {
-	createMessagesStore,
-	type MessagesStore,
+  createConversationEventsStore,
+  type ConversationEventsStore,
+} from "./store/conversation-events-store";
+import {
+  createMessagesStore,
+  type MessagesStore,
 } from "./store/messages-store";
 import {
-	createWebsiteStore,
-	type WebsiteState,
-	type WebsiteStore,
+  createWebsiteStore,
+  type WebsiteState,
+  type WebsiteStore,
 } from "./store/website-store";
 import type {
-	CossistantConfig,
-	PublicWebsiteResponse,
-	VisitorMetadata,
-	VisitorResponse,
+  CossistantConfig,
+  PublicWebsiteResponse,
+  VisitorMetadata,
+  VisitorResponse,
 } from "./types";
 import { generateConversationId, generateMessageId } from "./utils";
 
 type PendingConversation = {
-	conversation: Conversation;
-	initialMessages: Message[];
+  conversation: Conversation;
+  initialMessages: Message[];
 };
 
 type InitiateConversationParams = {
-	conversationId?: string;
-	visitorId?: string | null;
-	websiteId?: string | null;
-	title?: string;
-	status?: Conversation["status"];
-	defaultMessages?: Array<DefaultMessage | Message>;
+  conversationId?: string;
+  visitorId?: string | null;
+  websiteId?: string | null;
+  title?: string;
+  status?: Conversation["status"];
+  defaultMessages?: Array<DefaultMessage | Message>;
 };
 
 type InitiateConversationResult = {
-	conversationId: string;
-	conversation: Conversation;
-	defaultMessages: Message[];
+  conversationId: string;
+  conversation: Conversation;
+  defaultMessages: Message[];
 };
 
 export class CossistantClient {
-	private restClient: CossistantRestClient;
-	private config: CossistantConfig;
-	private pendingConversations = new Map<string, PendingConversation>();
-	private websiteRequest: Promise<PublicWebsiteResponse> | null = null;
-	readonly conversationsStore: ConversationsStore;
-	readonly messagesStore: MessagesStore;
-	readonly websiteStore: WebsiteStore;
+  private restClient: CossistantRestClient;
+  private config: CossistantConfig;
+  private pendingConversations = new Map<string, PendingConversation>();
+  private websiteRequest: Promise<PublicWebsiteResponse> | null = null;
+  readonly conversationsStore: ConversationsStore;
+  readonly conversationEventsStore: ConversationEventsStore;
+  readonly messagesStore: MessagesStore;
+  readonly websiteStore: WebsiteStore;
 
-	constructor(config: CossistantConfig) {
-		this.config = config;
-		this.restClient = new CossistantRestClient(config);
-		this.conversationsStore = createConversationsStore();
-		this.messagesStore = createMessagesStore();
-		this.websiteStore = createWebsiteStore();
-	}
+  constructor(config: CossistantConfig) {
+    this.config = config;
+    this.restClient = new CossistantRestClient(config);
+    this.conversationsStore = createConversationsStore();
+    this.conversationEventsStore = createConversationEventsStore();
+    this.messagesStore = createMessagesStore();
+    this.websiteStore = createWebsiteStore();
+  }
 
-	// Configuration updates
-	updateConfiguration(config: Partial<CossistantConfig>): void {
-		this.config = { ...this.config, ...config };
-		this.restClient.updateConfiguration(config);
-	}
+  // Configuration updates
+  updateConfiguration(config: Partial<CossistantConfig>): void {
+    this.config = { ...this.config, ...config };
+    this.restClient.updateConfiguration(config);
+  }
 
-	// Utility methods
-	getConfiguration(): CossistantConfig {
-		return { ...this.config };
-	}
+  // Utility methods
+  getConfiguration(): CossistantConfig {
+    return { ...this.config };
+  }
 
-	// Website information
-	async fetchWebsite(
-		params: { force?: boolean } = {}
-	): Promise<PublicWebsiteResponse> {
-		const { force = false } = params;
-		const current: WebsiteState = this.websiteStore.getState();
+  // Website information
+  async fetchWebsite(
+    params: { force?: boolean } = {},
+  ): Promise<PublicWebsiteResponse> {
+    const { force = false } = params;
+    const current: WebsiteState = this.websiteStore.getState();
 
-		if (!force) {
-			if (current.status === "success" && current.website) {
-				return current.website;
-			}
-			if (this.websiteRequest) {
-				return this.websiteRequest;
-			}
-		}
+    if (!force) {
+      if (current.status === "success" && current.website) {
+        return current.website;
+      }
+      if (this.websiteRequest) {
+        return this.websiteRequest;
+      }
+    }
 
-		this.websiteStore.setLoading();
+    this.websiteStore.setLoading();
 
-		const request = this.restClient
-			.getWebsite()
-			.then((website) => {
-				this.websiteStore.setWebsite(website);
-				return website;
-			})
-			.catch((error) => {
-				this.websiteStore.setError(error);
-				throw error;
-			})
-			.finally(() => {
-				if (this.websiteRequest === request) {
-					this.websiteRequest = null;
-				}
-			});
+    const request = this.restClient
+      .getWebsite()
+      .then((website) => {
+        this.websiteStore.setWebsite(website);
+        return website;
+      })
+      .catch((error) => {
+        this.websiteStore.setError(error);
+        throw error;
+      })
+      .finally(() => {
+        if (this.websiteRequest === request) {
+          this.websiteRequest = null;
+        }
+      });
 
-		this.websiteRequest = request;
+    this.websiteRequest = request;
 
-		return request;
-	}
+    return request;
+  }
 
-	async getWebsite(): Promise<PublicWebsiteResponse> {
-		return this.fetchWebsite({ force: true });
-	}
+  async getWebsite(): Promise<PublicWebsiteResponse> {
+    return this.fetchWebsite({ force: true });
+  }
 
-	setWebsiteContext(websiteId: string, visitorId?: string): void {
-		this.restClient.setWebsiteContext(websiteId, visitorId);
-	}
+  setWebsiteContext(websiteId: string, visitorId?: string): void {
+    this.restClient.setWebsiteContext(websiteId, visitorId);
+  }
 
-	async updateVisitorMetadata(
-		metadata: VisitorMetadata
-	): Promise<VisitorResponse> {
-		return this.restClient.updateVisitorMetadata(metadata);
-	}
+  async updateVisitorMetadata(
+    metadata: VisitorMetadata,
+  ): Promise<VisitorResponse> {
+    return this.restClient.updateVisitorMetadata(metadata);
+  }
 
-	async identify(params: {
-		externalId?: string;
-		email?: string;
-		name?: string;
-		image?: string;
-		metadata?: Record<string, unknown>;
-		contactOrganizationId?: string;
-	}): Promise<IdentifyContactResponse> {
-		return this.restClient.identify(params);
-	}
+  async identify(params: {
+    externalId?: string;
+    email?: string;
+    name?: string;
+    image?: string;
+    metadata?: Record<string, unknown>;
+    contactOrganizationId?: string;
+  }): Promise<IdentifyContactResponse> {
+    return this.restClient.identify(params);
+  }
 
-	async updateContactMetadata(
-		metadata: Record<string, unknown>
-	): Promise<VisitorResponse> {
-		return this.restClient.updateContactMetadata(metadata);
-	}
+  async updateContactMetadata(
+    metadata: Record<string, unknown>,
+  ): Promise<VisitorResponse> {
+    return this.restClient.updateContactMetadata(metadata);
+  }
 
-	// Conversation management
-	initiateConversation(
-		params: InitiateConversationParams = {}
-	): InitiateConversationResult {
-		const conversationId = params.conversationId ?? generateConversationId();
-		const now = new Date().toISOString();
-		const messages = (params.defaultMessages ?? []).map((message) =>
-			normalizeBootstrapMessage(conversationId, message)
-		);
-		const existing = this.conversationsStore.getState().byId[conversationId];
-		const baseVisitorId =
-			params.visitorId ?? this.restClient.getCurrentVisitorId() ?? "";
-		const baseWebsiteId =
-			params.websiteId ?? this.restClient.getCurrentWebsiteId() ?? "";
+  // Conversation management
+  initiateConversation(
+    params: InitiateConversationParams = {},
+  ): InitiateConversationResult {
+    const conversationId = params.conversationId ?? generateConversationId();
+    const now = new Date().toISOString();
+    const messages = (params.defaultMessages ?? []).map((message) =>
+      normalizeBootstrapMessage(conversationId, message),
+    );
+    const existing = this.conversationsStore.getState().byId[conversationId];
+    const baseVisitorId =
+      params.visitorId ?? this.restClient.getCurrentVisitorId() ?? "";
+    const baseWebsiteId =
+      params.websiteId ?? this.restClient.getCurrentWebsiteId() ?? "";
 
-		const conversation: Conversation = existing
-			? {
-					...existing,
-					title: params.title ?? existing.title,
-					status: params.status ?? existing.status,
-					updatedAt: now,
-					lastMessage: messages.at(-1) ?? existing.lastMessage,
-				}
-			: {
-					id: conversationId,
-					title: params.title,
-					createdAt: now,
-					updatedAt: now,
-					visitorId: baseVisitorId,
-					websiteId: baseWebsiteId,
-					status: params.status ?? ConversationStatus.OPEN,
-					lastMessage: messages.at(-1),
-				};
+    const conversation: Conversation = existing
+      ? {
+          ...existing,
+          title: params.title ?? existing.title,
+          status: params.status ?? existing.status,
+          updatedAt: now,
+          lastMessage: messages.at(-1) ?? existing.lastMessage,
+        }
+      : {
+          id: conversationId,
+          title: params.title,
+          createdAt: now,
+          updatedAt: now,
+          visitorId: baseVisitorId,
+          websiteId: baseWebsiteId,
+          status: params.status ?? ConversationStatus.OPEN,
+          lastMessage: messages.at(-1),
+        };
 
-		this.conversationsStore.ingestConversation(conversation);
+    this.conversationsStore.ingestConversation(conversation);
 
-		if (messages.length > 0) {
-			this.messagesStore.ingestPage(conversationId, {
-				messages,
-				hasNextPage: false,
-				nextCursor: undefined,
-			});
-		}
+    if (messages.length > 0) {
+      this.messagesStore.ingestPage(conversationId, {
+        messages,
+        hasNextPage: false,
+        nextCursor: undefined,
+      });
+    }
 
-		if (!existing || this.pendingConversations.has(conversationId)) {
-			this.pendingConversations.set(conversationId, {
-				conversation,
-				initialMessages: messages,
-			});
-		}
+    if (!existing || this.pendingConversations.has(conversationId)) {
+      this.pendingConversations.set(conversationId, {
+        conversation,
+        initialMessages: messages,
+      });
+    }
 
-		return {
-			conversationId,
-			conversation,
-			defaultMessages: messages,
-		};
-	}
+    return {
+      conversationId,
+      conversation,
+      defaultMessages: messages,
+    };
+  }
 
-	async createConversation(
-		params?: Partial<CreateConversationRequestBody>
-	): Promise<CreateConversationResponseBody> {
-		const response = await this.restClient.createConversation(params);
-		this.conversationsStore.ingestConversation(response.conversation);
-		return response;
-	}
+  async createConversation(
+    params?: Partial<CreateConversationRequestBody>,
+  ): Promise<CreateConversationResponseBody> {
+    const response = await this.restClient.createConversation(params);
+    this.conversationsStore.ingestConversation(response.conversation);
+    return response;
+  }
 
-	async listConversations(
-		params?: Partial<ListConversationsRequest>
-	): Promise<ListConversationsResponse> {
-		const response = await this.restClient.listConversations(params);
-		this.conversationsStore.ingestList(response);
-		return response;
-	}
+  async listConversations(
+    params?: Partial<ListConversationsRequest>,
+  ): Promise<ListConversationsResponse> {
+    const response = await this.restClient.listConversations(params);
+    this.conversationsStore.ingestList(response);
+    return response;
+  }
 
-	async getConversation(
-		params: GetConversationRequest
-	): Promise<GetConversationResponse> {
-		const response = await this.restClient.getConversation(params);
-		this.conversationsStore.ingestConversation(response.conversation);
-		return response;
-	}
+  async getConversation(
+    params: GetConversationRequest,
+  ): Promise<GetConversationResponse> {
+    const response = await this.restClient.getConversation(params);
+    this.conversationsStore.ingestConversation(response.conversation);
+    return response;
+  }
 
-	async markConversationSeen(
-		params: {
-			conversationId: string;
-		} & Partial<MarkConversationSeenRequestBody>
-	): Promise<MarkConversationSeenResponseBody> {
-		return this.restClient.markConversationSeen(params);
-	}
+  async markConversationSeen(
+    params: {
+      conversationId: string;
+    } & Partial<MarkConversationSeenRequestBody>,
+  ): Promise<MarkConversationSeenResponseBody> {
+    return this.restClient.markConversationSeen(params);
+  }
 
-	async getConversationSeenData(params: { conversationId: string }) {
-		return this.restClient.getConversationSeenData(params);
-	}
+  async getConversationSeenData(params: { conversationId: string }) {
+    return this.restClient.getConversationSeenData(params);
+  }
 
-	async setVisitorTyping(params: {
-		conversationId: string;
-		isTyping: boolean;
-		visitorPreview?: string | null;
-		visitorId?: string;
-	}): Promise<SetConversationTypingResponseBody> {
-		return this.restClient.setConversationTyping(params);
-	}
+  async setVisitorTyping(params: {
+    conversationId: string;
+    isTyping: boolean;
+    visitorPreview?: string | null;
+    visitorId?: string;
+  }): Promise<SetConversationTypingResponseBody> {
+    return this.restClient.setConversationTyping(params);
+  }
 
-	// Message management
-	async getConversationMessages(
-		params: GetMessagesRequest
-	): Promise<GetMessagesResponse> {
-		const response = await this.restClient.getConversationMessages(params);
-		this.messagesStore.ingestPage(params.conversationId, {
-			messages: response.messages,
-			hasNextPage: response.hasNextPage,
-			nextCursor: response.nextCursor,
-		});
-		return response;
-	}
+  // Message management
+  async getConversationEvents(
+    params: GetConversationEventsRequest,
+  ): Promise<GetConversationEventsResponse> {
+    const response = await this.restClient.getConversationEvents(params);
+    this.conversationEventsStore.ingestPage(params.conversationId, {
+      events: response.events,
+      hasNextPage: response.hasNextPage,
+      nextCursor: response.nextCursor ?? undefined,
+    });
+    return response;
+  }
 
-	async sendMessage(
-		params: SendMessageRequest & { createIfPending?: boolean }
-	): Promise<
-		SendMessageResponse & {
-			conversation?: Conversation;
-			initialMessages?: Message[];
-			wasConversationCreated?: boolean;
-		}
-	> {
-		const { createIfPending, ...rest } = params;
-		const optimisticId = rest.message.id ?? generateMessageId();
-		const createdAt = rest.message.createdAt
-			? rest.message.createdAt
-			: new Date().toISOString();
+  async getConversationMessages(
+    params: GetMessagesRequest,
+  ): Promise<GetMessagesResponse> {
+    const response = await this.restClient.getConversationMessages(params);
+    this.messagesStore.ingestPage(params.conversationId, {
+      messages: response.messages,
+      hasNextPage: response.hasNextPage,
+      nextCursor: response.nextCursor,
+    });
+    return response;
+  }
 
-		const optimisticMessage: Message = {
-			id: optimisticId,
-			bodyMd: rest.message.bodyMd,
-			type: (rest.message.type ?? MessageType.TEXT) as Message["type"],
-			userId: rest.message.userId ?? null,
-			aiAgentId: rest.message.aiAgentId ?? null,
-			parentMessageId: null,
-			modelUsed: null,
-			visitorId: rest.message.visitorId ?? null,
-			conversationId: rest.conversationId,
-			createdAt,
-			updatedAt: createdAt,
-			deletedAt: null,
-			visibility: (rest.message.visibility ??
-				MessageVisibility.PUBLIC) as Message["visibility"],
-		};
+  async sendMessage(
+    params: SendMessageRequest & { createIfPending?: boolean },
+  ): Promise<
+    SendMessageResponse & {
+      conversation?: Conversation;
+      initialMessages?: Message[];
+      wasConversationCreated?: boolean;
+    }
+  > {
+    const { createIfPending, ...rest } = params;
+    const optimisticId = rest.message.id ?? generateMessageId();
+    const createdAt = rest.message.createdAt
+      ? rest.message.createdAt
+      : new Date().toISOString();
 
-		this.messagesStore.ingestMessage(optimisticMessage);
+    const optimisticMessage: Message = {
+      id: optimisticId,
+      bodyMd: rest.message.bodyMd,
+      type: (rest.message.type ?? MessageType.TEXT) as Message["type"],
+      userId: rest.message.userId ?? null,
+      aiAgentId: rest.message.aiAgentId ?? null,
+      parentMessageId: null,
+      modelUsed: null,
+      visitorId: rest.message.visitorId ?? null,
+      conversationId: rest.conversationId,
+      createdAt,
+      updatedAt: createdAt,
+      deletedAt: null,
+      visibility: (rest.message.visibility ??
+        MessageVisibility.PUBLIC) as Message["visibility"],
+    };
 
-		const pending = this.pendingConversations.get(rest.conversationId);
+    this.messagesStore.ingestMessage(optimisticMessage);
 
-		if (pending && createIfPending !== false) {
-			try {
-				const response = await this.restClient.createConversation({
-					conversationId: rest.conversationId,
-					defaultMessages: [...pending.initialMessages, optimisticMessage],
-				});
+    const pending = this.pendingConversations.get(rest.conversationId);
 
-				this.conversationsStore.ingestConversation(response.conversation);
-				this.messagesStore.removeMessage(rest.conversationId, optimisticId);
-				this.messagesStore.clearConversation(rest.conversationId);
-				this.messagesStore.ingestPage(rest.conversationId, {
-					messages: response.initialMessages,
-					hasNextPage: false,
-					nextCursor: undefined,
-				});
+    if (pending && createIfPending !== false) {
+      try {
+        const response = await this.restClient.createConversation({
+          conversationId: rest.conversationId,
+          defaultMessages: [...pending.initialMessages, optimisticMessage],
+        });
 
-				this.pendingConversations.delete(rest.conversationId);
+        this.conversationsStore.ingestConversation(response.conversation);
+        this.messagesStore.removeMessage(rest.conversationId, optimisticId);
+        this.messagesStore.clearConversation(rest.conversationId);
+        this.messagesStore.ingestPage(rest.conversationId, {
+          messages: response.initialMessages,
+          hasNextPage: false,
+          nextCursor: undefined,
+        });
 
-				const message =
-					response.initialMessages.at(-1) ?? response.initialMessages[0];
+        this.pendingConversations.delete(rest.conversationId);
 
-				return {
-					message: message as Message,
-					conversation: response.conversation,
-					initialMessages: response.initialMessages,
-					wasConversationCreated: true,
-				} satisfies SendMessageResponse & {
-					conversation: Conversation;
-					initialMessages: Message[];
-					wasConversationCreated: true;
-				};
-			} catch (error) {
-				this.messagesStore.removeMessage(rest.conversationId, optimisticId);
-				throw error;
-			}
-		}
+        const message =
+          response.initialMessages.at(-1) ?? response.initialMessages[0];
 
-		const { createdAt: _createdAt, ...restMessage } = rest.message;
+        return {
+          message: message as Message,
+          conversation: response.conversation,
+          initialMessages: response.initialMessages,
+          wasConversationCreated: true,
+        } satisfies SendMessageResponse & {
+          conversation: Conversation;
+          initialMessages: Message[];
+          wasConversationCreated: true;
+        };
+      } catch (error) {
+        this.messagesStore.removeMessage(rest.conversationId, optimisticId);
+        throw error;
+      }
+    }
 
-		const payload: SendMessageRequest = {
-			...rest,
-			message: {
-				...restMessage,
-				id: optimisticId,
-			},
-		};
+    const { createdAt: _createdAt, ...restMessage } = rest.message;
 
-		try {
-			const response = await this.restClient.sendMessage(payload);
-			this.messagesStore.finalizeMessage(
-				rest.conversationId,
-				optimisticId,
-				response.message
-			);
-			return response;
-		} catch (error) {
-			this.messagesStore.removeMessage(rest.conversationId, optimisticId);
-			throw error;
-		}
-	}
+    const payload: SendMessageRequest = {
+      ...rest,
+      message: {
+        ...restMessage,
+        id: optimisticId,
+      },
+    };
 
-	handleRealtimeEvent(event: AnyRealtimeEvent): void {
-		if (event.type === "conversationCreated") {
-			const { conversation, header } = event.payload;
+    try {
+      const response = await this.restClient.sendMessage(payload);
+      this.messagesStore.finalizeMessage(
+        rest.conversationId,
+        optimisticId,
+        response.message,
+      );
+      return response;
+    } catch (error) {
+      this.messagesStore.removeMessage(rest.conversationId, optimisticId);
+      throw error;
+    }
+  }
 
-			this.conversationsStore.ingestConversation({
-				...conversation,
-				lastMessage: conversation.lastMessage ?? undefined,
-			});
-		} else if (event.type === "messageCreated") {
-			const message = this.messagesStore.ingestRealtime(event);
+  handleRealtimeEvent(event: AnyRealtimeEvent): void {
+    if (event.type === "conversationCreated") {
+      const { conversation, header } = event.payload;
 
-			const existingConversation =
-				this.conversationsStore.getState().byId[message.conversationId];
+      this.conversationsStore.ingestConversation({
+        ...conversation,
+        lastMessage: conversation.lastMessage ?? undefined,
+      });
+    } else if (event.type === "messageCreated") {
+      const message = this.messagesStore.ingestRealtime(event);
 
-			if (existingConversation) {
-				const nextConversation = {
-					...existingConversation,
-					updatedAt: message.updatedAt,
-					lastMessage: message,
-				};
+      const existingConversation =
+        this.conversationsStore.getState().byId[message.conversationId];
 
-				this.conversationsStore.ingestConversation(nextConversation);
-			}
-		}
-	}
+      if (existingConversation) {
+        const nextConversation = {
+          ...existingConversation,
+          updatedAt: message.updatedAt,
+          lastMessage: message,
+        };
 
-	// Cleanup method
-	destroy(): void {
-		// No cleanup needed for REST client
-	}
+        this.conversationsStore.ingestConversation(nextConversation);
+      }
+    } else if (event.type === "conversationEventCreated") {
+      const timelineEvent = this.conversationEventsStore.ingestRealtime(event);
+      const existingConversation =
+        this.conversationsStore.getState().byId[timelineEvent.conversationId];
+
+      if (existingConversation) {
+        this.conversationsStore.ingestConversation({
+          ...existingConversation,
+          updatedAt: timelineEvent.createdAt,
+        });
+      }
+    }
+  }
+
+  // Cleanup method
+  destroy(): void {
+    // No cleanup needed for REST client
+  }
 }
 
 function normalizeBootstrapMessage(
-	conversationId: string,
-	message: DefaultMessage | Message
+  conversationId: string,
+  message: DefaultMessage | Message,
 ): Message {
-	if (isDefaultMessage(message)) {
-		const createdAt = new Date().toISOString();
+  if (isDefaultMessage(message)) {
+    const createdAt = new Date().toISOString();
 
-		return {
-			id: generateMessageId(),
-			bodyMd: message.content,
-			type: MessageType.TEXT,
-			userId:
-				message.senderType === SenderType.TEAM_MEMBER
-					? (message.senderId ?? null)
-					: null,
-			aiAgentId:
-				message.senderType === SenderType.AI
-					? (message.senderId ?? null)
-					: null,
-			visitorId:
-				message.senderType === SenderType.VISITOR
-					? (message.senderId ?? null)
-					: null,
-			conversationId,
-			createdAt,
-			updatedAt: createdAt,
-			deletedAt: null,
-			parentMessageId: null,
-			modelUsed: null,
-			visibility: MessageVisibility.PUBLIC,
-		} satisfies Message;
-	}
+    return {
+      id: generateMessageId(),
+      bodyMd: message.content,
+      type: MessageType.TEXT,
+      userId:
+        message.senderType === SenderType.TEAM_MEMBER
+          ? (message.senderId ?? null)
+          : null,
+      aiAgentId:
+        message.senderType === SenderType.AI
+          ? (message.senderId ?? null)
+          : null,
+      visitorId:
+        message.senderType === SenderType.VISITOR
+          ? (message.senderId ?? null)
+          : null,
+      conversationId,
+      createdAt,
+      updatedAt: createdAt,
+      deletedAt: null,
+      parentMessageId: null,
+      modelUsed: null,
+      visibility: MessageVisibility.PUBLIC,
+    } satisfies Message;
+  }
 
-	const createdAt = message.createdAt
-		? message.createdAt
-		: new Date().toISOString();
-	const updatedAt = message.updatedAt ? message.updatedAt : createdAt;
+  const createdAt = message.createdAt
+    ? message.createdAt
+    : new Date().toISOString();
+  const updatedAt = message.updatedAt ? message.updatedAt : createdAt;
 
-	return {
-		...message,
-		id: message.id ?? generateMessageId(),
-		conversationId,
-		type: (message.type ?? MessageType.TEXT) as Message["type"],
-		createdAt,
-		updatedAt,
-		deletedAt: message.deletedAt ?? null,
-		parentMessageId: message.parentMessageId ?? null,
-		modelUsed: message.modelUsed ?? null,
-		userId: message.userId ?? null,
-		aiAgentId: message.aiAgentId ?? null,
-		visitorId: message.visitorId ?? null,
-		visibility: message.visibility ?? MessageVisibility.PUBLIC,
-	} satisfies Message;
+  return {
+    ...message,
+    id: message.id ?? generateMessageId(),
+    conversationId,
+    type: (message.type ?? MessageType.TEXT) as Message["type"],
+    createdAt,
+    updatedAt,
+    deletedAt: message.deletedAt ?? null,
+    parentMessageId: message.parentMessageId ?? null,
+    modelUsed: message.modelUsed ?? null,
+    userId: message.userId ?? null,
+    aiAgentId: message.aiAgentId ?? null,
+    visitorId: message.visitorId ?? null,
+    visibility: message.visibility ?? MessageVisibility.PUBLIC,
+  } satisfies Message;
 }
 
 function isDefaultMessage(
-	message: DefaultMessage | Message
+  message: DefaultMessage | Message,
 ): message is DefaultMessage {
-	return (message as DefaultMessage).content !== undefined;
+  return (message as DefaultMessage).content !== undefined;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,8 +1,8 @@
 export type {
-	CossistantConfig,
-	CossistantError,
-	Message,
-	PublicWebsiteResponse,
+  CossistantConfig,
+  CossistantError,
+  Message,
+  PublicWebsiteResponse,
 } from "@cossistant/types";
 
 export { conversationSchema, messageSchema } from "@cossistant/types";
@@ -10,65 +10,70 @@ export { CossistantClient, CossistantClient as default } from "./client";
 export { normalizeLocale } from "./locale-utils";
 export { CossistantRestClient } from "./rest-client";
 export {
-	type ConversationPagination,
-	type ConversationsState,
-	type ConversationsStore,
-	createConversationsStore,
-	getConversationById,
-	getConversationPagination,
-	getConversations,
+  type ConversationPagination,
+  type ConversationsState,
+  type ConversationsStore,
+  createConversationsStore,
+  getConversationById,
+  getConversationPagination,
+  getConversations,
 } from "./store/conversations-store";
 export {
-	type ConversationMessagesState,
-	createMessagesStore,
-	getConversationMessages,
-	type MessagesState,
-	type MessagesStore,
+  type ConversationMessagesState,
+  createMessagesStore,
+  getConversationMessages,
+  type MessagesState,
+  type MessagesStore,
 } from "./store/messages-store";
 export {
-	applyConversationSeenEvent,
-	type ConversationSeenState,
-	createSeenStore,
-	hydrateConversationSeen,
-	type SeenActorType,
-	type SeenEntry,
-	type SeenState,
-	type SeenStore,
-	upsertConversationSeen,
+  applyConversationSeenEvent,
+  type ConversationSeenState,
+  createSeenStore,
+  hydrateConversationSeen,
+  type SeenActorType,
+  type SeenEntry,
+  type SeenState,
+  type SeenStore,
+  upsertConversationSeen,
 } from "./store/seen-store";
 export {
-	createSupportStore,
-	type NavigationState,
-	type SUPPORT_PAGES,
-	type SupportConfig,
-	type SupportNavigation,
-	type SupportStore,
-	type SupportStoreActions,
-	type SupportStoreOptions,
-	type SupportStoreState,
-	type SupportStoreStorage,
+  createSupportStore,
+  type NavigationState,
+  type SUPPORT_PAGES,
+  type SupportConfig,
+  type SupportNavigation,
+  type SupportStore,
+  type SupportStoreActions,
+  type SupportStoreOptions,
+  type SupportStoreState,
+  type SupportStoreStorage,
 } from "./store/support-store";
 export {
-	applyConversationTypingEvent,
-	type ConversationTypingState,
-	clearTypingFromMessage,
-	clearTypingState,
-	createTypingStore,
-	getConversationTyping,
-	setTypingState,
-	type TypingActorType,
-	type TypingEntry,
-	type TypingState,
-	type TypingStore,
-	type TypingStoreDependencies,
+  applyConversationTypingEvent,
+  type ConversationTypingState,
+  clearTypingFromMessage,
+  clearTypingState,
+  createTypingStore,
+  getConversationTyping,
+  setTypingState,
+  type TypingActorType,
+  type TypingEntry,
+  type TypingState,
+  type TypingStore,
+  type TypingStoreDependencies,
 } from "./store/typing-store";
 export {
-	createWebsiteStore,
-	getWebsiteState,
-	type WebsiteError,
-	type WebsiteState,
-	type WebsiteStatus,
-	type WebsiteStore,
+  createConversationEventsStore,
+  type ConversationEventsState,
+  type ConversationEventsStore,
+} from "./store/conversation-events-store";
+export {
+  createWebsiteStore,
+  getWebsiteState,
+  type WebsiteError,
+  type WebsiteState,
+  type WebsiteStatus,
+  type WebsiteStore,
 } from "./store/website-store";
 // Core-specific exports
 export { CossistantAPIError } from "./types";
@@ -76,9 +81,9 @@ export { CossistantAPIError } from "./types";
 export { generateConversationId, generateMessageId } from "./utils";
 export { collectVisitorData, type VisitorData } from "./visitor-data";
 export {
-	clearAllVisitorIds,
-	clearVisitorId,
-	getVisitorId,
-	setVisitorId,
+  clearAllVisitorIds,
+  clearVisitorId,
+  getVisitorId,
+  setVisitorId,
 } from "./visitor-tracker";
 // WebSocket client removed - use React WebSocket context instead

--- a/packages/core/src/rest-client.ts
+++ b/packages/core/src/rest-client.ts
@@ -1,650 +1,687 @@
 import type { IdentifyContactResponse } from "@cossistant/types/api/contact";
 import type {
-	CreateConversationRequestBody,
-	CreateConversationResponseBody,
-	GetConversationRequest,
-	GetConversationResponse,
-	GetConversationSeenDataResponse,
-	ListConversationsRequest,
-	ListConversationsResponse,
-	MarkConversationSeenRequestBody,
-	MarkConversationSeenResponseBody,
-	SetConversationTypingRequestBody,
-	SetConversationTypingResponseBody,
+  CreateConversationRequestBody,
+  CreateConversationResponseBody,
+  GetConversationEventsRequest,
+  GetConversationEventsResponse,
+  GetConversationRequest,
+  GetConversationResponse,
+  GetConversationSeenDataResponse,
+  ListConversationsRequest,
+  ListConversationsResponse,
+  MarkConversationSeenRequestBody,
+  MarkConversationSeenResponseBody,
+  SetConversationTypingRequestBody,
+  SetConversationTypingResponseBody,
 } from "@cossistant/types/api/conversation";
 import type {
-	GetMessagesRequest,
-	GetMessagesResponse,
-	SendMessageRequest,
-	SendMessageResponse,
+  GetMessagesRequest,
+  GetMessagesResponse,
+  SendMessageRequest,
+  SendMessageResponse,
 } from "@cossistant/types/api/message";
 import {
-	CossistantAPIError,
-	type CossistantConfig,
-	type PublicWebsiteResponse,
-	type UpdateVisitorRequest,
-	type VisitorMetadata,
-	type VisitorResponse,
+  CossistantAPIError,
+  type CossistantConfig,
+  type PublicWebsiteResponse,
+  type UpdateVisitorRequest,
+  type VisitorMetadata,
+  type VisitorResponse,
 } from "./types";
 import { generateConversationId } from "./utils";
 import { collectVisitorData } from "./visitor-data";
 import {
-	getExistingVisitorId,
-	getVisitorId,
-	setVisitorId,
+  getExistingVisitorId,
+  getVisitorId,
+  setVisitorId,
 } from "./visitor-tracker";
 
 export class CossistantRestClient {
-	private config: CossistantConfig;
-	private baseHeaders: Record<string, string>;
-	private publicKey: string;
-	private websiteId: string | null = null;
-	private visitorId: string | null = null;
-
-	constructor(config: CossistantConfig) {
-		this.config = config;
-
-		// Get public key from config or environment variables
-		this.publicKey =
-			config.publicKey ||
-			(typeof process !== "undefined"
-				? process.env.NEXT_PUBLIC_COSSISTANT_KEY
-				: undefined) ||
-			(typeof process !== "undefined"
-				? process.env.COSSISTANT_PUBLIC_KEY
-				: undefined) ||
-			"";
-
-		if (!this.publicKey) {
-			throw new Error(
-				"Public key is required. Please provide it in the config or set NEXT_PUBLIC_COSSISTANT_KEY or COSSISTANT_PUBLIC_KEY environment variable."
-			);
-		}
-
-		this.baseHeaders = {
-			"Content-Type": "application/json",
-			"X-Public-Key": this.publicKey,
-		};
-
-		if (config.userId) {
-			this.baseHeaders["X-User-ID"] = config.userId;
-		}
-
-		if (config.organizationId) {
-			this.baseHeaders["X-Organization-ID"] = config.organizationId;
-		}
-	}
-
-	private normalizeVisitorResponse(payload: VisitorResponse): VisitorResponse {
-		const contact = payload.contact ? payload.contact : null;
-		return {
-			...payload,
-			// Ensure latitude and longitude are numbers or null
-			latitude:
-				typeof payload.latitude === "string"
-					? Number.parseFloat(payload.latitude)
-					: payload.latitude,
-			longitude:
-				typeof payload.longitude === "string"
-					? Number.parseFloat(payload.longitude)
-					: payload.longitude,
-			createdAt: payload.createdAt,
-			updatedAt: payload.updatedAt,
-			lastSeenAt: payload.lastSeenAt ? payload.lastSeenAt : null,
-			blockedAt: payload.blockedAt ? payload.blockedAt : null,
-			contact: payload.contact ? payload.contact : null,
-		};
-	}
-
-	private resolveVisitorId(): string {
-		if (this.visitorId) {
-			return this.visitorId;
-		}
-
-		if (this.websiteId) {
-			const storedVisitorId = getVisitorId(this.websiteId);
-			if (storedVisitorId) {
-				this.visitorId = storedVisitorId;
-				return storedVisitorId;
-			}
-		}
-
-		throw new Error("Visitor ID is required");
-	}
-
-	private async syncVisitorSnapshot(visitorId: string): Promise<void> {
-		try {
-			const visitorData = await collectVisitorData();
-			if (!visitorData) {
-				return;
-			}
-
-			const payload = Object.entries(visitorData).reduce<
-				Partial<UpdateVisitorRequest>
-			>((acc, [key, value]) => {
-				if (value === null || value === undefined) {
-					return acc;
-				}
-				(acc as Record<string, unknown>)[key] = value;
-				return acc;
-			}, {});
-
-			if (Object.keys(payload).length === 0) {
-				return;
-			}
-
-			await this.request<VisitorResponse>(`/visitors/${visitorId}`, {
-				method: "PATCH",
-				body: JSON.stringify(payload),
-				headers: {
-					"X-Visitor-Id": visitorId,
-				},
-			});
-		} catch (error) {
-			if (
-				typeof console !== "undefined" &&
-				typeof console.warn === "function"
-			) {
-				console.warn("Failed to sync visitor data", error);
-			}
-		}
-	}
-
-	private async request<T>(
-		path: string,
-		options: RequestInit = {}
-	): Promise<T> {
-		const url = `${this.config.apiUrl}${path}`;
-
-		const response = await fetch(url, {
-			...options,
-			headers: {
-				...this.baseHeaders,
-				...options.headers,
-			},
-		});
-
-		if (!response.ok) {
-			const errorData = await response.json().catch(() => ({}));
-			throw new CossistantAPIError({
-				code: errorData.code || `HTTP_${response.status}`,
-				message: errorData.message || response.statusText,
-				details: errorData.details,
-			});
-		}
-
-		return response.json();
-	}
-
-	async getWebsite(): Promise<PublicWebsiteResponse> {
-		// Make the request with visitor ID if we have one stored
-		const headers: Record<string, string> = {};
-
-		// First, check if we already know the website ID and have a visitor ID for it
-		if (this.websiteId) {
-			const storedVisitorId = getVisitorId(this.websiteId);
-			if (storedVisitorId) {
-				headers["X-Visitor-Id"] = storedVisitorId;
-			}
-		} else {
-			// We don't know the website ID yet, but check if we have any existing visitor
-			// This prevents creating duplicate visitors on page refresh
-			const existingVisitor = getExistingVisitorId(this.publicKey);
-			if (existingVisitor) {
-				headers["X-Visitor-Id"] = existingVisitor.visitorId;
-				// Pre-populate our local state
-				this.websiteId = existingVisitor.websiteId;
-				this.visitorId = existingVisitor.visitorId;
-			}
-		}
-
-		const response = await this.request<PublicWebsiteResponse>("/websites", {
-			headers,
-		});
-
-		// Store the website ID for future requests
-		this.websiteId = response.id;
-
-		// Store the visitor ID if we got one
-		if (response.visitor?.id) {
-			this.visitorId = response.visitor.id;
-			setVisitorId(response.id, response.visitor.id);
-			this.syncVisitorSnapshot(response.visitor.id);
-		}
-
-		return response;
-	}
-
-	// Manually prime website and visitor context when the caller already has it
-	setWebsiteContext(websiteId: string, visitorId?: string): void {
-		this.websiteId = websiteId;
-		if (visitorId) {
-			this.visitorId = visitorId;
-			setVisitorId(websiteId, visitorId);
-		}
-	}
-
-	getCurrentWebsiteId(): string | null {
-		return this.websiteId;
-	}
-
-	getCurrentVisitorId(): string | null {
-		if (this.visitorId) {
-			return this.visitorId;
-		}
-
-		if (!this.websiteId) {
-			return null;
-		}
-
-		return getVisitorId(this.websiteId) ?? null;
-	}
-
-	async updateVisitorMetadata(
-		metadata: VisitorMetadata
-	): Promise<VisitorResponse> {
-		const visitorId = this.resolveVisitorId();
-		const response = await this.request<VisitorResponse>(
-			`/visitors/${visitorId}/metadata`,
-			{
-				method: "PATCH",
-				body: JSON.stringify({ metadata }),
-				headers: {
-					"X-Visitor-Id": visitorId,
-				},
-			}
-		);
-
-		return this.normalizeVisitorResponse(response);
-	}
-
-	/**
-	 * Identify a visitor by creating or updating their contact information
-	 * This will link the visitor to a contact record that can be tracked across devices
-	 */
-	async identify(params: {
-		externalId?: string;
-		email?: string;
-		name?: string;
-		image?: string;
-		metadata?: Record<string, unknown>;
-		contactOrganizationId?: string;
-	}): Promise<IdentifyContactResponse> {
-		const visitorId = this.resolveVisitorId();
-
-		const response = await this.request<IdentifyContactResponse>(
-			"/contacts/identify",
-			{
-				method: "POST",
-				body: JSON.stringify({
-					visitorId,
-					...params,
-				}),
-				headers: {
-					"X-Visitor-Id": visitorId,
-				},
-			}
-		);
-
-		return {
-			contact: {
-				...response.contact,
-				// Ensure metadata is properly typed
-				metadata:
-					typeof response.contact.metadata === "string"
-						? JSON.parse(response.contact.metadata)
-						: response.contact.metadata,
-				createdAt: response.contact.createdAt,
-				updatedAt: response.contact.updatedAt,
-			},
-			visitorId: response.visitorId,
-		};
-	}
-
-	/**
-	 * Update metadata for the contact associated with the current visitor
-	 * Note: The visitor must be identified first via the identify() method
-	 */
-	async updateContactMetadata(
-		metadata: Record<string, unknown>
-	): Promise<VisitorResponse> {
-		// This still uses the visitor metadata endpoint for backward compatibility
-		// The endpoint will internally update the contact metadata
-		return this.updateVisitorMetadata(metadata as VisitorMetadata);
-	}
-
-	async createConversation(
-		params: Partial<CreateConversationRequestBody> = {}
-	): Promise<CreateConversationResponseBody> {
-		const conversationId = params.conversationId || generateConversationId();
-
-		// Get visitor ID from storage if we have the website ID, or use the provided one
-		const storedVisitorId = this.websiteId
-			? getVisitorId(this.websiteId)
-			: undefined;
-		const visitorId = params.visitorId || storedVisitorId;
-
-		if (!visitorId) {
-			throw new Error("Visitor ID is required");
-		}
-
-		const body: CreateConversationRequestBody = {
-			conversationId,
-			visitorId,
-			defaultMessages: params.defaultMessages || [],
-			channel: params.channel || "widget",
-		};
-
-		// Add visitor ID header if available
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const response = await this.request<CreateConversationResponseBody>(
-			"/conversations",
-			{
-				method: "POST",
-				body: JSON.stringify(body),
-				headers,
-			}
-		);
-
-		// Convert date strings to Date objects
-		return {
-			conversation: {
-				...response.conversation,
-				createdAt: response.conversation.createdAt,
-				updatedAt: response.conversation.updatedAt,
-				lastMessage: response.conversation.lastMessage,
-			},
-			initialMessages: response.initialMessages,
-		};
-	}
-
-	async updateConfiguration(config: Partial<CossistantConfig>): Promise<void> {
-		if (config.publicKey) {
-			this.publicKey = config.publicKey;
-			this.baseHeaders["X-Public-Key"] = config.publicKey;
-		}
-
-		if (config.userId) {
-			this.baseHeaders["X-User-ID"] = config.userId;
-		} else if (config.userId === null) {
-			const { "X-User-ID": _, ...rest } = this.baseHeaders;
-			this.baseHeaders = rest;
-		}
-
-		if (config.organizationId) {
-			this.baseHeaders["X-Organization-ID"] = config.organizationId;
-		} else if (config.organizationId === null) {
-			const { "X-Organization-ID": _, ...rest } = this.baseHeaders;
-			this.baseHeaders = rest;
-		}
-
-		this.config = { ...this.config, ...config };
-	}
-
-	async listConversations(
-		params: Partial<ListConversationsRequest> = {}
-	): Promise<ListConversationsResponse> {
-		// Get visitor ID from storage if we have the website ID, or use the provided one
-		const storedVisitorId = this.websiteId
-			? getVisitorId(this.websiteId)
-			: undefined;
-		const visitorId = params.visitorId || storedVisitorId;
-
-		if (!visitorId) {
-			throw new Error("Visitor ID is required");
-		}
-
-		// Create query parameters
-		const queryParams = new URLSearchParams();
-
-		if (visitorId) {
-			queryParams.set("visitorId", visitorId);
-		}
-
-		if (params.page) {
-			queryParams.set("page", params.page.toString());
-		}
-
-		if (params.limit) {
-			queryParams.set("limit", params.limit.toString());
-		}
-
-		if (params.status) {
-			queryParams.set("status", params.status);
-		}
-
-		if (params.orderBy) {
-			queryParams.set("orderBy", params.orderBy);
-		}
-
-		if (params.order) {
-			queryParams.set("order", params.order);
-		}
-
-		// Add visitor ID header if available
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const response = await this.request<ListConversationsResponse>(
-			`/conversations?${queryParams.toString()}`,
-			{
-				headers,
-			}
-		);
-
-		// Convert date strings to Date objects
-		return {
-			conversations: response.conversations.map((conv) => ({
-				...conv,
-				createdAt: conv.createdAt,
-				updatedAt: conv.updatedAt,
-				lastMessage: conv.lastMessage,
-			})),
-			pagination: response.pagination,
-		};
-	}
-
-	async getConversation(
-		params: GetConversationRequest
-	): Promise<GetConversationResponse> {
-		// Get visitor ID from storage if we have the website ID
-		const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
-
-		// Add visitor ID header if available
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const response = await this.request<GetConversationResponse>(
-			`/conversations/${params.conversationId}`,
-			{
-				headers,
-			}
-		);
-
-		// Convert date strings to Date objects
-		return {
-			conversation: {
-				...response.conversation,
-				createdAt: response.conversation.createdAt,
-				updatedAt: response.conversation.updatedAt,
-				lastMessage: response.conversation.lastMessage,
-			},
-		};
-	}
-
-	async markConversationSeen(
-		params: {
-			conversationId: string;
-		} & Partial<MarkConversationSeenRequestBody>
-	): Promise<MarkConversationSeenResponseBody> {
-		const storedVisitorId = this.websiteId
-			? getVisitorId(this.websiteId)
-			: undefined;
-		const visitorId = params.visitorId || storedVisitorId;
-
-		if (!visitorId) {
-			throw new Error("Visitor ID is required to mark a conversation as seen");
-		}
-
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const body: MarkConversationSeenRequestBody = {};
-		if (params.visitorId) {
-			body.visitorId = params.visitorId;
-		}
-
-		const response = await this.request<MarkConversationSeenResponseBody>(
-			`/conversations/${params.conversationId}/seen`,
-			{
-				method: "POST",
-				body: JSON.stringify(body),
-				headers,
-			}
-		);
-
-		return {
-			conversationId: response.conversationId,
-			lastSeenAt: response.lastSeenAt,
-		};
-	}
-
-	async getConversationSeenData(params: {
-		conversationId: string;
-	}): Promise<GetConversationSeenDataResponse> {
-		const response = await this.request<GetConversationSeenDataResponse>(
-			`/conversations/${params.conversationId}/seen`,
-			{
-				method: "GET",
-			}
-		);
-
-		return {
-			seenData: response.seenData.map((item) => ({
-				...item,
-				lastSeenAt: item.lastSeenAt,
-				createdAt: item.createdAt,
-				updatedAt: item.updatedAt,
-				deletedAt: item.deletedAt ? item.deletedAt : null,
-			})),
-		};
-	}
-
-	async setConversationTyping(params: {
-		conversationId: string;
-		isTyping: boolean;
-		visitorPreview?: string | null;
-		visitorId?: string;
-	}): Promise<SetConversationTypingResponseBody> {
-		const storedVisitorId = this.websiteId
-			? getVisitorId(this.websiteId)
-			: undefined;
-		const visitorId = params.visitorId || storedVisitorId;
-
-		if (!visitorId) {
-			throw new Error("Visitor ID is required to report typing state");
-		}
-
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const body: SetConversationTypingRequestBody = {
-			isTyping: params.isTyping,
-		};
-
-		if (params.visitorId) {
-			body.visitorId = params.visitorId;
-		}
-
-		if (params.visitorPreview && params.isTyping) {
-			body.visitorPreview = params.visitorPreview.slice(0, 2000);
-		}
-
-		const response = await this.request<SetConversationTypingResponseBody>(
-			`/conversations/${params.conversationId}/typing`,
-			{
-				method: "POST",
-				body: JSON.stringify(body),
-				headers,
-			}
-		);
-
-		return {
-			conversationId: response.conversationId,
-			isTyping: response.isTyping,
-			visitorPreview: response.visitorPreview,
-			sentAt: response.sentAt,
-		};
-	}
-
-	async getConversationMessages(
-		params: GetMessagesRequest
-	): Promise<GetMessagesResponse> {
-		// Get visitor ID from storage if we have the website ID
-		const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
-
-		// Create query parameters
-		const queryParams = new URLSearchParams();
-		queryParams.set("conversationId", params.conversationId);
-
-		if (params.limit) {
-			queryParams.set("limit", params.limit.toString());
-		}
-
-		if (params.cursor) {
-			queryParams.set("cursor", params.cursor);
-		}
-
-		// Add visitor ID header if available
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const response = await this.request<GetMessagesResponse>(
-			`/messages?${queryParams.toString()}`,
-			{
-				headers,
-			}
-		);
-
-		return {
-			messages: response.messages,
-			nextCursor: response.nextCursor,
-			hasNextPage: response.hasNextPage,
-		};
-	}
-
-	async sendMessage(params: SendMessageRequest): Promise<SendMessageResponse> {
-		// Get visitor ID from storage if we have the website ID
-		const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
-
-		// Add visitor ID header if available
-		const headers: Record<string, string> = {};
-		if (visitorId) {
-			headers["X-Visitor-Id"] = visitorId;
-		}
-
-		const response = await this.request<SendMessageResponse>("/messages", {
-			method: "POST",
-			body: JSON.stringify(params),
-			headers,
-		});
-
-		return {
-			message: response.message,
-		};
-	}
+  private config: CossistantConfig;
+  private baseHeaders: Record<string, string>;
+  private publicKey: string;
+  private websiteId: string | null = null;
+  private visitorId: string | null = null;
+
+  constructor(config: CossistantConfig) {
+    this.config = config;
+
+    // Get public key from config or environment variables
+    this.publicKey =
+      config.publicKey ||
+      (typeof process !== "undefined"
+        ? process.env.NEXT_PUBLIC_COSSISTANT_KEY
+        : undefined) ||
+      (typeof process !== "undefined"
+        ? process.env.COSSISTANT_PUBLIC_KEY
+        : undefined) ||
+      "";
+
+    if (!this.publicKey) {
+      throw new Error(
+        "Public key is required. Please provide it in the config or set NEXT_PUBLIC_COSSISTANT_KEY or COSSISTANT_PUBLIC_KEY environment variable.",
+      );
+    }
+
+    this.baseHeaders = {
+      "Content-Type": "application/json",
+      "X-Public-Key": this.publicKey,
+    };
+
+    if (config.userId) {
+      this.baseHeaders["X-User-ID"] = config.userId;
+    }
+
+    if (config.organizationId) {
+      this.baseHeaders["X-Organization-ID"] = config.organizationId;
+    }
+  }
+
+  private normalizeVisitorResponse(payload: VisitorResponse): VisitorResponse {
+    const contact = payload.contact ? payload.contact : null;
+    return {
+      ...payload,
+      // Ensure latitude and longitude are numbers or null
+      latitude:
+        typeof payload.latitude === "string"
+          ? Number.parseFloat(payload.latitude)
+          : payload.latitude,
+      longitude:
+        typeof payload.longitude === "string"
+          ? Number.parseFloat(payload.longitude)
+          : payload.longitude,
+      createdAt: payload.createdAt,
+      updatedAt: payload.updatedAt,
+      lastSeenAt: payload.lastSeenAt ? payload.lastSeenAt : null,
+      blockedAt: payload.blockedAt ? payload.blockedAt : null,
+      contact: payload.contact ? payload.contact : null,
+    };
+  }
+
+  private resolveVisitorId(): string {
+    if (this.visitorId) {
+      return this.visitorId;
+    }
+
+    if (this.websiteId) {
+      const storedVisitorId = getVisitorId(this.websiteId);
+      if (storedVisitorId) {
+        this.visitorId = storedVisitorId;
+        return storedVisitorId;
+      }
+    }
+
+    throw new Error("Visitor ID is required");
+  }
+
+  private async syncVisitorSnapshot(visitorId: string): Promise<void> {
+    try {
+      const visitorData = await collectVisitorData();
+      if (!visitorData) {
+        return;
+      }
+
+      const payload = Object.entries(visitorData).reduce<
+        Partial<UpdateVisitorRequest>
+      >((acc, [key, value]) => {
+        if (value === null || value === undefined) {
+          return acc;
+        }
+        (acc as Record<string, unknown>)[key] = value;
+        return acc;
+      }, {});
+
+      if (Object.keys(payload).length === 0) {
+        return;
+      }
+
+      await this.request<VisitorResponse>(`/visitors/${visitorId}`, {
+        method: "PATCH",
+        body: JSON.stringify(payload),
+        headers: {
+          "X-Visitor-Id": visitorId,
+        },
+      });
+    } catch (error) {
+      if (
+        typeof console !== "undefined" &&
+        typeof console.warn === "function"
+      ) {
+        console.warn("Failed to sync visitor data", error);
+      }
+    }
+  }
+
+  private async request<T>(
+    path: string,
+    options: RequestInit = {},
+  ): Promise<T> {
+    const url = `${this.config.apiUrl}${path}`;
+
+    const response = await fetch(url, {
+      ...options,
+      headers: {
+        ...this.baseHeaders,
+        ...options.headers,
+      },
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new CossistantAPIError({
+        code: errorData.code || `HTTP_${response.status}`,
+        message: errorData.message || response.statusText,
+        details: errorData.details,
+      });
+    }
+
+    return response.json();
+  }
+
+  async getWebsite(): Promise<PublicWebsiteResponse> {
+    // Make the request with visitor ID if we have one stored
+    const headers: Record<string, string> = {};
+
+    // First, check if we already know the website ID and have a visitor ID for it
+    if (this.websiteId) {
+      const storedVisitorId = getVisitorId(this.websiteId);
+      if (storedVisitorId) {
+        headers["X-Visitor-Id"] = storedVisitorId;
+      }
+    } else {
+      // We don't know the website ID yet, but check if we have any existing visitor
+      // This prevents creating duplicate visitors on page refresh
+      const existingVisitor = getExistingVisitorId(this.publicKey);
+      if (existingVisitor) {
+        headers["X-Visitor-Id"] = existingVisitor.visitorId;
+        // Pre-populate our local state
+        this.websiteId = existingVisitor.websiteId;
+        this.visitorId = existingVisitor.visitorId;
+      }
+    }
+
+    const response = await this.request<PublicWebsiteResponse>("/websites", {
+      headers,
+    });
+
+    // Store the website ID for future requests
+    this.websiteId = response.id;
+
+    // Store the visitor ID if we got one
+    if (response.visitor?.id) {
+      this.visitorId = response.visitor.id;
+      setVisitorId(response.id, response.visitor.id);
+      this.syncVisitorSnapshot(response.visitor.id);
+    }
+
+    return response;
+  }
+
+  // Manually prime website and visitor context when the caller already has it
+  setWebsiteContext(websiteId: string, visitorId?: string): void {
+    this.websiteId = websiteId;
+    if (visitorId) {
+      this.visitorId = visitorId;
+      setVisitorId(websiteId, visitorId);
+    }
+  }
+
+  getCurrentWebsiteId(): string | null {
+    return this.websiteId;
+  }
+
+  getCurrentVisitorId(): string | null {
+    if (this.visitorId) {
+      return this.visitorId;
+    }
+
+    if (!this.websiteId) {
+      return null;
+    }
+
+    return getVisitorId(this.websiteId) ?? null;
+  }
+
+  async updateVisitorMetadata(
+    metadata: VisitorMetadata,
+  ): Promise<VisitorResponse> {
+    const visitorId = this.resolveVisitorId();
+    const response = await this.request<VisitorResponse>(
+      `/visitors/${visitorId}/metadata`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ metadata }),
+        headers: {
+          "X-Visitor-Id": visitorId,
+        },
+      },
+    );
+
+    return this.normalizeVisitorResponse(response);
+  }
+
+  /**
+   * Identify a visitor by creating or updating their contact information
+   * This will link the visitor to a contact record that can be tracked across devices
+   */
+  async identify(params: {
+    externalId?: string;
+    email?: string;
+    name?: string;
+    image?: string;
+    metadata?: Record<string, unknown>;
+    contactOrganizationId?: string;
+  }): Promise<IdentifyContactResponse> {
+    const visitorId = this.resolveVisitorId();
+
+    const response = await this.request<IdentifyContactResponse>(
+      "/contacts/identify",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          visitorId,
+          ...params,
+        }),
+        headers: {
+          "X-Visitor-Id": visitorId,
+        },
+      },
+    );
+
+    return {
+      contact: {
+        ...response.contact,
+        // Ensure metadata is properly typed
+        metadata:
+          typeof response.contact.metadata === "string"
+            ? JSON.parse(response.contact.metadata)
+            : response.contact.metadata,
+        createdAt: response.contact.createdAt,
+        updatedAt: response.contact.updatedAt,
+      },
+      visitorId: response.visitorId,
+    };
+  }
+
+  /**
+   * Update metadata for the contact associated with the current visitor
+   * Note: The visitor must be identified first via the identify() method
+   */
+  async updateContactMetadata(
+    metadata: Record<string, unknown>,
+  ): Promise<VisitorResponse> {
+    // This still uses the visitor metadata endpoint for backward compatibility
+    // The endpoint will internally update the contact metadata
+    return this.updateVisitorMetadata(metadata as VisitorMetadata);
+  }
+
+  async createConversation(
+    params: Partial<CreateConversationRequestBody> = {},
+  ): Promise<CreateConversationResponseBody> {
+    const conversationId = params.conversationId || generateConversationId();
+
+    // Get visitor ID from storage if we have the website ID, or use the provided one
+    const storedVisitorId = this.websiteId
+      ? getVisitorId(this.websiteId)
+      : undefined;
+    const visitorId = params.visitorId || storedVisitorId;
+
+    if (!visitorId) {
+      throw new Error("Visitor ID is required");
+    }
+
+    const body: CreateConversationRequestBody = {
+      conversationId,
+      visitorId,
+      defaultMessages: params.defaultMessages || [],
+      channel: params.channel || "widget",
+    };
+
+    // Add visitor ID header if available
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<CreateConversationResponseBody>(
+      "/conversations",
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers,
+      },
+    );
+
+    // Convert date strings to Date objects
+    return {
+      conversation: {
+        ...response.conversation,
+        createdAt: response.conversation.createdAt,
+        updatedAt: response.conversation.updatedAt,
+        lastMessage: response.conversation.lastMessage,
+      },
+      initialMessages: response.initialMessages,
+    };
+  }
+
+  async updateConfiguration(config: Partial<CossistantConfig>): Promise<void> {
+    if (config.publicKey) {
+      this.publicKey = config.publicKey;
+      this.baseHeaders["X-Public-Key"] = config.publicKey;
+    }
+
+    if (config.userId) {
+      this.baseHeaders["X-User-ID"] = config.userId;
+    } else if (config.userId === null) {
+      const { "X-User-ID": _, ...rest } = this.baseHeaders;
+      this.baseHeaders = rest;
+    }
+
+    if (config.organizationId) {
+      this.baseHeaders["X-Organization-ID"] = config.organizationId;
+    } else if (config.organizationId === null) {
+      const { "X-Organization-ID": _, ...rest } = this.baseHeaders;
+      this.baseHeaders = rest;
+    }
+
+    this.config = { ...this.config, ...config };
+  }
+
+  async listConversations(
+    params: Partial<ListConversationsRequest> = {},
+  ): Promise<ListConversationsResponse> {
+    // Get visitor ID from storage if we have the website ID, or use the provided one
+    const storedVisitorId = this.websiteId
+      ? getVisitorId(this.websiteId)
+      : undefined;
+    const visitorId = params.visitorId || storedVisitorId;
+
+    if (!visitorId) {
+      throw new Error("Visitor ID is required");
+    }
+
+    // Create query parameters
+    const queryParams = new URLSearchParams();
+
+    if (visitorId) {
+      queryParams.set("visitorId", visitorId);
+    }
+
+    if (params.page) {
+      queryParams.set("page", params.page.toString());
+    }
+
+    if (params.limit) {
+      queryParams.set("limit", params.limit.toString());
+    }
+
+    if (params.status) {
+      queryParams.set("status", params.status);
+    }
+
+    if (params.orderBy) {
+      queryParams.set("orderBy", params.orderBy);
+    }
+
+    if (params.order) {
+      queryParams.set("order", params.order);
+    }
+
+    // Add visitor ID header if available
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<ListConversationsResponse>(
+      `/conversations?${queryParams.toString()}`,
+      {
+        headers,
+      },
+    );
+
+    // Convert date strings to Date objects
+    return {
+      conversations: response.conversations.map((conv) => ({
+        ...conv,
+        createdAt: conv.createdAt,
+        updatedAt: conv.updatedAt,
+        lastMessage: conv.lastMessage,
+      })),
+      pagination: response.pagination,
+    };
+  }
+
+  async getConversation(
+    params: GetConversationRequest,
+  ): Promise<GetConversationResponse> {
+    // Get visitor ID from storage if we have the website ID
+    const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
+
+    // Add visitor ID header if available
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<GetConversationResponse>(
+      `/conversations/${params.conversationId}`,
+      {
+        headers,
+      },
+    );
+
+    // Convert date strings to Date objects
+    return {
+      conversation: {
+        ...response.conversation,
+        createdAt: response.conversation.createdAt,
+        updatedAt: response.conversation.updatedAt,
+        lastMessage: response.conversation.lastMessage,
+      },
+    };
+  }
+
+  async markConversationSeen(
+    params: {
+      conversationId: string;
+    } & Partial<MarkConversationSeenRequestBody>,
+  ): Promise<MarkConversationSeenResponseBody> {
+    const storedVisitorId = this.websiteId
+      ? getVisitorId(this.websiteId)
+      : undefined;
+    const visitorId = params.visitorId || storedVisitorId;
+
+    if (!visitorId) {
+      throw new Error("Visitor ID is required to mark a conversation as seen");
+    }
+
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const body: MarkConversationSeenRequestBody = {};
+    if (params.visitorId) {
+      body.visitorId = params.visitorId;
+    }
+
+    const response = await this.request<MarkConversationSeenResponseBody>(
+      `/conversations/${params.conversationId}/seen`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers,
+      },
+    );
+
+    return {
+      conversationId: response.conversationId,
+      lastSeenAt: response.lastSeenAt,
+    };
+  }
+
+  async getConversationSeenData(params: {
+    conversationId: string;
+  }): Promise<GetConversationSeenDataResponse> {
+    const response = await this.request<GetConversationSeenDataResponse>(
+      `/conversations/${params.conversationId}/seen`,
+      {
+        method: "GET",
+      },
+    );
+
+    return {
+      seenData: response.seenData.map((item) => ({
+        ...item,
+        lastSeenAt: item.lastSeenAt,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        deletedAt: item.deletedAt ? item.deletedAt : null,
+      })),
+    };
+  }
+
+  async setConversationTyping(params: {
+    conversationId: string;
+    isTyping: boolean;
+    visitorPreview?: string | null;
+    visitorId?: string;
+  }): Promise<SetConversationTypingResponseBody> {
+    const storedVisitorId = this.websiteId
+      ? getVisitorId(this.websiteId)
+      : undefined;
+    const visitorId = params.visitorId || storedVisitorId;
+
+    if (!visitorId) {
+      throw new Error("Visitor ID is required to report typing state");
+    }
+
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const body: SetConversationTypingRequestBody = {
+      isTyping: params.isTyping,
+    };
+
+    if (params.visitorId) {
+      body.visitorId = params.visitorId;
+    }
+
+    if (params.visitorPreview && params.isTyping) {
+      body.visitorPreview = params.visitorPreview.slice(0, 2000);
+    }
+
+    const response = await this.request<SetConversationTypingResponseBody>(
+      `/conversations/${params.conversationId}/typing`,
+      {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers,
+      },
+    );
+
+    return {
+      conversationId: response.conversationId,
+      isTyping: response.isTyping,
+      visitorPreview: response.visitorPreview,
+      sentAt: response.sentAt,
+    };
+  }
+
+  async getConversationEvents(
+    params: GetConversationEventsRequest,
+  ): Promise<GetConversationEventsResponse> {
+    const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
+
+    const queryParams = new URLSearchParams();
+    queryParams.set("conversationId", params.conversationId);
+
+    if (params.limit) {
+      queryParams.set("limit", params.limit.toString());
+    }
+
+    if (params.cursor) {
+      queryParams.set("cursor", params.cursor);
+    }
+
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<GetConversationEventsResponse>(
+      `/conversations/events?${queryParams.toString()}`,
+      {
+        headers,
+      },
+    );
+
+    return {
+      events: response.events,
+      nextCursor: response.nextCursor,
+      hasNextPage: response.hasNextPage,
+    };
+  }
+
+  async getConversationMessages(
+    params: GetMessagesRequest,
+  ): Promise<GetMessagesResponse> {
+    // Get visitor ID from storage if we have the website ID
+    const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
+
+    // Create query parameters
+    const queryParams = new URLSearchParams();
+    queryParams.set("conversationId", params.conversationId);
+
+    if (params.limit) {
+      queryParams.set("limit", params.limit.toString());
+    }
+
+    if (params.cursor) {
+      queryParams.set("cursor", params.cursor);
+    }
+
+    // Add visitor ID header if available
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<GetMessagesResponse>(
+      `/messages?${queryParams.toString()}`,
+      {
+        headers,
+      },
+    );
+
+    return {
+      messages: response.messages,
+      nextCursor: response.nextCursor,
+      hasNextPage: response.hasNextPage,
+    };
+  }
+
+  async sendMessage(params: SendMessageRequest): Promise<SendMessageResponse> {
+    // Get visitor ID from storage if we have the website ID
+    const visitorId = this.websiteId ? getVisitorId(this.websiteId) : undefined;
+
+    // Add visitor ID header if available
+    const headers: Record<string, string> = {};
+    if (visitorId) {
+      headers["X-Visitor-Id"] = visitorId;
+    }
+
+    const response = await this.request<SendMessageResponse>("/messages", {
+      method: "POST",
+      body: JSON.stringify(params),
+      headers,
+    });
+
+    return {
+      message: response.message,
+    };
+  }
 }

--- a/packages/core/src/store/conversation-events-store.test.ts
+++ b/packages/core/src/store/conversation-events-store.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "bun:test";
+import type { ConversationEvent, RealtimeEvent } from "@cossistant/types";
+import { ConversationEventType } from "@cossistant/types/enums";
+import { createConversationEventsStore } from "./conversation-events-store";
+
+type ConversationEventCreatedEvent = RealtimeEvent<"conversationEventCreated">;
+
+function createMockEvent(
+  overrides: Partial<ConversationEvent> = {},
+): ConversationEvent {
+  const base: ConversationEvent = {
+    id: "evt-1",
+    conversationId: "conv-1",
+    organizationId: "org-1",
+    type: ConversationEventType.STATUS_CHANGED,
+    actorUserId: "user-1",
+    actorAiAgentId: null,
+    targetUserId: null,
+    targetAiAgentId: null,
+    message: undefined,
+    metadata: { archived: true },
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    deletedAt: null,
+  };
+
+  return { ...base, ...overrides };
+}
+
+function createRealtimeEvent(
+  overrides: Partial<ConversationEventCreatedEvent["payload"]> = {},
+): ConversationEventCreatedEvent {
+  const createdAt = overrides.event?.createdAt ?? "2024-01-02T00:00:00.000Z";
+  return {
+    type: "conversationEventCreated",
+    payload: {
+      websiteId: "site-1",
+      organizationId: "org-1",
+      conversationId: "conv-1",
+      visitorId: null,
+      userId: "user-1",
+      aiAgentId: null,
+      event: {
+        id: "evt-realtime",
+        conversationId: "conv-1",
+        organizationId: "org-1",
+        type: ConversationEventType.STATUS_CHANGED,
+        actorUserId: "user-1",
+        actorAiAgentId: null,
+        targetUserId: null,
+        targetAiAgentId: null,
+        metadata: { archived: false },
+        message: undefined,
+        createdAt,
+        updatedAt: createdAt,
+        deletedAt: null,
+        ...overrides.event,
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("conversation events store", () => {
+  it("ingests paginated events and sorts them", () => {
+    const store = createConversationEventsStore();
+    const newer = createMockEvent({
+      id: "evt-2",
+      createdAt: "2024-01-03T00:00:00.000Z",
+    });
+    const older = createMockEvent({
+      id: "evt-0",
+      createdAt: "2023-12-31T23:59:59.000Z",
+    });
+
+    store.ingestPage("conv-1", {
+      events: [newer, older],
+      hasNextPage: false,
+      nextCursor: undefined,
+    });
+
+    const events = store.getState().conversations["conv-1"]?.events ?? [];
+    expect(events.map((event) => event.id)).toEqual(["evt-0", "evt-2"]);
+  });
+
+  it("ingests realtime events", () => {
+    const store = createConversationEventsStore();
+    const realtimeEvent = createRealtimeEvent();
+
+    const normalized = store.ingestRealtime(realtimeEvent);
+
+    expect(normalized.id).toBe("evt-realtime");
+    const events = store.getState().conversations["conv-1"]?.events ?? [];
+    expect(events).toHaveLength(1);
+    expect(events[0]?.id).toBe("evt-realtime");
+  });
+
+  it("clears conversation events", () => {
+    const store = createConversationEventsStore();
+    store.ingestPage("conv-1", {
+      events: [createMockEvent()],
+      hasNextPage: false,
+      nextCursor: undefined,
+    });
+
+    expect(store.getState().conversations["conv-1"]).toBeDefined();
+
+    store.clearConversation("conv-1");
+
+    expect(store.getState().conversations["conv-1"]).toBeUndefined();
+  });
+});

--- a/packages/core/src/store/conversation-events-store.ts
+++ b/packages/core/src/store/conversation-events-store.ts
@@ -1,0 +1,244 @@
+import type { ConversationEvent, RealtimeEvent } from "@cossistant/types";
+import { createStore, type Store } from "./create-store";
+
+type ConversationEventCreatedEvent = RealtimeEvent<"conversationEventCreated">;
+
+export type ConversationEventsState = {
+  events: ConversationEvent[];
+  hasNextPage: boolean;
+  nextCursor?: string;
+};
+
+export type ConversationEventsStoreState = {
+  conversations: Record<string, ConversationEventsState>;
+};
+
+const INITIAL_STATE: ConversationEventsStoreState = {
+  conversations: {},
+};
+
+function sortEvents(events: ConversationEvent[]): ConversationEvent[] {
+  return [...events].sort((a, b) => {
+    const timeDiff =
+      new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+    if (timeDiff !== 0) {
+      return timeDiff;
+    }
+
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function isSameDate(
+  a: string | null | undefined,
+  b: string | null | undefined,
+) {
+  if (a === b) {
+    return true;
+  }
+
+  if (!(a && b)) {
+    return !(a || b);
+  }
+
+  return new Date(a).getTime() === new Date(b).getTime();
+}
+
+function isSameMetadata(
+  a?: Record<string, unknown>,
+  b?: Record<string, unknown>,
+): boolean {
+  if (a === b) {
+    return true;
+  }
+
+  if (!(a && b)) {
+    return !(a || b);
+  }
+
+  try {
+    return JSON.stringify(a) === JSON.stringify(b);
+  } catch {
+    return false;
+  }
+}
+
+function isSameEvent(a: ConversationEvent, b: ConversationEvent): boolean {
+  return (
+    a.id === b.id &&
+    a.organizationId === b.organizationId &&
+    a.conversationId === b.conversationId &&
+    a.type === b.type &&
+    a.actorUserId === b.actorUserId &&
+    a.actorAiAgentId === b.actorAiAgentId &&
+    a.targetUserId === b.targetUserId &&
+    a.targetAiAgentId === b.targetAiAgentId &&
+    a.message === b.message &&
+    isSameMetadata(a.metadata, b.metadata) &&
+    isSameDate(a.createdAt, b.createdAt) &&
+    isSameDate(a.updatedAt, b.updatedAt) &&
+    isSameDate(a.deletedAt, b.deletedAt)
+  );
+}
+
+function mergeEvents(
+  existing: ConversationEvent[],
+  incoming: ConversationEvent[],
+): ConversationEvent[] {
+  if (incoming.length === 0) {
+    return existing;
+  }
+
+  const byId = new Map<string, ConversationEvent>();
+  for (const event of existing) {
+    byId.set(event.id, event);
+  }
+
+  let changed = false;
+  for (const event of incoming) {
+    const previous = byId.get(event.id);
+    if (!(previous && isSameEvent(previous, event))) {
+      changed = true;
+    }
+    byId.set(event.id, event);
+  }
+
+  if (!changed && byId.size === existing.length) {
+    let stable = true;
+    for (const event of existing) {
+      if (byId.get(event.id) !== event) {
+        stable = false;
+        break;
+      }
+    }
+
+    if (stable) {
+      return existing;
+    }
+  }
+
+  return sortEvents(Array.from(byId.values()));
+}
+
+function applyPage(
+  state: ConversationEventsStoreState,
+  conversationId: string,
+  page: Pick<ConversationEventsState, "events" | "hasNextPage" | "nextCursor">,
+): ConversationEventsStoreState {
+  const existing = state.conversations[conversationId];
+  const mergedEvents = mergeEvents(existing?.events ?? [], page.events);
+
+  if (
+    existing &&
+    existing.events === mergedEvents &&
+    existing.hasNextPage === page.hasNextPage &&
+    existing.nextCursor === page.nextCursor
+  ) {
+    return state;
+  }
+
+  return {
+    ...state,
+    conversations: {
+      ...state.conversations,
+      [conversationId]: {
+        events: mergedEvents,
+        hasNextPage: page.hasNextPage,
+        nextCursor: page.nextCursor,
+      },
+    },
+  };
+}
+
+function applyEvent(
+  state: ConversationEventsStoreState,
+  event: ConversationEvent,
+): ConversationEventsStoreState {
+  const existing = state.conversations[event.conversationId];
+  const mergedEvents = mergeEvents(existing?.events ?? [], [event]);
+
+  if (existing && existing.events === mergedEvents) {
+    return state;
+  }
+
+  return {
+    ...state,
+    conversations: {
+      ...state.conversations,
+      [event.conversationId]: {
+        events: mergedEvents,
+        hasNextPage: existing?.hasNextPage ?? false,
+        nextCursor: existing?.nextCursor,
+      },
+    },
+  };
+}
+
+function removeConversation(
+  state: ConversationEventsStoreState,
+  conversationId: string,
+): ConversationEventsStoreState {
+  if (!state.conversations[conversationId]) {
+    return state;
+  }
+
+  const { [conversationId]: _removed, ...rest } = state.conversations;
+
+  return {
+    ...state,
+    conversations: rest,
+  };
+}
+
+function normalizeRealtimeEvent(
+  event: ConversationEventCreatedEvent,
+): ConversationEvent {
+  const raw = event.payload.event;
+  return {
+    id: raw.id,
+    conversationId: raw.conversationId,
+    organizationId: raw.organizationId,
+    type: raw.type as ConversationEvent["type"],
+    actorUserId: raw.actorUserId ?? null,
+    actorAiAgentId: raw.actorAiAgentId ?? null,
+    targetUserId: raw.targetUserId ?? null,
+    targetAiAgentId: raw.targetAiAgentId ?? null,
+    message: raw.message ?? undefined,
+    metadata: raw.metadata
+      ? (raw.metadata as Record<string, unknown>)
+      : undefined,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt ?? raw.createdAt,
+    deletedAt: raw.deletedAt ?? null,
+  };
+}
+
+export type ConversationEventsStore = Store<ConversationEventsStoreState> & {
+  ingestPage(conversationId: string, page: ConversationEventsState): void;
+  ingestEvent(conversationId: string, event: ConversationEvent): void;
+  ingestRealtime(event: ConversationEventCreatedEvent): ConversationEvent;
+  clearConversation(conversationId: string): void;
+};
+
+export function createConversationEventsStore(): ConversationEventsStore {
+  const store = createStore<ConversationEventsStoreState>(INITIAL_STATE);
+
+  return {
+    ...store,
+    ingestPage(conversationId, page) {
+      store.setState((state) => applyPage(state, conversationId, page));
+    },
+    ingestEvent(_conversationId, event) {
+      store.setState((state) => applyEvent(state, event));
+    },
+    ingestRealtime(event) {
+      const normalized = normalizeRealtimeEvent(event);
+      store.setState((state) => applyEvent(state, normalized));
+
+      return normalized;
+    },
+    clearConversation(conversationId) {
+      store.setState((state) => removeConversation(state, conversationId));
+    },
+  };
+}

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from "./private/use-multimodal-input";
 export * from "./private/use-rest-client";
 export * from "./use-conversation";
 export * from "./use-conversation-auto-seen";
+export * from "./use-conversation-events";
 export * from "./use-conversation-history-page";
 export * from "./use-conversation-lifecycle";
 export * from "./use-conversation-messages";

--- a/packages/react/src/hooks/use-conversation-events.ts
+++ b/packages/react/src/hooks/use-conversation-events.ts
@@ -1,0 +1,108 @@
+import type { ConversationEventsState } from "@cossistant/core";
+import type {
+  GetConversationEventsRequest,
+  GetConversationEventsResponse,
+} from "@cossistant/types/api/conversation";
+import { useCallback, useMemo } from "react";
+import { useSupport } from "../provider";
+import { useStoreSelector } from "./private/store/use-store-selector";
+import { useClientQuery } from "./private/use-client-query";
+
+const EMPTY_STATE: ConversationEventsState = {
+  events: [],
+  hasNextPage: false,
+  nextCursor: undefined,
+};
+
+const DEFAULT_LIMIT = 50;
+
+export type UseConversationEventsOptions = {
+  limit?: number;
+  cursor?: string | null;
+  enabled?: boolean;
+  refetchInterval?: number | false;
+  refetchOnWindowFocus?: boolean;
+};
+
+export type UseConversationEventsResult = ConversationEventsState & {
+  isLoading: boolean;
+  error: Error | null;
+  refetch: (
+    args?: Pick<GetConversationEventsRequest, "cursor" | "limit">,
+  ) => Promise<GetConversationEventsResponse | undefined>;
+  fetchNextPage: () => Promise<GetConversationEventsResponse | undefined>;
+};
+
+export function useConversationEvents(
+  conversationId: string,
+  options: UseConversationEventsOptions = {},
+): UseConversationEventsResult {
+  const { client } = useSupport();
+  const store = client.conversationEventsStore;
+
+  const selection = useStoreSelector(store, (state) => {
+    return state.conversations[conversationId] ?? EMPTY_STATE;
+  });
+
+  const baseArgs = useMemo(() => {
+    return {
+      limit: options.limit ?? DEFAULT_LIMIT,
+      cursor: options.cursor ?? undefined,
+    } satisfies Pick<GetConversationEventsRequest, "limit" | "cursor">;
+  }, [options.cursor, options.limit]);
+
+  const {
+    refetch: queryRefetch,
+    isLoading: queryLoading,
+    error,
+  } = useClientQuery<
+    GetConversationEventsResponse,
+    Pick<GetConversationEventsRequest, "cursor" | "limit">
+  >({
+    client,
+    queryFn: (instance, args) =>
+      instance.getConversationEvents({
+        conversationId,
+        limit: args?.limit ?? baseArgs.limit,
+        cursor: args?.cursor ?? baseArgs.cursor,
+      }),
+    enabled: options.enabled ?? true,
+    refetchInterval: options.refetchInterval ?? false,
+    refetchOnWindowFocus: options.refetchOnWindowFocus ?? true,
+    refetchOnMount: selection.events.length === 0,
+    initialArgs: baseArgs,
+    dependencies: [conversationId, baseArgs.limit, baseArgs.cursor ?? null],
+  });
+
+  const refetch = useCallback(
+    (args?: Pick<GetConversationEventsRequest, "cursor" | "limit">) => {
+      return queryRefetch({
+        limit: baseArgs.limit,
+        cursor: baseArgs.cursor,
+        ...args,
+      });
+    },
+    [queryRefetch, baseArgs],
+  );
+
+  const fetchNextPage = useCallback(() => {
+    if (!(selection.hasNextPage && selection.nextCursor)) {
+      return Promise.resolve(undefined);
+    }
+
+    return refetch({ cursor: selection.nextCursor });
+  }, [selection.hasNextPage, selection.nextCursor, refetch]);
+
+  const isInitialLoad = selection.events.length === 0;
+  const isLoading = isInitialLoad ? queryLoading : false;
+
+  return {
+    events: selection.events,
+    hasNextPage: selection.hasNextPage,
+    nextCursor: selection.nextCursor,
+    isLoading,
+    error,
+    refetch,
+    fetchNextPage,
+  };
+}

--- a/packages/react/src/hooks/use-conversation-page.ts
+++ b/packages/react/src/hooks/use-conversation-page.ts
@@ -3,63 +3,64 @@ import { useEffect, useMemo, useRef } from "react";
 import { useSupport } from "../provider";
 import { useDefaultMessages } from "./private/use-default-messages";
 import { useConversationAutoSeen } from "./use-conversation-auto-seen";
+import { useConversationEvents } from "./use-conversation-events";
 import { useConversationLifecycle } from "./use-conversation-lifecycle";
 import { useConversationMessages } from "./use-conversation-messages";
 import { useMessageComposer } from "./use-message-composer";
 
 export type UseConversationPageOptions = {
-	/**
-	 * Initial conversation ID (from URL params, navigation state, etc.)
-	 * Can be PENDING_CONVERSATION_ID or a real ID.
-	 */
-	conversationId: string;
+  /**
+   * Initial conversation ID (from URL params, navigation state, etc.)
+   * Can be PENDING_CONVERSATION_ID or a real ID.
+   */
+  conversationId: string;
 
-	/**
-	 * Optional initial message to send when the conversation opens.
-	 */
-	initialMessage?: string;
+  /**
+   * Optional initial message to send when the conversation opens.
+   */
+  initialMessage?: string;
 
-	/**
-	 * Callback when conversation ID changes (e.g., after creation).
-	 * Use this to update navigation state or URL.
-	 */
-	onConversationIdChange?: (conversationId: string) => void;
+  /**
+   * Callback when conversation ID changes (e.g., after creation).
+   * Use this to update navigation state or URL.
+   */
+  onConversationIdChange?: (conversationId: string) => void;
 
-	/**
-	 * Optional messages to pass through (e.g., optimistic updates).
-	 */
-	messages?: Message[];
+  /**
+   * Optional messages to pass through (e.g., optimistic updates).
+   */
+  messages?: Message[];
 
-	/**
-	 * Optional events to pass through.
-	 */
-	events?: ConversationEvent[];
+  /**
+   * Optional events to pass through.
+   */
+  events?: ConversationEvent[];
 };
 
 export type UseConversationPageReturn = {
-	// Conversation state
-	conversationId: string;
-	isPending: boolean;
-	messages: Message[];
-	events: ConversationEvent[];
-	isLoading: boolean;
-	error: Error | null;
+  // Conversation state
+  conversationId: string;
+  isPending: boolean;
+  messages: Message[];
+  events: ConversationEvent[];
+  isLoading: boolean;
+  error: Error | null;
 
-	// Message composer
-	composer: {
-		message: string;
-		files: File[];
-		isSubmitting: boolean;
-		canSubmit: boolean;
-		setMessage: (message: string) => void;
-		addFiles: (files: File[]) => void;
-		removeFile: (index: number) => void;
-		submit: () => void;
-	};
+  // Message composer
+  composer: {
+    message: string;
+    files: File[];
+    isSubmitting: boolean;
+    canSubmit: boolean;
+    setMessage: (message: string) => void;
+    addFiles: (files: File[]) => void;
+    removeFile: (index: number) => void;
+    submit: () => void;
+  };
 
-	// UI helpers
-	hasMessages: boolean;
-	lastMessage: Message | null;
+  // UI helpers
+  hasMessages: boolean;
+  lastMessage: Message | null;
 };
 
 /**
@@ -99,154 +100,169 @@ export type UseConversationPageReturn = {
  * ```
  */
 export function useConversationPage(
-	options: UseConversationPageOptions
+  options: UseConversationPageOptions,
 ): UseConversationPageReturn {
-	const {
-		conversationId: initialConversationId,
-		initialMessage,
-		onConversationIdChange,
-		messages: passedMessages = [],
-		events: passedEvents = [],
-	} = options;
+  const {
+    conversationId: initialConversationId,
+    initialMessage,
+    onConversationIdChange,
+    messages: passedMessages = [],
+    events: passedEvents = [],
+  } = options;
 
-	const { client, visitor } = useSupport();
+  const { client, visitor } = useSupport();
 
-	const trimmedInitialMessage = initialMessage?.trim() ?? "";
-	const hasInitialMessage = trimmedInitialMessage.length > 0;
+  const trimmedInitialMessage = initialMessage?.trim() ?? "";
+  const hasInitialMessage = trimmedInitialMessage.length > 0;
 
-	// 1. Manage conversation lifecycle (pending vs real)
-	const lifecycle = useConversationLifecycle({
-		initialConversationId,
-		onConversationCreated: onConversationIdChange,
-	});
+  // 1. Manage conversation lifecycle (pending vs real)
+  const lifecycle = useConversationLifecycle({
+    initialConversationId,
+    onConversationCreated: onConversationIdChange,
+  });
 
-	// 2. Get default messages for pending state
-	const defaultMessages = useDefaultMessages({
-		conversationId: lifecycle.conversationId,
-	});
+  // 2. Get default messages for pending state
+  const defaultMessages = useDefaultMessages({
+    conversationId: lifecycle.conversationId,
+  });
 
-	const effectiveDefaultMessages = hasInitialMessage ? [] : defaultMessages;
+  const effectiveDefaultMessages = hasInitialMessage ? [] : defaultMessages;
 
-	// 3. Fetch messages from backend if real conversation exists
-	const messagesQuery = useConversationMessages(lifecycle.conversationId, {
-		enabled: !lifecycle.isPending,
-	});
+  // 3. Fetch messages from backend if real conversation exists
+  const messagesQuery = useConversationMessages(lifecycle.conversationId, {
+    enabled: !lifecycle.isPending,
+  });
+  const eventsQuery = useConversationEvents(lifecycle.conversationId, {
+    enabled: !lifecycle.isPending,
+  });
 
-	// 4. Determine which messages to display
-	const displayMessages = useMemo(() => {
-		// If we have fetched messages, use them
-		if (messagesQuery.messages.length > 0) {
-			return messagesQuery.messages;
-		}
+  // 4. Determine which messages to display
+  const displayMessages = useMemo(() => {
+    // If we have fetched messages, use them
+    if (messagesQuery.messages.length > 0) {
+      return messagesQuery.messages;
+    }
 
-		// If real conversation but no fetched messages yet, use passed messages
-		if (!lifecycle.isPending && passedMessages.length > 0) {
-			return passedMessages;
-		}
+    // If real conversation but no fetched messages yet, use passed messages
+    if (!lifecycle.isPending && passedMessages.length > 0) {
+      return passedMessages;
+    }
 
-		// If pending, show default/welcome messages
-		if (lifecycle.isPending) {
-			return effectiveDefaultMessages;
-		}
+    // If pending, show default/welcome messages
+    if (lifecycle.isPending) {
+      return effectiveDefaultMessages;
+    }
 
-		// Fallback to empty
-		return [];
-	}, [
-		messagesQuery.messages,
-		lifecycle.isPending,
-		passedMessages,
-		effectiveDefaultMessages,
-	]);
+    // Fallback to empty
+    return [];
+  }, [
+    messagesQuery.messages,
+    lifecycle.isPending,
+    passedMessages,
+    effectiveDefaultMessages,
+  ]);
 
-	const lastMessage = useMemo(
-		() => displayMessages.at(-1) ?? null,
-		[displayMessages]
-	);
+  const displayEvents = useMemo(() => {
+    if (eventsQuery.events.length > 0) {
+      return eventsQuery.events;
+    }
 
-	// 5. Set up message composer
-	const composer = useMessageComposer({
-		client,
-		conversationId: lifecycle.realConversationId,
-		defaultMessages: effectiveDefaultMessages,
-		visitorId: visitor?.id,
-		onMessageSent: (newConversationId) => {
-			// Transition from pending to real conversation
-			if (lifecycle.isPending) {
-				lifecycle.setConversationId(newConversationId);
-			}
-		},
-	});
+    if (!lifecycle.isPending && passedEvents.length > 0) {
+      return passedEvents;
+    }
 
-	const initialMessageSubmittedRef = useRef(false);
-	const lastInitialMessageRef = useRef<string | null>(null);
+    return [];
+  }, [eventsQuery.events, lifecycle.isPending, passedEvents]);
 
-	useEffect(() => {
-		if (!hasInitialMessage) {
-			initialMessageSubmittedRef.current = false;
-			lastInitialMessageRef.current = null;
-			return;
-		}
+  const lastMessage = useMemo(
+    () => displayMessages.at(-1) ?? null,
+    [displayMessages],
+  );
 
-		if (lastInitialMessageRef.current !== trimmedInitialMessage) {
-			initialMessageSubmittedRef.current = false;
-			lastInitialMessageRef.current = trimmedInitialMessage;
-		}
+  // 5. Set up message composer
+  const composer = useMessageComposer({
+    client,
+    conversationId: lifecycle.realConversationId,
+    defaultMessages: effectiveDefaultMessages,
+    visitorId: visitor?.id,
+    onMessageSent: (newConversationId) => {
+      // Transition from pending to real conversation
+      if (lifecycle.isPending) {
+        lifecycle.setConversationId(newConversationId);
+      }
+    },
+  });
 
-		if (!lifecycle.isPending) {
-			return;
-		}
+  const initialMessageSubmittedRef = useRef(false);
+  const lastInitialMessageRef = useRef<string | null>(null);
 
-		if (composer.message !== trimmedInitialMessage) {
-			composer.setMessage(trimmedInitialMessage);
-			return;
-		}
+  useEffect(() => {
+    if (!hasInitialMessage) {
+      initialMessageSubmittedRef.current = false;
+      lastInitialMessageRef.current = null;
+      return;
+    }
 
-		if (
-			initialMessageSubmittedRef.current ||
-			composer.isSubmitting ||
-			!composer.canSubmit
-		) {
-			return;
-		}
+    if (lastInitialMessageRef.current !== trimmedInitialMessage) {
+      initialMessageSubmittedRef.current = false;
+      lastInitialMessageRef.current = trimmedInitialMessage;
+    }
 
-		initialMessageSubmittedRef.current = true;
-		composer.submit();
-	}, [
-		hasInitialMessage,
-		lifecycle.isPending,
-		composer.message,
-		composer.setMessage,
-		composer.isSubmitting,
-		composer.canSubmit,
-		composer.submit,
-		trimmedInitialMessage,
-	]);
-	// 6. Auto-mark messages as seen
-	useConversationAutoSeen({
-		client,
-		conversationId: lifecycle.realConversationId,
-		visitorId: visitor?.id,
-		lastMessage,
-	});
+    if (!lifecycle.isPending) {
+      return;
+    }
 
-	return {
-		conversationId: lifecycle.conversationId,
-		isPending: lifecycle.isPending,
-		messages: displayMessages,
-		events: passedEvents,
-		isLoading: messagesQuery.isLoading,
-		error: messagesQuery.error || composer.error,
-		composer: {
-			message: composer.message,
-			files: composer.files,
-			isSubmitting: composer.isSubmitting,
-			canSubmit: composer.canSubmit,
-			setMessage: composer.setMessage,
-			addFiles: composer.addFiles,
-			removeFile: composer.removeFile,
-			submit: composer.submit,
-		},
-		hasMessages: displayMessages.length > 0,
-		lastMessage,
-	};
+    if (composer.message !== trimmedInitialMessage) {
+      composer.setMessage(trimmedInitialMessage);
+      return;
+    }
+
+    if (
+      initialMessageSubmittedRef.current ||
+      composer.isSubmitting ||
+      !composer.canSubmit
+    ) {
+      return;
+    }
+
+    initialMessageSubmittedRef.current = true;
+    composer.submit();
+  }, [
+    hasInitialMessage,
+    lifecycle.isPending,
+    composer.message,
+    composer.setMessage,
+    composer.isSubmitting,
+    composer.canSubmit,
+    composer.submit,
+    trimmedInitialMessage,
+  ]);
+  // 6. Auto-mark messages as seen
+  useConversationAutoSeen({
+    client,
+    conversationId: lifecycle.realConversationId,
+    visitorId: visitor?.id,
+    lastMessage,
+  });
+
+  return {
+    conversationId: lifecycle.conversationId,
+    isPending: lifecycle.isPending,
+    messages: displayMessages,
+    events: displayEvents,
+    isLoading: messagesQuery.isLoading || eventsQuery.isLoading,
+    error: messagesQuery.error || eventsQuery.error || composer.error,
+    composer: {
+      message: composer.message,
+      files: composer.files,
+      isSubmitting: composer.isSubmitting,
+      canSubmit: composer.canSubmit,
+      setMessage: composer.setMessage,
+      addFiles: composer.addFiles,
+      removeFile: composer.removeFile,
+      submit: composer.submit,
+    },
+    hasMessages: displayMessages.length > 0,
+    lastMessage,
+  };
 }

--- a/packages/react/src/realtime/support-provider.tsx
+++ b/packages/react/src/realtime/support-provider.tsx
@@ -5,19 +5,19 @@ import { useMemo } from "react";
 import { useSupport } from "../provider";
 import { applyConversationSeenEvent } from "./seen-store";
 import {
-	applyConversationTypingEvent,
-	clearTypingFromMessage,
+  applyConversationTypingEvent,
+  clearTypingFromMessage,
 } from "./typing-store";
 import { useRealtime } from "./use-realtime";
 
 type SupportRealtimeContext = {
-	websiteId: string | null;
-	visitorId: string | null;
-	client: CossistantClient;
+  websiteId: string | null;
+  visitorId: string | null;
+  client: CossistantClient;
 };
 
 type SupportRealtimeProviderProps = {
-	children: React.ReactNode;
+  children: React.ReactNode;
 };
 
 /**
@@ -25,98 +25,117 @@ type SupportRealtimeProviderProps = {
  * in sync without forcing refetches.
  */
 export function SupportRealtimeProvider({
-	children,
+  children,
 }: SupportRealtimeProviderProps) {
-	const { website, client, visitor } = useSupport();
+  const { website, client, visitor } = useSupport();
 
-	const realtimeContext = useMemo<SupportRealtimeContext>(
-		() => ({
-			websiteId: website?.id ?? null,
-			visitorId: visitor?.id ?? null,
-			client,
-		}),
-		[website?.id, visitor?.id, client]
-	);
+  const realtimeContext = useMemo<SupportRealtimeContext>(
+    () => ({
+      websiteId: website?.id ?? null,
+      visitorId: visitor?.id ?? null,
+      client,
+    }),
+    [website?.id, visitor?.id, client],
+  );
 
-	const events = useMemo(
-		() => ({
-			messageCreated: (
-				_data: unknown,
-				{
-					event,
-					context,
-				}: {
-					event: RealtimeEvent<"messageCreated">;
-					context: SupportRealtimeContext;
-				}
-			) => {
-				if (
-					context.websiteId &&
-					event.payload.websiteId !== context.websiteId
-				) {
-					return;
-				}
+  const events = useMemo(
+    () => ({
+      messageCreated: (
+        _data: unknown,
+        {
+          event,
+          context,
+        }: {
+          event: RealtimeEvent<"messageCreated">;
+          context: SupportRealtimeContext;
+        },
+      ) => {
+        if (
+          context.websiteId &&
+          event.payload.websiteId !== context.websiteId
+        ) {
+          return;
+        }
 
-				// Clear typing state when a message is sent
-				clearTypingFromMessage(event);
+        // Clear typing state when a message is sent
+        clearTypingFromMessage(event);
 
-				context.client.handleRealtimeEvent(event);
-			},
-			conversationSeen: (
-				_data: unknown,
-				{
-					event,
-					context,
-				}: {
-					event: RealtimeEvent<"conversationSeen">;
-					context: SupportRealtimeContext;
-				}
-			) => {
-				if (
-					context.websiteId &&
-					event.payload.websiteId !== context.websiteId
-				) {
-					return;
-				}
+        context.client.handleRealtimeEvent(event);
+      },
+      conversationEventCreated: (
+        _data: unknown,
+        {
+          event,
+          context,
+        }: {
+          event: RealtimeEvent<"conversationEventCreated">;
+          context: SupportRealtimeContext;
+        },
+      ) => {
+        if (
+          context.websiteId &&
+          event.payload.websiteId !== context.websiteId
+        ) {
+          return;
+        }
 
-				// Update the seen store so the UI reflects who has seen messages
-				applyConversationSeenEvent(event);
-			},
-			conversationTyping: (
-				_data: unknown,
-				{
-					event,
-					context,
-				}: {
-					event: RealtimeEvent<"conversationTyping">;
-					context: SupportRealtimeContext;
-				}
-			) => {
-				if (
-					context.websiteId &&
-					event.payload.websiteId !== context.websiteId
-				) {
-					return;
-				}
+        context.client.handleRealtimeEvent(event);
+      },
+      conversationSeen: (
+        _data: unknown,
+        {
+          event,
+          context,
+        }: {
+          event: RealtimeEvent<"conversationSeen">;
+          context: SupportRealtimeContext;
+        },
+      ) => {
+        if (
+          context.websiteId &&
+          event.payload.websiteId !== context.websiteId
+        ) {
+          return;
+        }
 
-				// Update typing store, but ignore events from the current visitor (their own typing)
-				// Note: We use context.visitorId which is fresh from the context object
-				applyConversationTypingEvent(event, {
-					ignoreVisitorId: context.visitorId,
-				});
-			},
-		}),
-		// Empty dependencies is fine here since we use the context parameter
-		// which always has fresh data from the memoized realtimeContext
-		[]
-	);
+        // Update the seen store so the UI reflects who has seen messages
+        applyConversationSeenEvent(event);
+      },
+      conversationTyping: (
+        _data: unknown,
+        {
+          event,
+          context,
+        }: {
+          event: RealtimeEvent<"conversationTyping">;
+          context: SupportRealtimeContext;
+        },
+      ) => {
+        if (
+          context.websiteId &&
+          event.payload.websiteId !== context.websiteId
+        ) {
+          return;
+        }
 
-	useRealtime<SupportRealtimeContext>({
-		context: realtimeContext,
-		events,
-		websiteId: realtimeContext.websiteId,
-		visitorId: website?.visitor?.id ?? null,
-	});
+        // Update typing store, but ignore events from the current visitor (their own typing)
+        // Note: We use context.visitorId which is fresh from the context object
+        applyConversationTypingEvent(event, {
+          ignoreVisitorId: context.visitorId,
+        });
+      },
+    }),
+    // Empty dependencies is fine here since we use the context parameter
+    // which always has fresh data from the memoized realtimeContext
+    [],
+  );
 
-	return <>{children}</>;
+  useRealtime<SupportRealtimeContext>({
+    context: realtimeContext,
+    events,
+    websiteId: realtimeContext.websiteId,
+    visitorId: website?.visitor?.id ?? null,
+  });
+
+  return <>{children}</>;
 }

--- a/packages/types/src/api/conversation.ts
+++ b/packages/types/src/api/conversation.ts
@@ -108,15 +108,60 @@ export type GetConversationRequest = z.infer<
 >;
 
 export const getConversationResponseSchema = z
-	.object({
-		conversation: conversationSchema,
-	})
-	.openapi({
-		description: "Response containing a single conversation",
-	});
+.object({
+conversation: conversationSchema,
+})
+.openapi({
+description: "Response containing a single conversation",
+});
 
 export type GetConversationResponse = z.infer<
-	typeof getConversationResponseSchema
+typeof getConversationResponseSchema
+>;
+
+export const getConversationEventsRequestSchema = z
+.object({
+conversationId: z.string().openapi({
+description: "The ID of the conversation to retrieve events for",
+}),
+limit: z
+.coerce.number()
+.int()
+.min(1)
+.max(100)
+.optional()
+.openapi({
+description: "Maximum number of events to return",
+example: 50,
+}),
+cursor: z
+.string()
+.nullish()
+.openapi({
+description:
+"Cursor for pagination. Use the nextCursor value from the previous response.",
+}),
+})
+.openapi({
+description: "Query parameters for listing conversation timeline events",
+});
+
+export type GetConversationEventsRequest = z.infer<
+typeof getConversationEventsRequestSchema
+>;
+
+export const getConversationEventsResponseSchema = z
+.object({
+events: z.array(conversationEventSchema),
+nextCursor: z.string().nullable(),
+hasNextPage: z.boolean(),
+})
+.openapi({
+description: "Paginated response containing conversation events",
+});
+
+export type GetConversationEventsResponse = z.infer<
+typeof getConversationEventsResponseSchema
 >;
 
 export const markConversationSeenRequestSchema = z

--- a/packages/types/src/realtime-events.ts
+++ b/packages/types/src/realtime-events.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 import { MessageType, MessageVisibility } from "./enums";
-import { conversationSchema } from "./schemas";
+import { conversationEventSchema, conversationSchema } from "./schemas";
 import { conversationHeaderSchema } from "./trpc/conversation";
 
 export const baseRealtimeEvent = z.object({
-	websiteId: z.string(),
-	organizationId: z.string(),
-	visitorId: z.string().nullable(),
-	userId: z.string().nullable(),
+  websiteId: z.string(),
+  organizationId: z.string(),
+  visitorId: z.string().nullable(),
+  userId: z.string().nullable(),
 });
 
 /**
@@ -15,113 +15,106 @@ export const baseRealtimeEvent = z.object({
  * All WebSocket and Redis Pub/Sub events are defined here
  */
 export const realtimeSchema = {
-	userConnected: baseRealtimeEvent.extend({
-		connectionId: z.string(),
-	}),
-	userDisconnected: baseRealtimeEvent.extend({
-		connectionId: z.string(),
-	}),
-	visitorConnected: baseRealtimeEvent.extend({
-		visitorId: z.string(),
-		connectionId: z.string(),
-	}),
-	visitorDisconnected: baseRealtimeEvent.extend({
-		visitorId: z.string(),
-		connectionId: z.string(),
-	}),
-	userPresenceUpdate: baseRealtimeEvent.extend({
-		userId: z.string(),
-		status: z.enum(["online", "away", "offline"]),
-		lastSeen: z.string(),
-	}),
-	conversationSeen: baseRealtimeEvent.extend({
-		conversationId: z.string(),
-		aiAgentId: z.string().nullable(),
-		lastSeenAt: z.string(),
-	}),
-	conversationTyping: baseRealtimeEvent.extend({
-		conversationId: z.string(),
-		aiAgentId: z.string().nullable(),
-		isTyping: z.boolean(),
-		visitorPreview: z.string().max(2000).nullable().optional(),
-	}),
-	conversationEventCreated: baseRealtimeEvent.extend({
-		conversationId: z.string(),
-		aiAgentId: z.string().nullable(),
-		event: z.object({
-			id: z.string(),
-			conversationId: z.string(),
-			organizationId: z.string(),
-			type: z.string(),
-			actorUserId: z.string().nullable(),
-			actorAiAgentId: z.string().nullable(),
-		}),
-	}),
-	messageCreated: baseRealtimeEvent.extend({
-		message: z.object({
-			id: z.string(),
-			bodyMd: z.string(),
-			type: z.enum([MessageType.TEXT, MessageType.IMAGE, MessageType.FILE]),
-			userId: z.string().nullable(),
-			visitorId: z.string().nullable(),
-			organizationId: z.string(),
-			websiteId: z.string(),
-			conversationId: z.string(),
-			parentMessageId: z.string().nullable(),
-			aiAgentId: z.string().nullable(),
-			modelUsed: z.string().nullable(),
-			visibility: z.enum([MessageVisibility.PUBLIC, MessageVisibility.PRIVATE]),
-			createdAt: z.string(),
-			updatedAt: z.string(),
-			deletedAt: z.string().nullable(),
-		}),
-		conversationId: z.string(),
-	}),
-	conversationCreated: baseRealtimeEvent.extend({
-		conversationId: z.string(),
-		conversation: conversationSchema,
-		header: conversationHeaderSchema,
-	}),
+  userConnected: baseRealtimeEvent.extend({
+    connectionId: z.string(),
+  }),
+  userDisconnected: baseRealtimeEvent.extend({
+    connectionId: z.string(),
+  }),
+  visitorConnected: baseRealtimeEvent.extend({
+    visitorId: z.string(),
+    connectionId: z.string(),
+  }),
+  visitorDisconnected: baseRealtimeEvent.extend({
+    visitorId: z.string(),
+    connectionId: z.string(),
+  }),
+  userPresenceUpdate: baseRealtimeEvent.extend({
+    userId: z.string(),
+    status: z.enum(["online", "away", "offline"]),
+    lastSeen: z.string(),
+  }),
+  conversationSeen: baseRealtimeEvent.extend({
+    conversationId: z.string(),
+    aiAgentId: z.string().nullable(),
+    lastSeenAt: z.string(),
+  }),
+  conversationTyping: baseRealtimeEvent.extend({
+    conversationId: z.string(),
+    aiAgentId: z.string().nullable(),
+    isTyping: z.boolean(),
+    visitorPreview: z.string().max(2000).nullable().optional(),
+  }),
+  conversationEventCreated: baseRealtimeEvent.extend({
+    conversationId: z.string(),
+    aiAgentId: z.string().nullable(),
+    event: conversationEventSchema,
+  }),
+  messageCreated: baseRealtimeEvent.extend({
+    message: z.object({
+      id: z.string(),
+      bodyMd: z.string(),
+      type: z.enum([MessageType.TEXT, MessageType.IMAGE, MessageType.FILE]),
+      userId: z.string().nullable(),
+      visitorId: z.string().nullable(),
+      organizationId: z.string(),
+      websiteId: z.string(),
+      conversationId: z.string(),
+      parentMessageId: z.string().nullable(),
+      aiAgentId: z.string().nullable(),
+      modelUsed: z.string().nullable(),
+      visibility: z.enum([MessageVisibility.PUBLIC, MessageVisibility.PRIVATE]),
+      createdAt: z.string(),
+      updatedAt: z.string(),
+      deletedAt: z.string().nullable(),
+    }),
+    conversationId: z.string(),
+  }),
+  conversationCreated: baseRealtimeEvent.extend({
+    conversationId: z.string(),
+    conversation: conversationSchema,
+    header: conversationHeaderSchema,
+  }),
 } as const;
 
 export type RealtimeEventType = keyof typeof realtimeSchema;
 
 export type RealtimeEventPayload<T extends RealtimeEventType> = z.infer<
-	(typeof realtimeSchema)[T]
+  (typeof realtimeSchema)[T]
 >;
 
 export type RealtimeEvent<T extends RealtimeEventType> = {
-	type: T;
-	payload: RealtimeEventPayload<T>;
+  type: T;
+  payload: RealtimeEventPayload<T>;
 };
 
 export type AnyRealtimeEvent = {
-	[K in RealtimeEventType]: RealtimeEvent<K>;
+  [K in RealtimeEventType]: RealtimeEvent<K>;
 }[RealtimeEventType];
 
 export type RealtimeEventData<T extends RealtimeEventType> =
-	RealtimeEventPayload<T>;
+  RealtimeEventPayload<T>;
 
 /**
  * Validates an event against its schema
  */
 export function validateRealtimeEvent<T extends RealtimeEventType>(
-	type: T,
-	data: unknown
+  type: T,
+  data: unknown,
 ): RealtimeEventPayload<T> {
-	const schema = realtimeSchema[type];
-	return schema.parse(data) as RealtimeEventPayload<T>;
+  const schema = realtimeSchema[type];
+  return schema.parse(data) as RealtimeEventPayload<T>;
 }
 
 /**
  * Type guard to check if a string is a valid event type
  */
 export function isValidEventType(type: unknown): type is RealtimeEventType {
-	return typeof type === "string" && type in realtimeSchema;
+  return typeof type === "string" && type in realtimeSchema;
 }
 
 export function getEventPayload<T extends RealtimeEventType>(
-	event: RealtimeEvent<T>
+  event: RealtimeEvent<T>,
 ): RealtimeEventPayload<T> {
-	return event.payload;
+  return event.payload;
 }


### PR DESCRIPTION
## Summary
- add a reusable helper that writes conversation events and emits realtime notifications
- expose conversation events through REST/TRPC and hydrate dashboards & the visitor client
- add shared stores/hooks so realtime conversation events appear without manual refresh

## Testing
- bun test packages/core/src/store/conversation-events-store.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ea61c4c804832bb7e40768ea9a54dd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Conversation timeline events: new paginated API, SDK/REST support, and React hook to fetch and display events.
  - Real-time updates: timelines update instantly when new events are created.
  - Conversation pages now surface events alongside messages; dashboards and support views update caches live.

- Refactor
  - Unified event creation into a single utility for consistent handling.

- Tests
  - Added store tests covering pagination, realtime ingestion, and clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->