### PR TITLE
chore: add husky pre-commit hook for turbo fix

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+bunx turbo run fix

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "@commitlint/config-conventional": "^19.8.1",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.2",
+        "husky": "^9.1.7",
         "prettier": "^3.6.2",
         "tsdown": "^0.15.2",
         "tsx": "4.20.5",
@@ -1859,6 +1860,8 @@
     "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
 
     "human-id": ["human-id@4.1.2", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-v/J+4Z/1eIJovEBdlV5TYj1IR+ZiohcYGRY+qN/oC9dAfKzVT023N/Bgw37hrKCoVRBvk3bqyzpr2PP5YeTMSg=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
     "dev": "docker compose up -d && turbo run dev",
     "lint": "turbo run lint",
     "check": "npx ultracite@latest check",
-    "fix": "npx ultracite@latest fix",
+    "fix": "bunx ultracite fix",
     "check-types": "turbo run check-types",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.6",
@@ -19,6 +20,7 @@
     "@commitlint/config-conventional": "^19.8.1",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",
+    "husky": "^9.1.7",
     "prettier": "^3.6.2",
     "tsdown": "^0.15.2",
     "tsx": "4.20.5",


### PR DESCRIPTION
## Summary
- add husky as a dev dependency with a prepare script to install hooks
- create a pre-commit hook that runs `bunx turbo run fix`
- switch the fix npm script to use the locally installed ultracite binary

## Testing
- `bunx turbo run fix` *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68f9f1a001e4832b9febd7df6b96795d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated pre-commit code quality checks to run before each commit.
  * Updated build tooling configuration and dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->