### PR TITLE
fix(next): ensure exports and tsconfig dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -196,6 +196,9 @@
         "@cossistant/react": "workspace:*",
         "tailwindcss": "^4.1.13",
       },
+      "devDependencies": {
+        "@cossistant/typescript-config": "workspace:*",
+      },
       "peerDependencies": {
         "next": ">=13.5.2 || ^14.0.0 || ^15.0.0",
         "react": ">=18 <20",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -69,6 +69,9 @@
     "@cossistant/react": "workspace:*",
     "tailwindcss": "^4.1.13"
   },
+  "devDependencies": {
+    "@cossistant/typescript-config": "workspace:*"
+  },
   "peerDependencies": {
     "react": ">=18 <20",
     "react-dom": ">=18 <20",

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -7,3 +7,4 @@ export * from "./provider";
 export * from "./realtime";
 export * from "./support";
 export * from "./support-config";
+export * from "./utils";

--- a/packages/next/src/utils/index.ts
+++ b/packages/next/src/utils/index.ts
@@ -1,0 +1,3 @@
+"use client";
+
+export * from "@cossistant/react/utils";


### PR DESCRIPTION
## Summary
- add a Next.js utils barrel that re-exports the shared React utilities
- expose the utils barrel from the `@cossistant/next` entrypoint
- declare the shared typescript config as a dev dependency so the build can resolve it

## Testing
- bunx turbo run build --filter=@cossistant/next *(fails: connection refused downloading @tailwindcss/cli during CSS build)*

------
https://chatgpt.com/codex/tasks/task_e_68f927096b94832b96c7a9f89b095ab6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added utility exports to the Next.js package's public API, enabling direct access from the main entry point. Developers can now import utilities without navigating subpaths, resulting in cleaner code organization and a more streamlined development experience. All changes maintain complete backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->