### PR TITLE
refactor: separate dashboard inbox containers

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/client-router.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/client-router.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Conversation } from "@/components/conversation";
-import { ConversationsList } from "@/components/conversations-list";
 import { useInboxes } from "@/contexts/inboxes";
 import { useUserSession } from "@/contexts/website";
+import { ConversationPane } from "./conversation-pane";
+import { ConversationsListPane } from "./conversations-list-pane";
 
 type InboxClientProps = {
 	websiteSlug: string;
@@ -20,19 +20,19 @@ export default function InboxClientRouter({ websiteSlug }: InboxClientProps) {
 		selectedVisitorId,
 	} = useInboxes();
 
-	return selectedConversationId && selectedVisitorId ? (
-		<Conversation
-			conversationId={selectedConversationId}
-			currentUserId={user.id}
-			visitorId={selectedVisitorId}
-			websiteSlug={websiteSlug}
-		/>
-	) : (
-		<ConversationsList
-			basePath={basePath}
-			conversations={conversations}
-			selectedConversationStatus={selectedConversationStatus}
-			websiteSlug={websiteSlug}
-		/>
-	);
+        return selectedConversationId && selectedVisitorId ? (
+                <ConversationPane
+                        conversationId={selectedConversationId}
+                        currentUserId={user.id}
+                        visitorId={selectedVisitorId}
+                        websiteSlug={websiteSlug}
+                />
+        ) : (
+                <ConversationsListPane
+                        basePath={basePath}
+                        conversations={conversations}
+                        selectedConversationStatus={selectedConversationStatus}
+                        websiteSlug={websiteSlug}
+                />
+        );
 }

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import { useMultimodalInput } from "@cossistant/react/hooks/private/use-multimodal-input";
+import { useConversationSeen } from "@cossistant/react/hooks/use-conversation-seen";
+import type { TimelineItem } from "@cossistant/types/api/timeline-item";
+import { useWindowVisibilityFocus } from "@cossistant/react/hooks/use-window-visibility-focus";
+import { CONVERSATION_AUTO_SEEN_DELAY_MS } from "@cossistant/react/hooks/use-conversation-auto-seen";
+import { Conversation } from "@/components/conversation";
+import type { ConversationHeaderNavigationProps } from "@/components/conversation/header/navigation";
+import type { ConversationProps } from "@/components/conversation";
+import { useInboxes } from "@/contexts/inboxes";
+import { useWebsiteMembers } from "@/contexts/website";
+import { useConversationActions } from "@/data/use-conversation-actions";
+import { useConversationTimelineItems } from "@/data/use-conversation-timeline-items";
+import { useVisitor } from "@/data/use-visitor";
+import { useAgentTypingReporter } from "@/hooks/use-agent-typing-reporter";
+import { useSendConversationMessage } from "@/hooks/use-send-conversation-message";
+import { useSidebar } from "@/hooks/use-sidebars";
+
+const MESSAGES_PAGE_LIMIT = 50;
+
+type ConversationPaneProps = {
+        conversationId: string;
+        visitorId: string;
+        websiteSlug: string;
+        currentUserId: string;
+};
+
+export function ConversationPane({
+        conversationId,
+        visitorId,
+        websiteSlug,
+        currentUserId,
+}: ConversationPaneProps) {
+        const { submit: submitConversationMessage } = useSendConversationMessage({
+                conversationId,
+                websiteSlug,
+                currentUserId,
+                pageLimit: MESSAGES_PAGE_LIMIT,
+        });
+
+        const {
+                handleInputChange: handleTypingChange,
+                handleSubmit: handleTypingSubmit,
+                stop: stopTyping,
+        } = useAgentTypingReporter({
+                conversationId,
+                websiteSlug,
+        });
+
+        const {
+                message,
+                files,
+                isSubmitting,
+                error,
+                setMessage,
+                addFiles,
+                removeFile,
+                submit,
+        } = useMultimodalInput({
+                onSubmit: async (payload) => {
+                        handleTypingSubmit();
+                        await submitConversationMessage(payload);
+                },
+                onError: (submitError) => {
+                        console.error("Failed to send message", submitError);
+                },
+        });
+
+        const handleMessageChange = useCallback(
+                (value: string) => {
+                        setMessage(value);
+                        handleTypingChange(value);
+                },
+                [handleTypingChange, setMessage]
+        );
+
+        useEffect(
+                () => () => {
+                        stopTyping();
+                },
+                [stopTyping]
+        );
+
+        const members = useWebsiteMembers();
+        const {
+                selectedConversation,
+                previousConversation,
+                nextConversation,
+                navigateToPreviousConversation,
+                navigateToNextConversation,
+                goBack,
+                statusCounts,
+                selectedConversationIndex,
+        } = useInboxes();
+
+        const { open: isRightSidebarOpen, toggle: toggleRightSidebar } = useSidebar({
+                position: "right",
+        });
+        const { open: isLeftSidebarOpen, toggle: toggleLeftSidebar } = useSidebar({
+                position: "left",
+        });
+
+        const { markRead } = useConversationActions({
+                conversationId,
+                visitorId,
+        });
+
+        const lastMarkedMessageIdRef = useRef<string | null>(null);
+        const markSeenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+        const { isPageVisible, hasWindowFocus } = useWindowVisibilityFocus();
+
+        const { items, fetchNextPage, hasNextPage } = useConversationTimelineItems({
+                conversationId,
+                websiteSlug,
+                options: { limit: MESSAGES_PAGE_LIMIT },
+        });
+
+        const { visitor, isLoading: isVisitorLoading } = useVisitor({ visitorId, websiteSlug });
+
+        const seenData = useConversationSeen(conversationId, {
+                initialData: selectedConversation?.seenData ?? [],
+        });
+
+        const lastMessage = useMemo(
+                () => items.filter((item) => item.type === "message").at(-1) ?? null,
+                [items]
+        );
+
+        useEffect(() => {
+                if (markSeenTimeoutRef.current) {
+                        clearTimeout(markSeenTimeoutRef.current);
+                        markSeenTimeoutRef.current = null;
+                }
+
+                if (!lastMessage) {
+                        return;
+                }
+
+                if (!selectedConversation || selectedConversation.id !== conversationId) {
+                        lastMarkedMessageIdRef.current = null;
+                        return;
+                }
+
+                if (!isPageVisible || !hasWindowFocus) {
+                        return;
+                }
+
+                if (lastMessage.userId === currentUserId) {
+                        lastMarkedMessageIdRef.current = lastMessage.id || null;
+                        return;
+                }
+
+                const lastMessageCreatedAt = new Date(lastMessage.createdAt);
+                const lastSeenAt = selectedConversation.lastSeenAt
+                        ? new Date(selectedConversation.lastSeenAt)
+                        : null;
+
+                if (lastSeenAt && lastSeenAt >= lastMessageCreatedAt) {
+                        lastMarkedMessageIdRef.current = lastMessage.id || null;
+                        return;
+                }
+
+                if (lastMarkedMessageIdRef.current === (lastMessage.id || null)) {
+                        return;
+                }
+
+                const pendingMessageId = lastMessage.id || null;
+
+                markSeenTimeoutRef.current = setTimeout(() => {
+                        const isVisibleNow =
+                                typeof document !== "undefined" ? !document.hidden : true;
+                        const hasFocusNow =
+                                typeof document !== "undefined" &&
+                                typeof document.hasFocus === "function"
+                                        ? document.hasFocus()
+                                        : true;
+
+                        if (!isVisibleNow || !hasFocusNow) {
+                                markSeenTimeoutRef.current = null;
+                                return;
+                        }
+
+                        markRead()
+                                .then(() => {
+                                        lastMarkedMessageIdRef.current = pendingMessageId;
+                                })
+                                .catch(() => {
+                                        // no-op: we'll retry on next render if needed
+                                })
+                                .finally(() => {
+                                        markSeenTimeoutRef.current = null;
+                                });
+                }, CONVERSATION_AUTO_SEEN_DELAY_MS);
+
+                return () => {
+                        if (markSeenTimeoutRef.current) {
+                                clearTimeout(markSeenTimeoutRef.current);
+                                markSeenTimeoutRef.current = null;
+                        }
+                };
+        }, [
+                conversationId,
+                currentUserId,
+                hasWindowFocus,
+                isPageVisible,
+                lastMessage,
+                markRead,
+                selectedConversation,
+        ]);
+
+        useHotkeys(
+                ["escape", "j", "k"],
+                (_, handler) => {
+                        switch (handler.keys?.join("")) {
+                                case "escape":
+                                        goBack();
+                                        break;
+                                case "j":
+                                        if (previousConversation) {
+                                                navigateToPreviousConversation();
+                                        }
+                                        break;
+                                case "k":
+                                        if (nextConversation) {
+                                                navigateToNextConversation();
+                                        }
+                                        break;
+                                default:
+                                        break;
+                        }
+                },
+                {
+                        preventDefault: true,
+                        enableOnContentEditable: false,
+                        enableOnFormTags: false,
+                }
+        );
+
+        const onFetchMoreIfNeeded = useCallback(async () => {
+                if (hasNextPage) {
+                        await fetchNextPage();
+                }
+        }, [fetchNextPage, hasNextPage]);
+
+        if (!visitor) {
+                return null;
+        }
+
+        if (!selectedConversation) {
+                return null;
+        }
+
+        const navigationProps: ConversationHeaderNavigationProps = {
+                onGoBack: goBack,
+                onNavigateToPrevious: navigateToPreviousConversation,
+                onNavigateToNext: navigateToNextConversation,
+                hasPreviousConversation: Boolean(previousConversation),
+                hasNextConversation: Boolean(nextConversation),
+                selectedConversationIndex,
+                totalOpenConversations: statusCounts.open,
+        };
+
+        const hasUnreadMessage = useMemo(() => {
+                const lastTimelineItem = selectedConversation.lastTimelineItem ?? null;
+                if (!lastTimelineItem) {
+                        return false;
+                }
+
+                if (lastTimelineItem.userId === currentUserId) {
+                        return false;
+                }
+
+                const lastTimelineItemCreatedAt = lastTimelineItem.createdAt
+                        ? new Date(lastTimelineItem.createdAt)
+                        : null;
+                const lastSeenAt = selectedConversation.lastSeenAt
+                        ? new Date(selectedConversation.lastSeenAt)
+                        : null;
+
+                if (!lastTimelineItemCreatedAt) {
+                        return false;
+                }
+
+                if (!lastSeenAt) {
+                        return true;
+                }
+
+                return lastTimelineItemCreatedAt > lastSeenAt;
+        }, [currentUserId, selectedConversation]);
+
+        const conversationProps: ConversationProps = {
+                header: {
+                        isLeftSidebarOpen,
+                        isRightSidebarOpen,
+                        onToggleLeftSidebar: toggleLeftSidebar,
+                        onToggleRightSidebar: toggleRightSidebar,
+                        navigation: navigationProps,
+                        conversationId,
+                        visitorId,
+                        status: selectedConversation?.status,
+                        deletedAt: selectedConversation?.deletedAt ?? null,
+                        hasUnreadMessage,
+                        visitorIsBlocked: selectedConversation?.visitor.isBlocked ?? null,
+                },
+                timeline: {
+                        availableAIAgents: [],
+                        conversationId,
+                        currentUserId,
+                        items: items as TimelineItem[],
+                        onFetchMoreIfNeeded,
+                        seenData,
+                        teamMembers: members,
+                        visitor,
+                },
+                input: {
+                        allowedFileTypes: ["image/*", "application/pdf", "text/*"],
+                        error,
+                        files,
+                        isSubmitting,
+                        maxFileSize: 10 * 1024 * 1024,
+                        maxFiles: 2,
+                        onChange: handleMessageChange,
+                        onFileSelect: addFiles,
+                        onRemoveFile: removeFile,
+                        onSubmit: submit,
+                        placeholder: "Type your message...",
+                        value: message,
+                },
+                visitorSidebar: {
+                        isLoading: isVisitorLoading,
+                        visitor,
+                },
+        };
+
+        return <Conversation {...conversationProps} />;
+}

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversations-list-pane.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversations-list-pane.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useEffect } from "react";
+import type { ConversationStatus } from "@cossistant/types";
+import type { ConversationHeader } from "@/contexts/inboxes";
+import { ConversationsList } from "@/components/conversations-list";
+import { useConversationFocusStore } from "@/contexts/inboxes/conversation-focus-store";
+import { useSidebar } from "@/hooks/use-sidebars";
+
+type ConversationsListPaneProps = {
+        basePath: string;
+        selectedConversationStatus: ConversationStatus | "archived" | null;
+        conversations: ConversationHeader[];
+        websiteSlug: string;
+};
+
+export function ConversationsListPane({
+        basePath,
+        selectedConversationStatus,
+        conversations,
+        websiteSlug,
+}: ConversationsListPaneProps) {
+        const clearFocus = useConversationFocusStore((state) => state.clearFocus);
+        const { open: isLeftSidebarOpen, toggle: toggleLeftSidebar } = useSidebar({
+                position: "left",
+        });
+
+        useEffect(() => {
+                clearFocus();
+        }, [clearFocus, selectedConversationStatus]);
+
+        return (
+                <ConversationsList
+                        basePath={basePath}
+                        conversations={conversations}
+                        isLeftSidebarOpen={isLeftSidebarOpen}
+                        onToggleLeftSidebar={toggleLeftSidebar}
+                        selectedConversationStatus={selectedConversationStatus}
+                        websiteSlug={websiteSlug}
+                />
+        );
+}

