### PR TITLE
fix: block visitor messaging in closed conversations

### DIFF
--- a/apps/api/src/rest/routers/messages.ts
+++ b/apps/api/src/rest/routers/messages.ts
@@ -4,21 +4,24 @@ import { getMessages } from "@api/db/queries/message";
 import { emitConversationSeenEvent } from "@api/utils/conversation-realtime";
 import { createMessage } from "@api/utils/message";
 import {
-	safelyExtractRequestData,
-	safelyExtractRequestQuery,
-	validateResponse,
+        safelyExtractRequestData,
+        safelyExtractRequestQuery,
+        validateResponse,
 } from "@api/utils/validate";
+import { ConversationStatus } from "@cossistant/types";
 import {
-	getMessagesRequestSchema,
-	getMessagesResponseSchema,
-	sendMessageRequestSchema,
-	sendMessageResponseSchema,
+        getMessagesRequestSchema,
+        getMessagesResponseSchema,
+        sendMessageRequestSchema,
+        sendMessageResponseSchema,
 } from "@cossistant/types/api/message";
 import { OpenAPIHono, z } from "@hono/zod-openapi";
 import { protectedPublicApiKeyMiddleware } from "../middleware";
 import type { RestContext } from "../types";
 
 export const messagesRouter = new OpenAPIHono<RestContext>();
+
+const errorResponseSchema = z.object({ error: z.string() });
 
 // Apply middleware to all routes in this router
 messagesRouter.use("/*", ...protectedPublicApiKeyMiddleware);
@@ -46,9 +49,9 @@ messagesRouter.openapi(
 			400: {
 				description: "Invalid request",
 				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
+                                        "application/json": {
+                                                schema: errorResponseSchema,
+                                        },
 				},
 			},
 		},
@@ -135,9 +138,9 @@ messagesRouter.openapi(
 			400: {
 				description: "Invalid request",
 				content: {
-					"application/json": {
-						schema: z.object({ error: z.string() }),
-					},
+                                        "application/json": {
+                                                schema: errorResponseSchema,
+                                        },
 				},
 			},
 		},
