### PR TITLE
fix(react): show setup guidance when widget configuration fails

### DIFF
--- a/packages/react/src/hooks/private/use-rest-client.ts
+++ b/packages/react/src/hooks/private/use-rest-client.ts
@@ -5,8 +5,8 @@ import type { CossistantConfig } from "@cossistant/types";
 import { useMemo } from "react";
 
 export type UseClientResult = {
-	client: CossistantClient;
-	error: Error | null;
+        client: CossistantClient | null;
+        error: Error | null;
 };
 
 /**
@@ -16,36 +16,44 @@ export type UseClientResult = {
  * `error` field.
  */
 export function useClient(
-	publicKey: string | undefined,
-	apiUrl = "https://api.cossistant.com/v1",
-	wsUrl = "wss://api.cossistant.com/ws"
+        publicKey: string | undefined,
+        apiUrl = "https://api.cossistant.com/v1",
+        wsUrl = "wss://api.cossistant.com/ws"
 ): UseClientResult {
-	const client = useMemo(() => {
-		const keyFromEnv =
-			process.env.NEXT_PUBLIC_COSSISTANT_KEY ||
-			process.env.COSSISTANT_PUBLIC_KEY;
-		const keyToUse = publicKey ?? keyFromEnv;
+        return useMemo(() => {
+                const keyFromEnv =
+                        process.env.NEXT_PUBLIC_COSSISTANT_KEY ||
+                        process.env.COSSISTANT_PUBLIC_KEY;
+                const keyToUse = publicKey ?? keyFromEnv;
 
-		if (!keyToUse) {
-			throw new Error(
-				"Public key is required. Please provide it as a prop or set NEXT_PUBLIC_COSSISTANT_KEY environment variable."
-			);
-		}
+                if (!keyToUse) {
+                        return {
+                                client: null,
+                                error: new Error(
+                                        "Public key is required. Please provide it as a prop or set NEXT_PUBLIC_COSSISTANT_KEY environment variable."
+                                ),
+                        };
+                }
 
-		const config: CossistantConfig = {
-			apiUrl,
-			wsUrl,
-			publicKey: keyToUse,
-		};
+                const config: CossistantConfig = {
+                        apiUrl,
+                        wsUrl,
+                        publicKey: keyToUse,
+                };
 
-		try {
-			return new CossistantClient(config);
-		} catch (err: unknown) {
-			throw err instanceof Error
-				? err
-				: new Error("Failed to initialize Cossistant client");
-		}
-	}, [publicKey, apiUrl, wsUrl]);
-
-	return { client, error: null };
+                try {
+                        return {
+                                client: new CossistantClient(config),
+                                error: null,
+                        };
+                } catch (err: unknown) {
+                        return {
+                                client: null,
+                                error:
+                                        err instanceof Error
+                                                ? err
+                                                : new Error("Failed to initialize Cossistant client"),
+                        };
+                }
+        }, [publicKey, apiUrl, wsUrl]);
 }

