### PR TITLE
fix: prevent widget from auto-seeing hidden conversations

### DIFF
--- a/packages/react/src/hooks/use-conversation-auto-seen.ts
+++ b/packages/react/src/hooks/use-conversation-auto-seen.ts
@@ -74,6 +74,19 @@ export function useConversationAutoSeen(
         const markSeenInFlightRef = useRef(false);
         const markSeenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
         const { isPageVisible, hasWindowFocus } = useWindowVisibilityFocus();
+        const latestStateRef = useRef({
+                enabled,
+                isPageVisible,
+                hasWindowFocus,
+        });
+
+        useEffect(() => {
+                latestStateRef.current = {
+                        enabled,
+                        isPageVisible,
+                        hasWindowFocus,
+                };
+        }, [enabled, hasWindowFocus, isPageVisible]);
 
         // Reset seen tracking when conversation changes
         useEffect(() => {
@@ -140,7 +153,20 @@ export function useConversationAutoSeen(
                 const pendingItemId = lastTimelineItem.id || null;
 
                 markSeenTimeoutRef.current = setTimeout(() => {
-                        if (!client || !conversationId) {
+                        const {
+                                enabled: latestEnabled,
+                                isPageVisible: latestPageVisible,
+                                hasWindowFocus: latestHasFocus,
+                        } = latestStateRef.current;
+
+                        if (
+                                !client ||
+                                !conversationId ||
+                                !latestEnabled ||
+                                !latestPageVisible ||
+                                !latestHasFocus
+                        ) {
+                                markSeenInFlightRef.current = false;
                                 markSeenTimeoutRef.current = null;
                                 return;
                         }

--- a/packages/react/src/hooks/use-conversation-page.ts
+++ b/packages/react/src/hooks/use-conversation-page.ts
@@ -8,11 +8,11 @@ import { useConversationTimelineItems } from "./use-conversation-timeline-items"
 import { useMessageComposer } from "./use-message-composer";
 
 export type UseConversationPageOptions = {
-	/**
-	 * Initial conversation ID (from URL params, navigation state, etc.)
-	 * Can be PENDING_CONVERSATION_ID or a real ID.
-	 */
-	conversationId: string;
+        /**
+         * Initial conversation ID (from URL params, navigation state, etc.)
+         * Can be PENDING_CONVERSATION_ID or a real ID.
+         */
+        conversationId: string;
 
 	/**
 	 * Optional initial message to send when the conversation opens.
@@ -25,10 +25,17 @@ export type UseConversationPageOptions = {
 	 */
 	onConversationIdChange?: (conversationId: string) => void;
 
-	/**
-	 * Optional timeline items to pass through (e.g., optimistic updates).
-	 */
-	items?: TimelineItem[];
+        /**
+         * Optional timeline items to pass through (e.g., optimistic updates).
+         */
+        items?: TimelineItem[];
+
+        /**
+         * Whether automatic "seen" tracking should be enabled.
+         * Set to false when the conversation isn't visible (e.g. widget closed).
+         * Default: true
+         */
+        autoSeenEnabled?: boolean;
 };
 
 export type UseConversationPageReturn = {
@@ -93,14 +100,15 @@ export type UseConversationPageReturn = {
  * ```
  */
 export function useConversationPage(
-	options: UseConversationPageOptions
+        options: UseConversationPageOptions
 ): UseConversationPageReturn {
-	const {
-		conversationId: initialConversationId,
-		initialMessage,
-		onConversationIdChange,
-		items: passedItems = [],
-	} = options;
+        const {
+                conversationId: initialConversationId,
+                initialMessage,
+                onConversationIdChange,
+                items: passedItems = [],
+                autoSeenEnabled = true,
+        } = options;
 
 	const { client, visitor } = useSupport();
 
@@ -217,12 +225,13 @@ export function useConversationPage(
 	]);
 
 	// 6. Auto-mark messages as seen
-	useConversationAutoSeen({
-		client,
-		conversationId: lifecycle.realConversationId,
-		visitorId: visitor?.id,
-		lastTimelineItem,
-	});
+        useConversationAutoSeen({
+                client,
+                conversationId: lifecycle.realConversationId,
+                visitorId: visitor?.id,
+                lastTimelineItem,
+                enabled: autoSeenEnabled,
+        });
 
 	return {
 		conversationId: lifecycle.conversationId,

--- a/packages/react/src/support/pages/conversation.tsx
+++ b/packages/react/src/support/pages/conversation.tsx
@@ -5,7 +5,7 @@ import { AvatarStack } from "../components/avatar-stack";
 import { ConversationTimelineList } from "../components/conversation-timeline";
 import { Header } from "../components/header";
 import { MultimodalInput } from "../components/multimodal-input";
-import { useSupportNavigation } from "../store";
+import { useSupportConfig, useSupportNavigation } from "../store";
 import { Text, useSupportText } from "../text";
 
 type ConversationPageProps = {
@@ -36,17 +36,19 @@ export const ConversationPage = ({
 	initialMessage,
 	items: passedItems = [],
 }: ConversationPageProps) => {
-	const { website, availableAIAgents, availableHumanAgents, visitor } =
-		useSupport();
-	const { navigate, replace, goBack, canGoBack } = useSupportNavigation();
+        const { website, availableAIAgents, availableHumanAgents, visitor } =
+                useSupport();
+        const { navigate, replace, goBack, canGoBack } = useSupportNavigation();
+        const { isOpen } = useSupportConfig();
 	const text = useSupportText();
 
 	// Main conversation hook - handles all logic
-	const conversation = useConversationPage({
-		conversationId: initialConversationId,
-		items: passedItems,
-		initialMessage,
-		onConversationIdChange: (newConversationId) => {
+        const conversation = useConversationPage({
+                conversationId: initialConversationId,
+                items: passedItems,
+                initialMessage,
+                autoSeenEnabled: isOpen,
+                onConversationIdChange: (newConversationId) => {
 			// Update navigation when conversation is created
 			replace({
 				page: "CONVERSATION",


### PR DESCRIPTION
## Summary
- ensure the auto-seen hook re-checks focus/visibility/enablement before calling the API
- expose an `autoSeenEnabled` flag in the conversation page hook and disable it when the widget is closed

## Testing
- bunx turbo run lint --filter=@cossistant/react *(fails: Missing tasks in project)*
- bunx @biomejs/biome check . *(fails: Could not resolve ultracite)*

------
https://chatgpt.com/codex/tasks/task_e_68f7f229f5e0832babbd1f94d6aa19a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable option to control automatic message marking behavior.

* **Bug Fixes**
  * Improved automatic message marking logic to respect UI visibility and focus state, preventing actions when conditions change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->