### PR TITLE
feat: scope S3 uploads and add cleanup utilities

### DIFF
--- a/apps/api/src/rest/routers/upload.ts
+++ b/apps/api/src/rest/routers/upload.ts
@@ -78,10 +78,29 @@ uploadRouter.openapi(
 			);
 		}
 
-		const basePathSegments = [organization.id];
+		if (body.scope.organizationId !== organization.id) {
+			return c.json(
+				validateResponse(
+					{
+						error:
+							"Scope organization does not match the API key organization context",
+					},
+					z.object({ error: z.string() })
+				),
+				400
+			);
+		}
 
-		if (apiKey.website) {
-			basePathSegments.push(apiKey.website.id);
+		if (apiKey.website && body.scope.websiteId !== apiKey.website.id) {
+			return c.json(
+				validateResponse(
+					{
+						error: "Scope website does not match the API key website context",
+					},
+					z.object({ error: z.string() })
+				),
+				400
+			);
 		}
 
 		const result = await generateUploadUrl({
@@ -89,8 +108,9 @@ uploadRouter.openapi(
 			fileName: body.fileName,
 			fileExtension: body.fileExtension,
 			path: body.path,
+			scope: body.scope,
+			useCdn: body.useCdn,
 			expiresInSeconds: body.expiresInSeconds,
-			basePathSegments,
 		});
 
 		return c.json(validateResponse(result, generateUploadUrlResponseSchema));

--- a/apps/api/src/services/upload.ts
+++ b/apps/api/src/services/upload.ts
@@ -1,129 +1,374 @@
 import path from "node:path";
 
 import { env } from "@api/env";
-import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+	DeleteObjectsCommand,
+	ListObjectsV2Command,
+	PutObjectCommand,
+	S3Client,
+} from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { ulid } from "ulid";
+import type { GenerateUploadUrlRequest } from "@cossistant/types/api/upload";
 
 const LEADING_DOT_PATTERN = /^\./;
+const CDN_PREFIX = "cdn";
 
 const endpoint =
-  env.S3_ENDPOINT.trim().length > 0 ? env.S3_ENDPOINT : undefined;
+	env.S3_ENDPOINT.trim().length > 0 ? env.S3_ENDPOINT : undefined;
 const forcePathStyle = env.S3_FORCE_PATH_STYLE;
 
 export const s3Client = new S3Client({
-  region: env.S3_REGION,
-  credentials: {
-    accessKeyId: env.S3_ACCESS_KEY_ID,
-    secretAccessKey: env.S3_SECRET_ACCESS_KEY,
-  },
-  endpoint,
-  forcePathStyle,
+	region: env.S3_REGION,
+	credentials: {
+		accessKeyId: env.S3_ACCESS_KEY_ID,
+		secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+	},
+	endpoint,
+	forcePathStyle,
 });
 
 function sanitizeSegmentsFromInput(input: string | undefined): string[] {
-  if (!input) {
-    return [];
-  }
+	if (!input) {
+		return [];
+	}
 
-  return input
-    .replace(/\\/g, "/")
-    .split("/")
-    .map((segment) => segment.trim())
-    .filter(
-      (segment) => segment.length > 0 && segment !== "." && segment !== ".."
-    )
-    .map((segment) => segment.replace(/[^a-zA-Z0-9_.-]/g, "-"))
-    .filter((segment) => segment.length > 0);
+	return input
+		.replace(/\\/g, "/")
+		.split("/")
+		.map((segment) => segment.trim())
+		.filter(
+			(segment) => segment.length > 0 && segment !== "." && segment !== ".."
+		)
+		.map((segment) => segment.replace(/[^a-zA-Z0-9_.-]/g, "-"))
+		.filter((segment) => segment.length > 0);
 }
 
 function sanitizeFileName(fileName: string | undefined): string {
-  if (!fileName) {
-    return ulid();
-  }
+	if (!fileName) {
+		return ulid();
+	}
 
-  const cleaned = fileName.replace(/[\\/]/g, "").trim();
-  const sanitized = cleaned.replace(/[^a-zA-Z0-9_.-]/g, "-");
+	const cleaned = fileName.replace(/[\\/]/g, "").trim();
+	const sanitized = cleaned.replace(/[^a-zA-Z0-9_.-]/g, "-");
 
-  return sanitized.length > 0 ? sanitized : ulid();
+	return sanitized.length > 0 ? sanitized : ulid();
 }
 
 function sanitizeExtension(extension: string | undefined): string | null {
-  if (!extension) {
-    return null;
-  }
+	if (!extension) {
+		return null;
+	}
 
-  const trimmed = extension.trim().replace(LEADING_DOT_PATTERN, "");
-  const sanitized = trimmed.replace(/[^a-zA-Z0-9]/g, "");
+	const trimmed = extension.trim().replace(LEADING_DOT_PATTERN, "");
+	const sanitized = trimmed.replace(/[^a-zA-Z0-9]/g, "");
 
-  if (sanitized.length === 0) {
-    return null;
-  }
+	if (sanitized.length === 0) {
+		return null;
+	}
 
-  return `.${sanitized.toLowerCase()}`;
+	return `.${sanitized.toLowerCase()}`;
 }
 
+export type UploadScope = GenerateUploadUrlRequest["scope"];
+
 export type GenerateUploadUrlOptions = {
-  contentType: string;
-  path?: string;
-  fileName?: string;
-  fileExtension?: string;
-  expiresInSeconds?: number;
-  basePathSegments?: string[];
+	contentType: string;
+	scope: UploadScope;
+	path?: string;
+	fileName?: string;
+	fileExtension?: string;
+	expiresInSeconds?: number;
+	useCdn?: boolean;
 };
 
 export type GenerateUploadUrlResult = {
-  uploadUrl: string;
-  key: string;
-  bucket: string;
-  expiresAt: string;
-  contentType: string;
+	uploadUrl: string;
+	key: string;
+	bucket: string;
+	expiresAt: string;
+	contentType: string;
 };
 
+function sanitizeSingleSegment(input: string): string {
+	const [sanitized] = sanitizeSegmentsFromInput(input);
+
+	if (!sanitized) {
+		throw new Error("Unable to sanitize segment for S3 key generation");
+	}
+
+	return sanitized;
+}
+
+function buildScopeBaseSegments(scope: UploadScope, useCdn: boolean): string[] {
+	const segments: string[] = [];
+
+	if (useCdn) {
+		segments.push(CDN_PREFIX);
+	}
+
+	segments.push(
+		sanitizeSingleSegment(scope.organizationId),
+		sanitizeSingleSegment(scope.websiteId)
+	);
+
+	switch (scope.type) {
+		case "conversation":
+			segments.push(sanitizeSingleSegment(scope.conversationId));
+			break;
+		case "user":
+			segments.push(sanitizeSingleSegment(scope.userId));
+			break;
+		case "contact":
+			segments.push(sanitizeSingleSegment(scope.contactId));
+			break;
+		case "visitor":
+			segments.push(sanitizeSingleSegment(scope.visitorId));
+			break;
+		default: {
+			const exhaustiveCheck: never = scope;
+			throw new Error(
+				`Unsupported upload scope encountered: ${JSON.stringify(exhaustiveCheck)}`
+			);
+		}
+	}
+
+	return segments;
+}
+
 export async function generateUploadUrl(
-  options: GenerateUploadUrlOptions
+	options: GenerateUploadUrlOptions
 ): Promise<GenerateUploadUrlResult> {
-  const baseSegments = (options.basePathSegments ?? [])
-    .flatMap((segment) => sanitizeSegmentsFromInput(segment))
-    .filter((segment) => segment.length > 0);
-  const normalizedPathSegments = sanitizeSegmentsFromInput(options.path);
+	const baseSegments = buildScopeBaseSegments(
+		options.scope,
+		Boolean(options.useCdn)
+	);
+	const normalizedPathSegments = sanitizeSegmentsFromInput(options.path);
 
-  const allSegments = [...baseSegments, ...normalizedPathSegments];
+	const allSegments = [...baseSegments, ...normalizedPathSegments];
 
-  const sanitizedFileName = sanitizeFileName(options.fileName);
-  const extension = sanitizeExtension(options.fileExtension);
+	const sanitizedFileName = sanitizeFileName(options.fileName);
+	const extension = sanitizeExtension(options.fileExtension);
 
-  const finalFileName = extension
-    ? sanitizedFileName.endsWith(extension)
-      ? sanitizedFileName
-      : `${sanitizedFileName}${extension}`
-    : sanitizedFileName;
+	const finalFileName = extension
+		? sanitizedFileName.endsWith(extension)
+			? sanitizedFileName
+			: `${sanitizedFileName}${extension}`
+		: sanitizedFileName;
 
-  const objectKey = path.posix.join(...allSegments, finalFileName);
+	const objectKey = path.posix.join(...allSegments, finalFileName);
 
-  const expiresIn =
-    options.expiresInSeconds ?? env.S3_SIGNED_URL_EXPIRATION_SECONDS;
+	const expiresIn =
+		options.expiresInSeconds ?? env.S3_SIGNED_URL_EXPIRATION_SECONDS;
 
-  const command = new PutObjectCommand({
-    Bucket: env.S3_BUCKET_NAME,
-    Key: objectKey,
-    ContentType: options.contentType,
-  });
+	const command = new PutObjectCommand({
+		Bucket: env.S3_BUCKET_NAME,
+		Key: objectKey,
+		ContentType: options.contentType,
+	});
 
-  try {
-    const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn });
+	try {
+		const uploadUrl = await getSignedUrl(s3Client, command, { expiresIn });
 
-    return {
-      uploadUrl,
-      key: objectKey,
-      bucket: env.S3_BUCKET_NAME,
-      expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
-      contentType: options.contentType,
-    };
-  } catch (error) {
-    throw new Error(
-      `Failed to generate signed upload URL: ${error instanceof Error ? error.message : "Unknown error"}`,
-      { cause: error }
-    );
-  }
+		return {
+			uploadUrl,
+			key: objectKey,
+			bucket: env.S3_BUCKET_NAME,
+			expiresAt: new Date(Date.now() + expiresIn * 1000).toISOString(),
+			contentType: options.contentType,
+		};
+	} catch (error) {
+		throw new Error(
+			`Failed to generate signed upload URL: ${error instanceof Error ? error.message : "Unknown error"}`,
+			{ cause: error }
+		);
+	}
+}
+
+async function deleteByPrefix(prefix: string): Promise<number> {
+	let continuationToken: string | undefined;
+	let deletedCount = 0;
+
+	do {
+		const listResponse = await s3Client.send(
+			new ListObjectsV2Command({
+				Bucket: env.S3_BUCKET_NAME,
+				Prefix: prefix,
+				ContinuationToken: continuationToken,
+			})
+		);
+
+		const objects = (listResponse.Contents ?? [])
+			.map((entry) => entry.Key)
+			.filter((key): key is string => Boolean(key))
+			.map((key) => ({ Key: key }));
+
+		if (objects.length > 0) {
+			const deleteResponse = await s3Client.send(
+				new DeleteObjectsCommand({
+					Bucket: env.S3_BUCKET_NAME,
+					Delete: { Objects: objects, Quiet: true },
+				})
+			);
+
+			deletedCount += deleteResponse.Deleted?.length ?? 0;
+		}
+
+		continuationToken = listResponse.IsTruncated
+			? listResponse.NextContinuationToken
+			: undefined;
+	} while (continuationToken);
+
+	return deletedCount;
+}
+
+async function calculateSizeByPrefix(prefix: string): Promise<number> {
+	let continuationToken: string | undefined;
+	let totalSize = 0;
+
+	do {
+		const listResponse = await s3Client.send(
+			new ListObjectsV2Command({
+				Bucket: env.S3_BUCKET_NAME,
+				Prefix: prefix,
+				ContinuationToken: continuationToken,
+			})
+		);
+
+		totalSize += (listResponse.Contents ?? []).reduce(
+			(accumulator, entry) => accumulator + (entry.Size ?? 0),
+			0
+		);
+
+		continuationToken = listResponse.IsTruncated
+			? listResponse.NextContinuationToken
+			: undefined;
+	} while (continuationToken);
+
+	return totalSize;
+}
+
+function buildPrefixes(
+	organizationId: string,
+	websiteId?: string,
+	leafId?: string
+): string[] {
+	const organizationSegment = sanitizeSingleSegment(organizationId);
+	const websiteSegment = websiteId
+		? sanitizeSingleSegment(websiteId)
+		: undefined;
+	const leafSegment = leafId ? sanitizeSingleSegment(leafId) : undefined;
+
+	const basePath = [organizationSegment, websiteSegment, leafSegment]
+		.filter((segment): segment is string => Boolean(segment))
+		.join("/");
+
+	const prefixes = [] as string[];
+
+	if (basePath.length > 0) {
+		prefixes.push(`${basePath}/`);
+		prefixes.push(`${CDN_PREFIX}/${basePath}/`);
+	} else {
+		prefixes.push("");
+	}
+
+	return prefixes;
+}
+
+export async function deleteOrganizationFiles(
+	organizationId: string
+): Promise<number> {
+	const prefixes = buildPrefixes(organizationId);
+	let deleted = 0;
+
+	for (const prefix of prefixes) {
+		deleted += await deleteByPrefix(prefix);
+	}
+
+	return deleted;
+}
+
+export async function deleteWebsiteFiles(params: {
+	organizationId: string;
+	websiteId: string;
+}): Promise<number> {
+	const prefixes = buildPrefixes(params.organizationId, params.websiteId);
+	let deleted = 0;
+
+	for (const prefix of prefixes) {
+		deleted += await deleteByPrefix(prefix);
+	}
+
+	return deleted;
+}
+
+export async function deleteConversationFiles(params: {
+	organizationId: string;
+	websiteId: string;
+	conversationId: string;
+}): Promise<number> {
+	const prefixes = buildPrefixes(
+		params.organizationId,
+		params.websiteId,
+		params.conversationId
+	);
+	let deleted = 0;
+
+	for (const prefix of prefixes) {
+		deleted += await deleteByPrefix(prefix);
+	}
+
+	return deleted;
+}
+
+export async function deleteVisitorFiles(params: {
+	organizationId: string;
+	websiteId: string;
+	visitorId: string;
+}): Promise<number> {
+	const prefixes = buildPrefixes(
+		params.organizationId,
+		params.websiteId,
+		params.visitorId
+	);
+	let deleted = 0;
+
+	for (const prefix of prefixes) {
+		deleted += await deleteByPrefix(prefix);
+	}
+
+	return deleted;
+}
+
+export async function deleteContactFiles(params: {
+	organizationId: string;
+	websiteId: string;
+	contactId: string;
+}): Promise<number> {
+	const prefixes = buildPrefixes(
+		params.organizationId,
+		params.websiteId,
+		params.contactId
+	);
+	let deleted = 0;
+
+	for (const prefix of prefixes) {
+		deleted += await deleteByPrefix(prefix);
+	}
+
+	return deleted;
+}
+
+export async function getWebsiteUsageBytes(params: {
+	organizationId: string;
+	websiteId: string;
+}): Promise<number> {
+	const prefixes = buildPrefixes(params.organizationId, params.websiteId);
+	let total = 0;
+
+	for (const prefix of prefixes) {
+		total += await calculateSizeByPrefix(prefix);
+	}
+
+	return total;
 }

