### PR TITLE
fix: import React in transactional email templates

### DIFF
--- a/packages/transactional/emails/joined-waitlist.tsx
+++ b/packages/transactional/emails/joined-waitlist.tsx
@@ -8,6 +8,9 @@ import {
 	Text,
 } from "@react-email/components";
 
+// Needed for email templates, don't remove
+import React from "react";
+
 import { LOGO_URL } from "../constants";
 
 type WaitlistConfirmationEmailProps = {

--- a/packages/transactional/emails/reset-password.tsx
+++ b/packages/transactional/emails/reset-password.tsx
@@ -9,6 +9,10 @@ import {
 	Tailwind,
 	Text,
 } from "@react-email/components";
+
+// Needed for email templates, don't remove
+import React from "react";
+
 import { LOGO_URL } from "../constants";
 
 type ResetPasswordEmailProps = {


### PR DESCRIPTION
## Summary
- add explicit React imports to the transactional email templates so the JSX renders when compiled

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_e_68f7b7c181d4832b913e7feca5550261