### PR TITLE
fix(web): handle dashboard auth without layout guard

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/layout.tsx
@@ -5,10 +5,10 @@ import { InboxesProvider } from "@/contexts/inboxes";
 import { VisitorPresenceProvider } from "@/contexts/visitor-presence";
 import { WebsiteProvider } from "@/contexts/website";
 import {
-	getQueryClient,
-	HydrateClient,
-	prefetch,
-	trpc,
+        getQueryClient,
+        HydrateClient,
+        prefetch,
+        trpc,
 } from "@/lib/trpc/server";
 import { Realtime } from "./providers/realtime";
 import { DashboardWebSocketProvider } from "./providers/websocket";
@@ -21,50 +21,57 @@ type LayoutProps = {
 };
 
 export default async function Layout({ children, params }: LayoutProps) {
-	const { websiteSlug } = await params;
-	const queryClient = getQueryClient();
+        const { websiteSlug } = await params;
+        const queryClient = getQueryClient();
 
-	await Promise.all([
-		prefetch(
-			trpc.website.getBySlug.queryOptions({ slug: websiteSlug }),
-			(error) => {
-				// Handle any error type, not just UNAUTHORIZED
-				if (
-					error.data?.code === "UNAUTHORIZED" ||
-					error.data?.code === "FORBIDDEN"
-				) {
-					redirect("/select");
-				}
-				// For other errors, we still redirect to select
-				// This ensures the user doesn't see a broken page
-				redirect("/select");
-			}
-		),
-		prefetch(trpc.view.list.queryOptions({ slug: websiteSlug })),
-		prefetch(trpc.user.getWebsiteMembers.queryOptions({ websiteSlug })),
-		// Prefetch the conversation headers as an infinite query
-		queryClient.prefetchInfiniteQuery({
-			queryKey: [
-				...trpc.conversation.listConversationsHeaders.queryOptions({
-					websiteSlug,
-				}).queryKey,
-				{ type: "infinite" },
-			],
-			queryFn: async ({ pageParam }) => {
-				const response = await queryClient.fetchQuery(
-					trpc.conversation.listConversationsHeaders.queryOptions({
-						websiteSlug,
-						limit: 500,
-						cursor: pageParam ?? null,
-					})
-				);
-				return response;
-			},
-			initialPageParam: null as string | null,
-			getNextPageParam: (lastPage) => lastPage.nextCursor,
-			pages: 1, // Prefetch the first page
-		}),
-	]);
+        const handleAuthRedirect = (
+                error: Parameters<NonNullable<Parameters<typeof prefetch>[1]>>[0]
+        ) => {
+                if (error.data?.code === "UNAUTHORIZED") {
+                        redirect("/login");
+                }
+
+                if (error.data?.code === "FORBIDDEN") {
+                        redirect("/select");
+                }
+
+                redirect("/select");
+        };
+
+        await prefetch(
+                trpc.website.getBySlug.queryOptions({ slug: websiteSlug }),
+                handleAuthRedirect
+        );
+
+        await Promise.all([
+                prefetch(trpc.view.list.queryOptions({ slug: websiteSlug }), handleAuthRedirect),
+                prefetch(
+                        trpc.user.getWebsiteMembers.queryOptions({ websiteSlug }),
+                        handleAuthRedirect
+                ),
+                // Prefetch the conversation headers as an infinite query
+                queryClient.prefetchInfiniteQuery({
+                        queryKey: [
+                                ...trpc.conversation.listConversationsHeaders.queryOptions({
+                                        websiteSlug,
+                                }).queryKey,
+                                { type: "infinite" },
+                        ],
+                        queryFn: async ({ pageParam }) => {
+                                const response = await queryClient.fetchQuery(
+                                        trpc.conversation.listConversationsHeaders.queryOptions({
+                                                websiteSlug,
+                                                limit: 500,
+                                                cursor: pageParam ?? null,
+                                        })
+                                );
+                                return response;
+                        },
+                        initialPageParam: null as string | null,
+                        getNextPageParam: (lastPage) => lastPage.nextCursor,
+                        pages: 1, // Prefetch the first page
+                }),
+        ]);
 
 	return (
 		<HydrateClient>

--- a/apps/web/src/lib/auth/website-access.ts
+++ b/apps/web/src/lib/auth/website-access.ts
@@ -7,9 +7,9 @@ import { getAuth } from "./server";
 export const ensureWebsiteAccess = cache(async (websiteSlug: string) => {
 	const { user } = await getAuth();
 
-	if (!user) {
-		redirect("/");
-	}
+        if (!user) {
+                redirect("/login");
+        }
 
 	const accessCheck = await checkUserWebsiteAccess(db, {
 		userId: user.id,


### PR DESCRIPTION
## Summary
- redirect unauthenticated visitors to /login from the dashboard data prefetcher instead of invoking layout-level auth helpers
- ensure server-side website access checks send unauthenticated traffic to /login

## Testing
- bun run lint *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f110498f88832b98a2d764681003ff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling and redirect logic for better user experience
  * Unauthenticated users now redirect to login page instead of home
  * Enhanced permission-based routing for unauthorized and forbidden access scenarios
  * Refined loading state management for data dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->