--- a/packages/types/src/api/upload.ts
+++ b/packages/types/src/api/upload.ts
@@ -1,5 +1,37 @@
 import { z } from "@hono/zod-openapi";
 
+const idSchema = z.string().min(1).max(128);
+
+export const uploadOrganizationIdSchema = idSchema.openapi({
+	description: "Identifier of the organization that owns the uploaded file.",
+	example: "org_01HZYFG9W5V6YB5R6T6V7N9M2Q",
+});
+
+export const uploadWebsiteIdSchema = idSchema.openapi({
+	description: "Identifier of the website associated with the uploaded file.",
+	example: "site_01HZYFH3KJ3MYHJJ3JJ6Y2RNAV",
+});
+
+export const uploadConversationIdSchema = idSchema.openapi({
+	description: "Conversation identifier that will scope the uploaded asset.",
+	example: "conv_01HZYFJ5P7DQ0VE8F68G5VYBAQ",
+});
+
+export const uploadUserIdSchema = idSchema.openapi({
+	description: "User identifier that will scope the uploaded asset.",
+	example: "user_01HZYFKJS3K0M9W6PQZ0J6G1WR",
+});
+
+export const uploadContactIdSchema = idSchema.openapi({
+	description: "Contact identifier that will scope the uploaded asset.",
+	example: "contact_01HZYFMN7J2J4F2SW3Q2N1H0D9",
+});
+
+export const uploadVisitorIdSchema = idSchema.openapi({
+	description: "Visitor identifier that will scope the uploaded asset.",
+	example: "visitor_01HZYFPQ8R2FK1D9V7ZQ6CG6TN",
+});
+
 export const uploadPathSchema = z.string().max(512).openapi({
 	description:
 		"Optional relative path used to group uploads inside the bucket. Nested paths are supported.",
@@ -28,15 +60,82 @@ export const uploadFileExtensionSchema = z
 		example: "png",
 	});
 