--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -23,16 +23,16 @@ export type SupportProviderProps = {
 export type CossistantProviderProps = SupportProviderProps;
 
 export type CossistantContextValue = {
-	website: PublicWebsiteResponse | null;
-	defaultMessages: DefaultMessage[];
-	quickOptions: string[];
-	setDefaultMessages: (messages: DefaultMessage[]) => void;
-	setQuickOptions: (options: string[]) => void;
-	unreadCount: number;
-	setUnreadCount: (count: number) => void;
-	isLoading: boolean;
-	error: Error | null;
-	client: CossistantClient;
+        website: PublicWebsiteResponse | null;
+        defaultMessages: DefaultMessage[];
+        quickOptions: string[];
+        setDefaultMessages: (messages: DefaultMessage[]) => void;
+        setQuickOptions: (options: string[]) => void;
+        unreadCount: number;
+        setUnreadCount: (count: number) => void;
+        isLoading: boolean;
+        error: Error | null;
+        client: CossistantClient;
 };
 
 type WebsiteData = NonNullable<CossistantContextValue["website"]>;
@@ -48,8 +48,105 @@ export type UseSupportValue = CossistantContextValue & {
 };
 
 const SupportContext = React.createContext<CossistantContextValue | undefined>(
-	undefined
+        undefined
 );
+
+function createUnavailableClient(error: Error): CossistantClient {
+        const fallbackError = error;
+
+        return new Proxy(
+                {},
+                {
+                        get() {
+                                throw fallbackError;
+                        },
+                }
+        ) as CossistantClient;
+}
+
+type SupportProviderWithClientProps = SupportProviderProps & {
+        client: CossistantClient;
+        clientError: Error | null;
+        defaultMessagesState: DefaultMessage[];
+        quickOptionsState: string[];
+        setDefaultMessages: (messages: DefaultMessage[]) => void;
+        setQuickOptions: (options: string[]) => void;
+        unreadCount: number;
+        setUnreadCount: (count: number) => void;
+};
+
+function SupportProviderWithClient({
+        children,
+        client,
+        clientError,
+        autoConnect,
+        onWsConnect,
+        onWsDisconnect,
+        onWsError,
+        publicKey,
+        wsUrl,
+        defaultMessagesState,
+        quickOptionsState,
+        setDefaultMessages,
+        setQuickOptions,
+        unreadCount,
+        setUnreadCount,
+}: SupportProviderWithClientProps) {
+        const { website, isLoading, error: websiteError } = useWebsiteStore(client);
+
+        React.useEffect(() => {
+                if (website) {
+                        // @ts-expect-error internal priming: safe in our library context
+                        client.restClient?.setWebsiteContext?.(website.id, website.visitor?.id);
+                }
+        }, [client, website]);
+
+        const error = clientError ?? websiteError;
+
+        const value = React.useMemo<CossistantContextValue>(
+                () => ({
+                        website,
+                        unreadCount,
+                        setUnreadCount,
+                        isLoading,
+                        error,
+                        client,
+                        defaultMessages: defaultMessagesState,
+                        setDefaultMessages,
+                        quickOptions: quickOptionsState,
+                        setQuickOptions,
+                }),
+                [
+                        website,
+                        unreadCount,
+                        isLoading,
+                        error,
+                        client,
+                        defaultMessagesState,
+                        quickOptionsState,
+                        setDefaultMessages,
+                        setQuickOptions,
+                        setUnreadCount,
+                ]
+        );
+
+        return (
+                <SupportContext.Provider value={value}>
+                        <WebSocketProvider
+                                autoConnect={autoConnect}
+                                onConnect={onWsConnect}
+                                onDisconnect={onWsDisconnect}
+                                onError={onWsError}
+                                publicKey={publicKey}
+                                visitorId={website?.visitor?.id}
+                                websiteId={website?.id}
+                                wsUrl={wsUrl}
+                        >
+                                {children}
+                        </WebSocketProvider>
+                </SupportContext.Provider>
+        );
+}
 
 /**
  * Internal implementation that wires the REST client and websocket provider
@@ -87,82 +184,90 @@ function SupportProviderInner({
 		}
 	}, [quickOptions]);
 
-	const { client } = useClient(publicKey, apiUrl, wsUrl);
-	const { website, isLoading, error: websiteError } = useWebsiteStore(client);
+        const { client, error: clientError } = useClient(publicKey, apiUrl, wsUrl);
 
-	// Prefetch conversations
-	// useConversations(client, {
-	//   enabled: !!website && !!website.visitor && isClientPrimed,
-	// });
+        const setDefaultMessages = React.useCallback(
+                (messages: DefaultMessage[]) => _setDefaultMessages(messages),
+                []
+        );
 
-	const error = websiteError;
+        const setQuickOptions = React.useCallback(
+                (options: string[]) => _setQuickOptions(options),
+                []
+        );
 
-	// Prime REST client with website/visitor context so headers are sent reliably
-	React.useEffect(() => {
-		if (website) {
-			// @ts-expect-error internal priming: safe in our library context
-			client.restClient?.setWebsiteContext?.(website.id, website.visitor?.id);
-		}
-	}, [client, website]);
+        const setUnreadCountStable = React.useCallback(
+                (count: number) => setUnreadCount(count),
+                []
+        );
 
-	const setDefaultMessages = React.useCallback(
-		(messages: DefaultMessage[]) => _setDefaultMessages(messages),
-		[]
-	);
+        const fallbackError = React.useMemo(
+                () =>
+                        clientError ??
+                        new Error(
+                                "Public key is required. Please provide it as a prop or set NEXT_PUBLIC_COSSISTANT_KEY environment variable."
+                        ),
+                [clientError]
+        );
 
-	const setQuickOptions = React.useCallback(
-		(options: string[]) => _setQuickOptions(options),
-		[]
-	);
+        const unavailableClient = React.useMemo(
+                () => createUnavailableClient(fallbackError),
+                [fallbackError]
+        );
 
-	const setUnreadCountStable = React.useCallback(
-		(count: number) => setUnreadCount(count),
-		[]
-	);
+        if (!client) {
+                const value = React.useMemo<CossistantContextValue>(
+                        () => ({
+                                website: null,
+                                unreadCount,
+                                setUnreadCount: setUnreadCountStable,
+                                isLoading: false,
+                                error: fallbackError,
+                                client: unavailableClient,
+                                defaultMessages: _defaultMessages,
+                                setDefaultMessages,
+                                quickOptions: _quickOptions,
+                                setQuickOptions,
+                        }),
+                        [
+                                unreadCount,
+                                setUnreadCountStable,
+                                fallbackError,
+                                unavailableClient,
+                                _defaultMessages,
+                                _quickOptions,
+                                setDefaultMessages,
+                                setQuickOptions,
+                        ]
+                );
 
-	const value = React.useMemo<CossistantContextValue>(
-		() => ({
-			website,
-			unreadCount,
-			setUnreadCount: setUnreadCountStable,
-			isLoading,
-			error,
-			client,
-			defaultMessages: _defaultMessages,
-			setDefaultMessages,
-			quickOptions: _quickOptions,
-			setQuickOptions,
-		}),
-		[
-			website,
-			unreadCount,
-			isLoading,
-			error,
-			client,
-			_defaultMessages,
-			_quickOptions,
-			setDefaultMessages,
-			setQuickOptions,
-			setUnreadCountStable,
-		]
-	);
+                return (
+                        <SupportContext.Provider value={value}>
+                                {children}
+                        </SupportContext.Provider>
+                );
+        }
 
-	return (
-		<SupportContext.Provider value={value}>
-			<WebSocketProvider
-				autoConnect={autoConnect}
-				onConnect={onWsConnect}
-				onDisconnect={onWsDisconnect}
-				onError={onWsError}
-				publicKey={publicKey}
-				visitorId={website?.visitor?.id}
-				websiteId={website?.id}
-				wsUrl={wsUrl}
-			>
-				{children}
-			</WebSocketProvider>
-		</SupportContext.Provider>
-	);
+        return (
+                <SupportProviderWithClient
+                        autoConnect={autoConnect}
+                        client={client}
+                        clientError={clientError}
+                        defaultMessagesState={_defaultMessages}
+                        onWsConnect={onWsConnect}
+                        onWsDisconnect={onWsDisconnect}
+                        onWsError={onWsError}
+                        publicKey={publicKey}
+                        quickOptionsState={_quickOptions}
+                        setDefaultMessages={setDefaultMessages}
+                        setQuickOptions={setQuickOptions}
+                        setUnreadCount={setUnreadCountStable}
+                        unreadCount={unreadCount}
+                        wsUrl={wsUrl}
+                >
+                        {children}
+                </SupportProviderWithClient>
+        );
 }
 
 /**

--- a/packages/react/src/support/components/support-unavailable.tsx
+++ b/packages/react/src/support/components/support-unavailable.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import React, { type ReactElement } from "react";
+
+import { Button } from "../../primitives/button";
+import { cn } from "../utils";
+
+const DOCS_URL = "https://cossistant.com/docs";
+
+export type SupportUnavailableProps = {
+        className?: string;
+        position?: "top" | "bottom";
+        align?: "right" | "left";
+        mode?: "floating" | "responsive";
+        errorMessage?: string;
+};
+
+export function SupportUnavailable({
+        className,
+        position = "bottom",
+        align = "right",
+        mode = "floating",
+        errorMessage,
+}: SupportUnavailableProps): ReactElement {
+        const wrapperClasses = cn(
+                "cossistant",
+                {
+                        "fixed z-[9999]": mode === "floating",
+                        "bottom-4": mode === "floating" && position === "bottom",
+                        "top-4": mode === "floating" && position === "top",
+                        "right-4": mode === "floating" && align === "right",
+                        "left-4": mode === "floating" && align === "left",
+                        "relative h-full w-full": mode === "responsive",
+                },
+                className
+        );
+
+        const panelClasses = cn(
+                "flex h-full w-full flex-col items-center justify-center bg-co-background text-center",
+                mode === "floating"
+                        ? "max-md:fixed max-md:inset-0 max-md:bg-co-background md:relative md:aspect-[9/18] md:max-h-[calc(100vh-6rem)] md:w-[400px] md:rounded-lg md:border md:border-dashed md:border-co-border md:shadow-xl"
+                        : "md:relative md:h-full md:w-full md:rounded-none md:border-0 md:shadow-none"
+        );
+
+        return (
+                <div className={wrapperClasses}>
+                        <div className={panelClasses}>
+                                <div className="mx-auto flex w-full max-w-xs flex-col items-center justify-center space-y-4 px-6 py-12">
+                                        <div className="space-y-2">
+                                                <h2 className="text-base font-semibold text-co-foreground">
+                                                        No public key found
+                                                </h2>
+                                                <p className="text-sm text-co-muted-foreground">
+                                                        Add your Cossistant public key to finish configuring the widget. This
+                                                        notice only appears in local development.
+                                                </p>
+                                                {errorMessage ? (
+                                                        <p className="text-xs text-co-muted-foreground/80">
+                                                                {errorMessage}
+                                                        </p>
+                                                ) : null}
+                                        </div>
+                                        <Button
+                                                asChild
+                                                className="inline-flex items-center justify-center rounded-md border border-co-border bg-co-primary px-4 py-2 text-sm font-medium text-co-primary-foreground shadow-sm transition-colors hover:bg-co-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-co-ring focus-visible:ring-offset-2 focus-visible:ring-offset-co-background"
+                                        >
+                                                <a href={DOCS_URL} rel="noreferrer" target="_blank">
+                                                        View documentation
+                                                </a>
+                                        </Button>
+                                </div>
+                        </div>
+                </div>
+        );
+}

--- a/packages/react/src/support/index.tsx
+++ b/packages/react/src/support/index.tsx
@@ -6,9 +6,28 @@ import { useSupport } from "../provider";
 import { SupportRealtimeProvider } from "../realtime";
 import { SupportConfig } from "../support-config";
 import { SupportContent } from "./components/support-content";
+import { SupportUnavailable } from "./components/support-unavailable";
 import { SupportConfigProvider } from "./context/config";
 import type { SupportLocale, SupportTextContentOverrides } from "./text";
 import { SupportTextProvider } from "./text";
+
+const LOCALHOST_HOSTNAMES = new Set([
+        "localhost",
+        "127.0.0.1",
+        "0.0.0.0",
+        "::1",
+]);
+
+function isLocalEnvironment(): boolean {
+        if (typeof window === "undefined") {
+                return false;
+        }
+
+        const hostname = window.location.hostname.toLowerCase();
+        return (
+                LOCALHOST_HOSTNAMES.has(hostname) || hostname.endsWith(".localhost")
+        );
+}
 
 export type SupportProps<Locale extends string = SupportLocale> = {
 	className?: string;
@@ -30,21 +49,39 @@ export type SupportProps<Locale extends string = SupportLocale> = {
  * flashing incomplete UI.
  */
 export function Support<Locale extends string = SupportLocale>({
-	className,
-	position = "bottom",
-	align = "right",
-	mode = "floating",
-	quickOptions,
-	defaultMessages,
-	defaultOpen,
-	locale,
-	content,
+        className,
+        position = "bottom",
+        align = "right",
+        mode = "floating",
+        quickOptions,
+        defaultMessages,
+        defaultOpen,
+        locale,
+        content,
 }: SupportProps<Locale>): ReactElement | null {
-	const { website } = useSupport();
+        const { website, error } = useSupport();
 
-	if (!website) {
-		return null;
-	}
+        const isLocalhost = isLocalEnvironment();
+
+        if (error) {
+                if (!isLocalhost) {
+                        return null;
+                }
+
+                return (
+                        <SupportUnavailable
+                                align={align}
+                                className={className}
+                                errorMessage={error.message}
+                                mode={mode}
+                                position={position}
+                        />
+                );
+        }
+
+        if (!website) {
+                return null;
+        }
 
 	return (
 		<>


### PR DESCRIPTION
## Summary
- surface missing or invalid Cossistant public key errors via the React support provider
- short-circuit provider wiring when the REST client cannot be created and expose a localhost-only fallback context
- render a setup guidance panel with documentation link in the support widget when website loading fails during local development

## Testing
- bun run lint *(fails: turbo not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa11f030d4832bb874fdf01236740e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful error state UI for when support is unavailable, displayed in local development environments.

* **Bug Fixes**
  * Improved error handling to show user-friendly messages instead of failing silently.
  * Support feature now degrades gracefully when client initialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->