--- a/apps/web/src/components/conversation/header/index.tsx
+++ b/apps/web/src/components/conversation/header/index.tsx
@@ -1,101 +1,98 @@
 "use client";
 
+import type { ConversationStatus } from "@cossistant/types";
 import { Button } from "@/components/ui/button";
 import { Icon } from "@/components/ui/icons";
 import { TooltipOnHover } from "@/components/ui/tooltip";
-import { useInboxes } from "@/contexts/inboxes";
-import { useUserSession } from "@/contexts/website";
-import { useSidebar } from "@/hooks/use-sidebars";
 import { PageHeader } from "../../ui/layout";
 import { ConversationBasicActions } from "../actions/basic";
 import { MoreConversationActions } from "../actions/more";
-import { ConversationHeaderNavigation } from "./navigation";
+import {
+        ConversationHeaderNavigation,
+        type ConversationHeaderNavigationProps,
+} from "./navigation";
 
-export function ConversationHeader() {
-	const { selectedConversationId, selectedVisitorId, selectedConversation } =
-		useInboxes();
-	const { user } = useUserSession();
+export type ConversationHeaderProps = {
+        isLeftSidebarOpen: boolean;
+        isRightSidebarOpen: boolean;
+        onToggleLeftSidebar: () => void;
+        onToggleRightSidebar: () => void;
+        navigation: ConversationHeaderNavigationProps;
+        conversationId: string;
+        visitorId?: string | null;
+        status?: ConversationStatus;
+        deletedAt?: string | null;
+        hasUnreadMessage: boolean;
+        visitorIsBlocked?: boolean | null;
+};
 
-	const { open: isRightSidebarOpen, toggle: toggleRightSidebar } = useSidebar({
-		position: "right",
-	});
-	const { open: isLeftSidebarOpen, toggle: toggleLeftSidebar } = useSidebar({
-		position: "left",
-	});
-
-	if (!selectedConversationId) {
-		return null;
-	}
-
-	const lastTimelineItem = selectedConversation?.lastTimelineItem ?? null;
-	const lastTimelineItemCreatedAt = lastTimelineItem?.createdAt
-		? new Date(lastTimelineItem.createdAt)
-		: null;
-	const lastSeenAt = selectedConversation?.lastSeenAt
-		? new Date(selectedConversation.lastSeenAt)
-		: null;
-
-	const hasUnreadMessage = Boolean(
-		lastTimelineItem &&
-			lastTimelineItem.userId !== user.id &&
-			lastTimelineItemCreatedAt &&
-			(!lastSeenAt || lastTimelineItemCreatedAt > lastSeenAt)
-	);
-
-	return (
-		<PageHeader className="z-10 border-primary/10 border-b bg-background pl-3.5 2xl:border-transparent 2xl:bg-transparent dark:bg-background-100 2xl:dark:bg-transparent">
-			<div className="flex items-center gap-2">
-				{!isLeftSidebarOpen && (
-					<TooltipOnHover
-						align="end"
-						content="Click to open sidebar"
-						shortcuts={["["]}
-					>
-						<Button
-							className="ml-0.5"
-							onClick={toggleLeftSidebar}
-							size="icon-small"
-							variant="ghost"
-						>
-							<Icon filledOnHover name="sidebar-collapse" />
-						</Button>
-					</TooltipOnHover>
-				)}
-				<ConversationHeaderNavigation />
-			</div>
-			<div className="flex items-center gap-3">
-				<ConversationBasicActions
-					className="gap-3 pr-0"
-					conversationId={selectedConversationId}
-					deletedAt={selectedConversation?.deletedAt ?? null}
-					status={selectedConversation?.status}
-					visitorId={selectedVisitorId}
-				/>
-				<MoreConversationActions
-					conversationId={selectedConversationId}
-					deletedAt={selectedConversation?.deletedAt ?? null}
-					hasUnreadMessage={hasUnreadMessage}
-					status={selectedConversation?.status}
-					visitorId={selectedVisitorId}
-					visitorIsBlocked={selectedConversation?.visitor.isBlocked ?? null}
-				/>
-				{!isRightSidebarOpen && (
-					<TooltipOnHover
-						align="end"
-						content="Click to open sidebar"
-						shortcuts={["]"]}
-					>
-						<Button
-							className="rotate-180"
-							onClick={toggleRightSidebar}
-							size="icon-small"
-							variant="ghost"
-						>
-							<Icon filledOnHover name="sidebar-collapse" />
-						</Button>
-					</TooltipOnHover>
-				)}
-			</div>
-		</PageHeader>
-	);
+export function ConversationHeader({
+        isLeftSidebarOpen,
+        isRightSidebarOpen,
+        onToggleLeftSidebar,
+        onToggleRightSidebar,
+        navigation,
+        conversationId,
+        visitorId,
+        status,
+        deletedAt,
+        hasUnreadMessage,
+        visitorIsBlocked,
+}: ConversationHeaderProps) {
+        return (
+                <PageHeader className="z-10 border-primary/10 border-b bg-background pl-3.5 2xl:border-transparent 2xl:bg-transparent dark:bg-background-100 2xl:dark:bg-transparent">
+                        <div className="flex items-center gap-2">
+                                {!isLeftSidebarOpen && (
+                                        <TooltipOnHover
+                                                align="end"
+                                                content="Click to open sidebar"
+                                                shortcuts={["["]}
+                                        >
+                                                <Button
+                                                        className="ml-0.5"
+                                                        onClick={onToggleLeftSidebar}
+                                                        size="icon-small"
+                                                        variant="ghost"
+                                                >
+                                                        <Icon filledOnHover name="sidebar-collapse" />
+                                                </Button>
+                                        </TooltipOnHover>
+                                )}
+                                <ConversationHeaderNavigation {...navigation} />
+                        </div>
+                        <div className="flex items-center gap-3">
+                                <ConversationBasicActions
+                                        className="gap-3 pr-0"
+                                        conversationId={conversationId}
+                                        deletedAt={deletedAt ?? null}
+                                        status={status}
+                                        visitorId={visitorId}
+                                />
+                                <MoreConversationActions
+                                        conversationId={conversationId}
+                                        deletedAt={deletedAt ?? null}
+                                        hasUnreadMessage={hasUnreadMessage}
+                                        status={status}
+                                        visitorId={visitorId}
+                                        visitorIsBlocked={visitorIsBlocked ?? null}
+                                />
+                                {!isRightSidebarOpen && (
+                                        <TooltipOnHover
+                                                align="end"
+                                                content="Click to open sidebar"
+                                                shortcuts={["]"]}
+                                        >
+                                                <Button
+                                                        className="rotate-180"
+                                                        onClick={onToggleRightSidebar}
+                                                        size="icon-small"
+                                                        variant="ghost"
+                                                >
+                                                        <Icon filledOnHover name="sidebar-collapse" />
+                                                </Button>
+                                        </TooltipOnHover>
+                                )}
+                        </div>
+                </PageHeader>
+        );
 }

--- a/apps/web/src/components/conversation/header/navigation.tsx
+++ b/apps/web/src/components/conversation/header/navigation.tsx
@@ -1,83 +1,60 @@
-import { useHotkeys } from "react-hotkeys-hook";
 import { Button } from "@/components/ui/button";
 import Icon from "@/components/ui/icons";
 import { TooltipOnHover } from "@/components/ui/tooltip";
-import { useInboxes } from "@/contexts/inboxes";
 
-export function ConversationHeaderNavigation() {
-	const {
-		previousConversation,
-		nextConversation,
-		navigateToPreviousConversation,
-		navigateToNextConversation,
-		goBack,
-		statusCounts,
-		selectedConversationIndex,
-	} = useInboxes();
+export type ConversationHeaderNavigationProps = {
+        onGoBack: () => void;
+        onNavigateToPrevious: () => void;
+        onNavigateToNext: () => void;
+        hasPreviousConversation: boolean;
+        hasNextConversation: boolean;
+        selectedConversationIndex: number;
+        totalOpenConversations: number;
+};
 
-	// keyboard shortcuts for back, previous and next conversation
-	useHotkeys(
-		["escape", "j", "k"],
-		(_, handler) => {
-			switch (handler.keys?.join("")) {
-				case "escape":
-					goBack();
-					break;
-				case "j":
-					if (previousConversation) {
-						navigateToPreviousConversation();
-					}
-					break;
-				case "k":
-					if (nextConversation) {
-						navigateToNextConversation();
-					}
-					break;
-				default:
-					break;
-			}
-		},
-		{
-			preventDefault: true,
-			enableOnContentEditable: false,
-			enableOnFormTags: false,
-		}
-	);
-
-	return (
-		<div className="flex items-center gap-4">
-			<TooltipOnHover content="Go back" shortcuts={["Esc"]}>
-				<Button onClick={goBack} size="icon-small" variant="ghost">
-					<Icon name="arrow-left" />
-				</Button>
-			</TooltipOnHover>
-			<div className="flex items-center gap-2">
-				<TooltipOnHover content="Previous conversation" shortcuts={["j"]}>
-					<Button
-						disabled={!previousConversation}
-						onClick={navigateToPreviousConversation}
-						size="icon-small"
-						variant="outline"
-					>
-						<Icon className="rotate-90" name="arrow-left" />
-					</Button>
-				</TooltipOnHover>
-				<TooltipOnHover content="Next conversation" shortcuts={["k"]}>
-					<Button
-						disabled={!nextConversation}
-						onClick={navigateToNextConversation}
-						size="icon-small"
-						variant="outline"
-					>
-						<Icon className="rotate-90" name="arrow-right" />
-					</Button>
-				</TooltipOnHover>
-			</div>
-			<div className="flex gap-0.5 text-primary/40 text-sm">
-				<span className="text-primary/90">{selectedConversationIndex + 1}</span>
-				<span>/</span>
-				<span>{statusCounts.open}</span>
-			</div>
-		</div>
-	);
+export function ConversationHeaderNavigation({
+        onGoBack,
+        onNavigateToPrevious,
+        onNavigateToNext,
+        hasPreviousConversation,
+        hasNextConversation,
+        selectedConversationIndex,
+        totalOpenConversations,
+}: ConversationHeaderNavigationProps) {
+        return (
+                <div className="flex items-center gap-4">
+                        <TooltipOnHover content="Go back" shortcuts={["Esc"]}>
+                                <Button onClick={onGoBack} size="icon-small" variant="ghost">
+                                        <Icon name="arrow-left" />
+                                </Button>
+                        </TooltipOnHover>
+                        <div className="flex items-center gap-2">
+                                <TooltipOnHover content="Previous conversation" shortcuts={["j"]}>
+                                        <Button
+                                                disabled={!hasPreviousConversation}
+                                                onClick={onNavigateToPrevious}
+                                                size="icon-small"
+                                                variant="outline"
+                                        >
+                                                <Icon className="rotate-90" name="arrow-left" />
+                                        </Button>
+                                </TooltipOnHover>
+                                <TooltipOnHover content="Next conversation" shortcuts={["k"]}>
+                                        <Button
+                                                disabled={!hasNextConversation}
+                                                onClick={onNavigateToNext}
+                                                size="icon-small"
+                                                variant="outline"
+                                        >
+                                                <Icon className="rotate-90" name="arrow-right" />
+                                        </Button>
+                                </TooltipOnHover>
+                        </div>
+                        <div className="flex gap-0.5 text-primary/40 text-sm">
+                                <span className="text-primary/90">{selectedConversationIndex + 1}</span>
+                                <span>/</span>
+                                <span>{totalOpenConversations}</span>
+                        </div>
+                </div>
+        );
 }

--- a/apps/web/src/components/conversation/index.tsx
+++ b/apps/web/src/components/conversation/index.tsx
@@ -1,245 +1,36 @@
 "use client";
 
-import { useMultimodalInput } from "@cossistant/react/hooks/private/use-multimodal-input";
-import { useConversationSeen } from "@cossistant/react/hooks/use-conversation-seen";
-import type { TimelineItem } from "@cossistant/types/api/timeline-item";
-import { useEffect, useMemo, useRef } from "react";
-import { useWindowVisibilityFocus } from "@cossistant/react/hooks/use-window-visibility-focus";
-import { CONVERSATION_AUTO_SEEN_DELAY_MS } from "@cossistant/react/hooks/use-conversation-auto-seen";
-import { useInboxes } from "@/contexts/inboxes";
-import { useWebsiteMembers } from "@/contexts/website";
-import { useConversationActions } from "@/data/use-conversation-actions";
-import { useConversationTimelineItems } from "@/data/use-conversation-timeline-items";
-import { useVisitor } from "@/data/use-visitor";
-import { useAgentTypingReporter } from "@/hooks/use-agent-typing-reporter";
-import { useSendConversationMessage } from "@/hooks/use-send-conversation-message";
+import type { ComponentProps } from "react";
 import { Page } from "../ui/layout";
-import { VisitorSidebar } from "../ui/layout/sidebars/visitor/visitor-sidebar";
-import { ConversationHeader } from "./header";
+import {
+        VisitorSidebar,
+        type VisitorSidebarProps,
+} from "../ui/layout/sidebars/visitor/visitor-sidebar";
+import { ConversationHeader, type ConversationHeaderProps } from "./header";
 import { ConversationTimelineList } from "./messages/conversation-timeline";
-import { MultimodalInput } from "./multimodal-input";
+import { MultimodalInput, type MultimodalInputProps } from "./multimodal-input";
 
-type ConversationProps = {
-	conversationId: string;
-	visitorId: string;
-	websiteSlug: string;
-	currentUserId: string;
+type ConversationTimelineProps = ComponentProps<typeof ConversationTimelineList>;
+
+export type ConversationProps = {
+        header: ConversationHeaderProps;
+        timeline: ConversationTimelineProps;
+        input: MultimodalInputProps;
+        visitorSidebar: VisitorSidebarProps;
 };
 
-const MESSAGES_PAGE_LIMIT = 50;
-
-export function Conversation({
-	conversationId,
-	visitorId,
-	currentUserId,
-	websiteSlug,
-}: ConversationProps) {
-	const { submit: submitConversationMessage } = useSendConversationMessage({
-		conversationId,
-		websiteSlug,
-		currentUserId,
-		pageLimit: MESSAGES_PAGE_LIMIT,
-	});
-
-	const {
-		handleInputChange: handleTypingChange,
-		handleSubmit: handleTypingSubmit,
-		stop: stopTyping,
-	} = useAgentTypingReporter({
-		conversationId,
-		websiteSlug,
-	});
-
-	const {
-		message,
-		files,
-		isSubmitting,
-		error,
-		setMessage,
-		addFiles,
-		removeFile,
-		clearFiles,
-		submit,
-		reset,
-		isValid,
-		canSubmit,
-	} = useMultimodalInput({
-		onSubmit: async (payload) => {
-			handleTypingSubmit();
-			await submitConversationMessage(payload);
-		},
-		onError: (submitError) => {
-			console.error("Failed to send message", submitError);
-		},
-	});
-
-	const handleMessageChange = (value: string) => {
-		setMessage(value);
-		handleTypingChange(value);
-	};
-
-	useEffect(
-		() => () => {
-			stopTyping();
-		},
-		[stopTyping]
-	);
-
-	const members = useWebsiteMembers();
-	const { selectedConversation } = useInboxes();
-	const { markRead } = useConversationActions({
-		conversationId,
-		visitorId,
-	});
-
-        const lastMarkedMessageIdRef = useRef<string | null>(null);
-        const markSeenTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-        const { isPageVisible, hasWindowFocus } = useWindowVisibilityFocus();
-
-	const { items, fetchNextPage, hasNextPage } = useConversationTimelineItems({
-		conversationId,
-		websiteSlug,
-		options: { limit: MESSAGES_PAGE_LIMIT },
-	});
-
-	const { visitor, isLoading } = useVisitor({ visitorId, websiteSlug });
-
-	// Hydrate and subscribe to seen data from the store
-	const seenData = useConversationSeen(conversationId, {
-		initialData: selectedConversation?.seenData ?? [],
-	});
-
-	// Get last message from timeline items (filter for message type)
-	const lastMessage = useMemo(
-		() => items.filter((item) => item.type === "message").at(-1) ?? null,
-		[items]
-	);
-
-        useEffect(() => {
-                if (markSeenTimeoutRef.current) {
-                        clearTimeout(markSeenTimeoutRef.current);
-                        markSeenTimeoutRef.current = null;
-                }
-
-                if (!lastMessage) {
-                        return;
-                }
-
-                if (!selectedConversation || selectedConversation.id !== conversationId) {
-                        lastMarkedMessageIdRef.current = null;
-                        return;
-                }
-
-                if (!isPageVisible || !hasWindowFocus) {
-                        return;
-                }
-
-                if (lastMessage.userId === currentUserId) {
-                        lastMarkedMessageIdRef.current = lastMessage.id || null;
-                        return;
-                }
-
-                const lastMessageCreatedAt = new Date(lastMessage.createdAt);
-                const lastSeenAt = selectedConversation.lastSeenAt
-                        ? new Date(selectedConversation.lastSeenAt)
-                        : null;
-
-                if (lastSeenAt && lastSeenAt >= lastMessageCreatedAt) {
-                        lastMarkedMessageIdRef.current = lastMessage.id || null;
-                        return;
-                }
-
-                if (lastMarkedMessageIdRef.current === (lastMessage.id || null)) {
-                        return;
-                }
-
-                const pendingMessageId = lastMessage.id || null;
-
-                markSeenTimeoutRef.current = setTimeout(() => {
-                        const isVisibleNow =
-                                typeof document !== "undefined" ? !document.hidden : true;
-                        const hasFocusNow =
-                                typeof document !== "undefined" &&
-                                typeof document.hasFocus === "function"
-                                        ? document.hasFocus()
-                                        : true;
-
-                        if (!isVisibleNow || !hasFocusNow) {
-                                markSeenTimeoutRef.current = null;
-                                return;
-                        }
-
-                        markRead()
-                                .then(() => {
-                                        lastMarkedMessageIdRef.current = pendingMessageId;
-                                })
-                                .catch(() => {
-                                        // no-op: we'll retry on next render if needed
-                                })
-                                .finally(() => {
-                                        markSeenTimeoutRef.current = null;
-                                });
-                }, CONVERSATION_AUTO_SEEN_DELAY_MS);
-
-                return () => {
-                        if (markSeenTimeoutRef.current) {
-                                clearTimeout(markSeenTimeoutRef.current);
-                                markSeenTimeoutRef.current = null;
-                        }
-                };
-        }, [
-                conversationId,
-                currentUserId,
-                hasWindowFocus,
-                isPageVisible,
-                lastMessage,
-                markRead,
-                selectedConversation,
-        ]);
-
-	const onFetchMoreIfNeeded = async () => {
-		if (hasNextPage) {
-			await fetchNextPage();
-		}
-	};
-
-	if (!visitor) {
-		return null;
-	}
-
-	return (
-		<>
-			<Page className="relative py-0 pr-0.5 pl-0">
-				<div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-14 bg-gradient-to-b from-co-background/50 to-transparent dark:from-co-background-100/80" />
-				<ConversationHeader />
-				<ConversationTimelineList
-					availableAIAgents={[]}
-					conversationId={conversationId}
-					currentUserId={currentUserId}
-					items={items as TimelineItem[]}
-					onFetchMoreIfNeeded={onFetchMoreIfNeeded}
-					seenData={seenData}
-					teamMembers={members}
-					visitor={visitor}
-				/>
-				<MultimodalInput
-					allowedFileTypes={["image/*", "application/pdf", "text/*"]}
-					error={error}
-					files={files}
-					isSubmitting={isSubmitting}
-					maxFileSize={10 * 1024 * 1024}
-					maxFiles={2}
-					onChange={handleMessageChange}
-					onFileSelect={addFiles}
-					onRemoveFile={removeFile}
-					onSubmit={submit}
-					placeholder="Type your message..."
-					value={message}
-				/>
-				<div className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-30 bg-gradient-to-t from-co-background to-transparent dark:from-co-background-100/90" />
-				<div className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-40 bg-gradient-to-t from-co-background/50 via-co-background to-transparent dark:from-co-background-100/90 dark:via-co-background-100" />
-			</Page>
-			<VisitorSidebar isLoading={isLoading} visitor={visitor} />
-		</>
-	);
+export function Conversation({ header, timeline, input, visitorSidebar }: ConversationProps) {
+        return (
+                <>
+                        <Page className="relative py-0 pr-0.5 pl-0">
+                                <div className="pointer-events-none absolute inset-x-0 top-0 z-0 h-14 bg-gradient-to-b from-co-background/50 to-transparent dark:from-co-background-100/80" />
+                                <ConversationHeader {...header} />
+                                <ConversationTimelineList {...timeline} />
+                                <MultimodalInput {...input} />
+                                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-30 bg-gradient-to-t from-co-background to-transparent dark:from-co-background-100/90" />
+                                <div className="pointer-events-none absolute inset-x-0 bottom-0 z-0 h-40 bg-gradient-to-t from-co-background/50 via-co-background to-transparent dark:from-co-background-100/90 dark:via-co-background-100" />
+                        </Page>
+                        <VisitorSidebar {...visitorSidebar} />
+                </>
+        );
 }

--- a/apps/web/src/components/conversations-list/index.tsx
+++ b/apps/web/src/components/conversations-list/index.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import type { ConversationStatus } from "@cossistant/types";
-import { useEffect } from "react";
 import type { ConversationHeader } from "@/contexts/inboxes";
-import { useConversationFocusStore } from "@/contexts/inboxes/conversation-focus-store";
-import { useSidebar } from "@/hooks/use-sidebars";
 import { Button } from "../ui/button";
 import Icon from "../ui/icons";
 import { Page, PageContent, PageHeader, PageHeaderTitle } from "../ui/layout";
@@ -16,6 +13,8 @@ type Props = {
   selectedConversationStatus: ConversationStatus | "archived" | null;
   conversations: ConversationHeader[];
   websiteSlug: string;
+  isLeftSidebarOpen: boolean;
+  onToggleLeftSidebar: () => void;
 };
 
 export function ConversationsList({
@@ -23,16 +22,9 @@ export function ConversationsList({
   selectedConversationStatus,
   conversations,
   websiteSlug,
+  isLeftSidebarOpen,
+  onToggleLeftSidebar,
 }: Props) {
-  const clearFocus = useConversationFocusStore((state) => state.clearFocus);
-  const { open: isLeftSidebarOpen, toggle: toggleLeftSidebar } = useSidebar({
-    position: "left",
-  });
-
-  useEffect(() => {
-    clearFocus();
-  }, [selectedConversationStatus, clearFocus]);
-
   return (
     <Page className="px-0">
       <PageHeader className="px-4">
@@ -45,7 +37,7 @@ export function ConversationsList({
             >
               <Button
                 className="ml-0.5"
-                onClick={toggleLeftSidebar}
+                onClick={onToggleLeftSidebar}
                 size="icon-small"
                 variant="ghost"
               >

--- a/apps/web/src/components/ui/layout/sidebars/visitor/visitor-sidebar.tsx
+++ b/apps/web/src/components/ui/layout/sidebars/visitor/visitor-sidebar.tsx
@@ -11,9 +11,9 @@ import { VisitorSidebarPlaceholder } from "./placeholder";
 import { ValueDisplay } from "./value-display";
 import { ValueGroup } from "./value-group";
 
-type VisitorSidebarProps = {
-	visitor: RouterOutputs["conversation"]["getVisitorById"];
-	isLoading: boolean;
+export type VisitorSidebarProps = {
+        visitor: RouterOutputs["conversation"]["getVisitorById"] | null;
+        isLoading: boolean;
 };
 
 export function VisitorSidebar({ visitor, isLoading }: VisitorSidebarProps) {


### PR DESCRIPTION
## Summary
- convert dashboard conversation and inbox list React components into presentational shells
- introduce page-level containers that manage data fetching, navigation, and hotkeys for the inbox views
- adjust shared sidebar types to support nullable data for loading states

## Testing
- bun run lint --filter=@cossistant/web *(fails: biome command not found in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68f8dad22fb0832bbe41a59732c4525e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of conversation and inbox components to improve maintainability and code organization. Component architecture updated to be more modular and prop-driven while maintaining all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->