@@ -195,51 +198,83 @@ messagesRouter.openapi(
 
 		const visitorId = body.message.visitorId || visitorIdHeader || null;
 
-		if (!visitorId) {
-			return c.json(
-				validateResponse(
-					{ error: "Visitor ID is required" },
-					z.object({ error: z.string() })
-				)
-			);
-		}
+                if (!visitorId) {
+                        return c.json(
+                                validateResponse(
+                                        { error: "Visitor ID is required" },
+                                        errorResponseSchema
+                                ),
+                                400
+                        );
+                }
 
-		const sentMessage = await createMessage({
-			db,
-			organizationId: organization.id,
-			websiteId: website.id,
-			conversationId: body.conversationId,
-			conversationOwnerVisitorId: visitorId,
-			message: {
-				bodyMd: body.message.bodyMd,
-				type: body.message.type ?? undefined,
-				userId: body.message.userId ?? null,
-				aiAgentId: body.message.aiAgentId ?? null,
-				visitorId,
-				visibility: body.message.visibility ?? undefined,
-				createdAt: body.message.createdAt
-					? new Date(body.message.createdAt)
-					: undefined,
-			},
-		});
+                const conversation = await getConversationById(db, {
+                        conversationId: body.conversationId,
+                });
 
-		// Mark conversation as seen by visitor after sending message
-		const conversation = await getConversationById(db, {
-			conversationId: body.conversationId,
-		});
+                if (
+                        !conversation ||
+                        conversation.websiteId !== website.id ||
+                        conversation.organizationId !== organization.id
+                ) {
+                        return c.json(
+                                validateResponse(
+                                        { error: "Conversation not found" },
+                                        errorResponseSchema
+                                ),
+                                404
+                        );
+                }
 
-		if (conversation && conversation.websiteId === website.id) {
-			const lastSeenAt = await markConversationAsSeenByVisitor(db, {
-				conversation,
-				visitorId,
-			});
+                if (conversation.visitorId && conversation.visitorId !== visitorId) {
+                        return c.json(
+                                validateResponse(
+                                        { error: "Conversation is not accessible" },
+                                        errorResponseSchema
+                                ),
+                                403
+                        );
+                }
 
-			await emitConversationSeenEvent({
-				conversation,
-				actor: { type: "visitor", visitorId },
-				lastSeenAt,
-			});
-		}
+                if (conversation.status !== ConversationStatus.OPEN) {
+                        return c.json(
+                                validateResponse(
+                                        { error: "Conversation is not open" },
+                                        errorResponseSchema
+                                ),
+                                403
+                        );
+                }
+
+                const sentMessage = await createMessage({
+                        db,
+                        organizationId: organization.id,
+                        websiteId: website.id,
+                        conversationId: body.conversationId,
+                        conversationOwnerVisitorId: visitorId,
+                        message: {
+                                bodyMd: body.message.bodyMd,
+                                type: body.message.type ?? undefined,
+                                userId: body.message.userId ?? null,
+                                aiAgentId: body.message.aiAgentId ?? null,
+                                visitorId,
+                                visibility: body.message.visibility ?? undefined,
+                                createdAt: body.message.createdAt
+                                        ? new Date(body.message.createdAt)
+                                        : undefined,
+                        },
+                });
+
+                const lastSeenAt = await markConversationAsSeenByVisitor(db, {
+                        conversation,
+                        visitorId,
+                });
+
+                await emitConversationSeenEvent({
+                        conversation,
+                        actor: { type: "visitor", visitorId },
+                        lastSeenAt,
+                });
 
 		return c.json(
 			validateResponse({ message: sentMessage }, sendMessageResponseSchema)

--- a/packages/react/src/support/pages/conversation.tsx
+++ b/packages/react/src/support/pages/conversation.tsx
@@ -1,8 +1,10 @@
-import type {
-	ConversationEvent,
-	Message as MessageType,
+import {
+        ConversationStatus,
+        type ConversationEvent,
+        type Message as MessageType,
 } from "@cossistant/types";
 import { useConversationPage } from "../../hooks/use-conversation-page";
+import { useConversation } from "../../hooks/use-conversation";
 import { useSupport } from "../../provider";
 import { AvatarStack } from "../components/avatar-stack";
 import { Header } from "../components/header";
@@ -51,19 +53,42 @@ export const ConversationPage = ({
 	const text = useSupportText();
 
 	// Main conversation hook - handles all logic
-	const conversation = useConversationPage({
-		conversationId: initialConversationId,
-		messages: passedMessages,
-		events,
-		initialMessage,
-		onConversationIdChange: (newConversationId) => {
-			// Update navigation when conversation is created
-			replace({
-				page: "CONVERSATION",
-				params: { conversationId: newConversationId },
-			});
-		},
-	});
+        const conversation = useConversationPage({
+                conversationId: initialConversationId,
+                messages: passedMessages,
+                events,
+                initialMessage,
+                onConversationIdChange: (newConversationId) => {
+                        // Update navigation when conversation is created
+                        replace({
+                                page: "CONVERSATION",
+                                params: { conversationId: newConversationId },
+                        });
+                },
+        });
+
+        const realConversationId = conversation.isPending
+                ? null
+                : conversation.conversationId;
+
+        const {
+                conversation: activeConversation,
+                isLoading: isConversationLoading,
+        } = useConversation(realConversationId, {
+                enabled: !conversation.isPending,
+        });
+
+        const canUseComposer =
+                conversation.isPending ||
+                activeConversation?.status === ConversationStatus.OPEN;
+
+        const shouldRenderComposer =
+                conversation.isPending ||
+                isConversationLoading ||
+                canUseComposer;
+
+        const composerDisabled =
+                conversation.composer.isSubmitting || !canUseComposer;
 
 	const handleGoBack = () => {
 		if (canGoBack) {
@@ -105,20 +130,24 @@ export const ConversationPage = ({
 				messages={conversation.messages}
 			/>
 
-			<div className="flex-shrink-0 p-1">
-				<MultimodalInput
-					disabled={conversation.composer.isSubmitting}
-					error={conversation.error}
-					files={conversation.composer.files}
-					isSubmitting={conversation.composer.isSubmitting}
-					onChange={conversation.composer.setMessage}
-					onFileSelect={conversation.composer.addFiles}
-					onRemoveFile={conversation.composer.removeFile}
-					onSubmit={conversation.composer.submit}
-					placeholder={text("component.multimodalInput.placeholder")}
-					value={conversation.composer.message}
-				/>
-			</div>
-		</div>
-	);
+                        {shouldRenderComposer ? (
+                                <div className="flex-shrink-0 p-1">
+                                        <MultimodalInput
+                                                disabled={composerDisabled}
+                                                error={conversation.error}
+                                                files={conversation.composer.files}
+                                                isSubmitting={conversation.composer.isSubmitting}
+                                                onChange={conversation.composer.setMessage}
+                                                onFileSelect={conversation.composer.addFiles}
+                                                onRemoveFile={conversation.composer.removeFile}
+                                                onSubmit={conversation.composer.submit}
+                                                placeholder={text(
+                                                        "component.multimodalInput.placeholder"
+                                                )}
+                                                value={conversation.composer.message}
+                                        />
+                                </div>
+                        ) : null}
+                </div>
+        );
 };


### PR DESCRIPTION
## Summary
- ensure the visitor messages endpoint validates conversation ownership and rejects non-open conversations
- hide the support widget composer when the current conversation status prevents sending messages

## Testing
- bunx turbo run lint --filter=@cossistant/api --filter=@cossistant/react *(fails: missing build deps in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68eec4d86d70832bb7bbb18ddc85f227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Composer now appears only when a conversation is pending, loading, or open, and disables appropriately during submission.
  - Automatic navigation updates when a conversation ID changes.

- Bug Fixes
  - Clear, standardized error messages for missing visitor info or inaccessible/closed conversations.
  - Prevents sending messages to conversations the visitor cannot access.

- Refactor
  - Unified error response format across API endpoints.
  - Consistent request/response schema usage and streamlined conversation “seen” handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->