### PR TITLE
fix(web): refetch visitor details on conversation open

### DIFF
--- a/apps/web/src/data/use-visitor.tsx
+++ b/apps/web/src/data/use-visitor.tsx
@@ -4,30 +4,32 @@ import { useQuery } from "@tanstack/react-query";
 import { useTRPC } from "@/lib/trpc/client";
 
 export function useVisitor({
-	websiteSlug,
-	visitorId,
+        websiteSlug,
+        visitorId,
 }: {
-	websiteSlug: string;
-	visitorId: string;
+        websiteSlug: string;
+        visitorId: string;
 }) {
-	const trpc = useTRPC();
+        const trpc = useTRPC();
 
-	const {
-		data: visitor,
-		isFetching,
-		isLoading,
-		error,
-		isError,
-		refetch,
-	} = useQuery({
-		...trpc.conversation.getVisitorById.queryOptions({
-			websiteSlug,
-			visitorId,
-		}),
-	});
+        const {
+                data: visitor,
+                isFetching,
+                isLoading,
+                error,
+                isError,
+                refetch,
+        } = useQuery({
+                ...trpc.conversation.getVisitorById.queryOptions({
+                        websiteSlug,
+                        visitorId,
+                }),
+                staleTime: 0,
+                refetchOnMount: "always",
+        });
 
-	return {
-		visitor: visitor ?? null,
+        return {
+                visitor: visitor ?? null,
 		isLoading,
 		isFetching,
 		isError,


### PR DESCRIPTION
## Summary
- force visitor data queries to refetch when opening a conversation so sidebar details stay up to date

## Testing
- bunx turbo run lint --filter=@cossistant/web *(fails: missing @hono/zod-openapi typings in workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68ef866fb924832ba3a3612170090369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Visitor data now refreshes immediately on page load, eliminating stale information after navigation or returning to the app.
  * Ensures more accurate, up-to-date personalization and access control by always fetching the latest visitor state on mount.
  * Reduces inconsistencies across sessions and improves reliability without changing the visible data fields or UI behavior.
  * Loading and error indicators behave as before; the primary change is improved data freshness and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->