+const baseScope = {
+	organizationId: uploadOrganizationIdSchema,
+	websiteId: uploadWebsiteIdSchema,
+};
+
+export const uploadScopeConversationSchema = z
+	.object({
+		...baseScope,
+		type: z.literal("conversation"),
+		conversationId: uploadConversationIdSchema,
+	})
+	.openapi({
+		description:
+			"Scope uploads to a specific conversation. Files will be placed under /{organizationId}/{websiteId}/{conversationId}.",
+	});
+
+export const uploadScopeUserSchema = z
+	.object({
+		...baseScope,
+		type: z.literal("user"),
+		userId: uploadUserIdSchema,
+	})
+	.openapi({
+		description:
+			"Scope uploads to a specific user. Files will be placed under /{organizationId}/{websiteId}/{userId}.",
+	});
+
+export const uploadScopeContactSchema = z
+	.object({
+		...baseScope,
+		type: z.literal("contact"),
+		contactId: uploadContactIdSchema,
+	})
+	.openapi({
+		description:
+			"Scope uploads to a specific contact. Files will be placed under /{organizationId}/{websiteId}/{contactId}.",
+	});
+
+export const uploadScopeVisitorSchema = z
+	.object({
+		...baseScope,
+		type: z.literal("visitor"),
+		visitorId: uploadVisitorIdSchema,
+	})
+	.openapi({
+		description:
+			"Scope uploads to a specific visitor. Files will be placed under /{organizationId}/{websiteId}/{visitorId}.",
+	});
+
+export const uploadScopeSchema = z
+	.discriminatedUnion("type", [
+		uploadScopeConversationSchema,
+		uploadScopeUserSchema,
+		uploadScopeContactSchema,
+		uploadScopeVisitorSchema,
+	])
+	.openapi({
+		description:
+			"Defines how uploaded files should be grouped inside the S3 bucket.",
+	});
+
 export const generateUploadUrlRequestSchema = z
 	.object({
 		contentType: z.string().min(1).max(256).openapi({
 			description: "MIME type of the file to upload.",
 			example: "image/png",
 		}),
+		scope: uploadScopeSchema,
 		path: uploadPathSchema.optional(),
 		fileName: uploadFileNameSchema.optional(),
 		fileExtension: uploadFileExtensionSchema.optional(),
+		useCdn: z.boolean().optional().openapi({
+			description:
+				"Set to true to place the file under the /cdn prefix so it is cached by the CDN.",
+			example: true,
+		}),
 		expiresInSeconds: z
 			.number()
 			.int()


### PR DESCRIPTION
## Summary
- add request typing for upload scope identifiers and a CDN opt-in flag so assets live under deterministic prefixes
- update the upload service to build scoped keys, support CDN uploads, and provide helpers for deleting or sizing scoped prefixes
- enforce scope validation in the REST/TRPC endpoints while passing the new options to signed URL generation

## Testing
- bunx turbo run lint --filter=@cossistant/api *(fails: task not defined for @cossistant/api)*

------
https://chatgpt.com/codex/tasks/task_e_68f89c0e9dfc832b9f01ca5969a01dbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CDN support option for file uploads.
  * Added storage usage tracking to measure website storage consumption.
  * Added file cleanup capabilities for organizations, websites, conversations, visitors, and contacts.

* **Improvements**
  * Enhanced upload request validation to enforce proper scope and security checks.
  * Improved file organization and management with structured scope-based handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->