### PR TITLE
feat(react): collect visitor contact details

### DIFF
--- a/packages/react/src/support/components/index.ts
+++ b/packages/react/src/support/components/index.ts
@@ -8,6 +8,7 @@ export type { IconName, IconProps, IconVariant } from "./icons";
 export { default as Icon } from "./icons";
 export { SendButton } from "./multimodal-input";
 export { SupportContent } from "./support-content";
+export { VisitorIdentification } from "./visitor-identification";
 export type { TimelineMessageGroupProps } from "./timeline-message-group";
 export { TimelineMessageGroup } from "./timeline-message-group";
 export type { TimelineMessageItemProps } from "./timeline-message-item";

--- a/packages/react/src/support/components/visitor-identification.tsx
+++ b/packages/react/src/support/components/visitor-identification.tsx
@@ -1,0 +1,168 @@
+import { useState, type FormEvent, type ReactElement } from "react";
+
+import { useVisitor } from "../../hooks/use-visitor";
+import { useSupport } from "../../provider";
+import { Button } from "./button";
+import { Header } from "./header";
+import { Text, useSupportText } from "../text";
+import { Watermark } from "./watermark";
+
+const EMAIL_PATTERN = /[^@\s]+@[^@\s]+\.[^@\s]+/;
+
+export function VisitorIdentification(): ReactElement {
+        const { identify } = useVisitor();
+        const { website, client } = useSupport();
+        const text = useSupportText();
+        const [email, setEmail] = useState("");
+        const [name, setName] = useState("");
+        const [error, setError] = useState<string | null>(null);
+        const [isSubmitting, setIsSubmitting] = useState(false);
+
+        if (!website) {
+                return null;
+        }
+
+        const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault();
+                setError(null);
+
+                const trimmedEmail = email.trim();
+                if (!EMAIL_PATTERN.test(trimmedEmail)) {
+                        setError(text("component.visitorIdentification.error.emailRequired"));
+                        return;
+                }
+
+                setIsSubmitting(true);
+
+                try {
+                        const result = await identify({
+                                email: trimmedEmail,
+                                name: name.trim() || undefined,
+                        });
+
+                        if (!result) {
+                                throw new Error("Identify failed");
+                        }
+
+                        const normalizedContact = {
+                                id: result.contact.id,
+                                name: result.contact.name,
+                                email: result.contact.email ?? trimmedEmail,
+                                image: result.contact.image,
+                        };
+
+                        const currentVisitor = website.visitor;
+
+                        const updatedVisitor = currentVisitor
+                                ? { ...currentVisitor, id: result.visitorId, contact: normalizedContact }
+                                : {
+                                          id: result.visitorId,
+                                          isBlocked: false,
+                                          language: null,
+                                          contact: normalizedContact,
+                                  };
+
+                        client.websiteStore.setWebsite({
+                                ...website,
+                                visitor: updatedVisitor,
+                        });
+                } catch (submitError) {
+                        console.error("Failed to identify visitor", submitError);
+                        setError(text("component.visitorIdentification.error.generic"));
+                } finally {
+                        setIsSubmitting(false);
+                }
+        };
+
+        return (
+                <div className="flex h-full flex-col overflow-hidden">
+                        <Header />
+
+                        <div className="flex flex-1 flex-col justify-center px-6 py-8">
+                                <div className="mx-auto flex w-full max-w-sm flex-col gap-6">
+                                        <div className="flex flex-col items-center gap-2 text-center">
+                                                <Text
+                                                        as="h2"
+                                                        className="font-co-sans text-xl text-co-foreground"
+                                                        textKey="component.visitorIdentification.title"
+                                                />
+                                                <Text
+                                                        as="p"
+                                                        className="text-co-primary/70 text-sm"
+                                                        textKey="component.visitorIdentification.description"
+                                                />
+                                        </div>
+
+                                        <form className="flex flex-col gap-4" noValidate onSubmit={handleSubmit}>
+                                                <label className="flex flex-col gap-1 text-left">
+                                                        <Text
+                                                                as="span"
+                                                                className="text-xs font-medium uppercase tracking-wide text-co-primary/60"
+                                                                textKey="component.visitorIdentification.emailLabel"
+                                                        />
+                                                        <input
+                                                                aria-describedby={
+                                                                        error
+                                                                                ? "cossistant-support-identify-error"
+                                                                                : undefined
+                                                                }
+                                                                aria-invalid={error ? "true" : undefined}
+                                                                autoComplete="email"
+                                                                className="w-full rounded-md border border-co-border bg-transparent px-3 py-2 text-sm text-co-foreground outline-none transition focus:border-co-primary focus:ring-2 focus:ring-co-primary/20"
+                                                                disabled={isSubmitting}
+                                                                inputMode="email"
+                                                                onChange={(event) => setEmail(event.target.value)}
+                                                                placeholder={text(
+                                                                        "component.visitorIdentification.emailPlaceholder"
+                                                                )}
+                                                                required
+                                                                type="email"
+                                                                value={email}
+                                                        />
+                                                </label>
+
+                                                <label className="flex flex-col gap-1 text-left">
+                                                        <span className="text-xs font-medium uppercase tracking-wide text-co-primary/60">
+                                                                <Text textKey="component.visitorIdentification.nameLabel" />
+                                                                <span className="ml-1 text-co-primary/40">
+                                                                        <Text textKey="component.visitorIdentification.nameOptional" />
+                                                                </span>
+                                                        </span>
+                                                        <input
+                                                                autoComplete="name"
+                                                                className="w-full rounded-md border border-co-border bg-transparent px-3 py-2 text-sm text-co-foreground outline-none transition focus:border-co-primary focus:ring-2 focus:ring-co-primary/20"
+                                                                disabled={isSubmitting}
+                                                                onChange={(event) => setName(event.target.value)}
+                                                                placeholder={text(
+                                                                        "component.visitorIdentification.namePlaceholder"
+                                                                )}
+                                                                type="text"
+                                                                value={name}
+                                                        />
+                                                </label>
+
+                                                {error && (
+                                                        <p
+                                                                className="text-destructive text-sm"
+                                                                id="cossistant-support-identify-error"
+                                                        >
+                                                                {error}
+                                                        </p>
+                                                )}
+
+                                                <Button
+                                                        className="w-full"
+                                                        disabled={isSubmitting}
+                                                        type="submit"
+                                                        variant="secondary"
+                                                >
+                                                        <Text textKey="component.visitorIdentification.submit" />
+                                                </Button>
+                                        </form>
+                                </div>
+                        </div>
+
+                        <Watermark className="mb-4" />
+                </div>
+        );
+}

--- a/packages/react/src/support/router.tsx
+++ b/packages/react/src/support/router.tsx
@@ -1,4 +1,6 @@
 import type React from "react";
+import { useSupport } from "../provider";
+import { VisitorIdentification } from "./components/visitor-identification";
 import { ArticlesPage } from "./pages/articles";
 import { ConversationPage } from "./pages/conversation";
 import { ConversationHistoryPage } from "./pages/conversation-history";
@@ -12,11 +14,16 @@ import { useSupportNavigation } from "./store/support-store";
  * so the router simply maps navigation state to the appropriate page component.
  */
 export const SupportRouter: React.FC = () => {
-	const { current } = useSupportNavigation();
+        const { visitor } = useSupport();
+        const { current } = useSupportNavigation();
 
-	switch (current.page) {
-		case "HOME":
-			return <HomePage />;
+        if (!visitor?.contact) {
+                return <VisitorIdentification />;
+        }
+
+        switch (current.page) {
+                case "HOME":
+                        return <HomePage />;
 
 		case "ARTICLES":
 			return <ArticlesPage />;

--- a/packages/react/src/support/text/locales/en.tsx
+++ b/packages/react/src/support/text/locales/en.tsx
@@ -74,12 +74,25 @@ const en: SupportLocaleMessages = {
 		`${variables.actorName} added a tag`,
 	"component.conversationEvent.tagRemoved": ({ variables }) =>
 		`${variables.actorName} removed a tag`,
-	"component.multimodalInput.placeholder": "Type your message...",
-	"component.multimodalInput.remove": ({ variables }) =>
-		`Remove ${variables.fileName}`,
-	"component.navigation.articles": "Articles",
-	"component.navigation.home": "Home",
-	"component.message.timestamp.aiIndicator": "• AI agent",
+        "component.multimodalInput.placeholder": "Type your message...",
+        "component.multimodalInput.remove": ({ variables }) =>
+                `Remove ${variables.fileName}`,
+        "component.visitorIdentification.title": "Stay in touch",
+        "component.visitorIdentification.description":
+                "Leave your contact details so we can follow up if you step away.",
+        "component.visitorIdentification.emailLabel": "Email address",
+        "component.visitorIdentification.emailPlaceholder": "you@example.com",
+        "component.visitorIdentification.nameLabel": "Name",
+        "component.visitorIdentification.nameOptional": "optional",
+        "component.visitorIdentification.namePlaceholder": "Jane Doe",
+        "component.visitorIdentification.submit": "Continue",
+        "component.visitorIdentification.error.emailRequired":
+                "Please enter a valid email address.",
+        "component.visitorIdentification.error.generic":
+                "We couldn't save your details. Please try again.",
+        "component.navigation.articles": "Articles",
+        "component.navigation.home": "Home",
+        "component.message.timestamp.aiIndicator": "• AI agent",
 };
 
 export default en;

--- a/packages/react/src/support/text/locales/es.tsx
+++ b/packages/react/src/support/text/locales/es.tsx
@@ -72,12 +72,25 @@ const es: SupportLocaleMessages = {
 		`${variables.actorName} agregó una etiqueta`,
 	"component.conversationEvent.tagRemoved": ({ variables }) =>
 		`${variables.actorName} quitó una etiqueta`,
-	"component.multimodalInput.placeholder": "Escribe tu mensaje...",
-	"component.multimodalInput.remove": ({ variables }) =>
-		`Eliminar ${variables.fileName}`,
-	"component.navigation.articles": "Artículos",
-	"component.navigation.home": "Inicio",
-	"component.message.timestamp.aiIndicator": "• Agente IA",
+        "component.multimodalInput.placeholder": "Escribe tu mensaje...",
+        "component.multimodalInput.remove": ({ variables }) =>
+                `Eliminar ${variables.fileName}`,
+        "component.visitorIdentification.title": "Mantente en contacto",
+        "component.visitorIdentification.description":
+                "Déjanos tus datos de contacto para que podamos hacer seguimiento si te ausentas.",
+        "component.visitorIdentification.emailLabel": "Correo electrónico",
+        "component.visitorIdentification.emailPlaceholder": "tu@ejemplo.com",
+        "component.visitorIdentification.nameLabel": "Nombre",
+        "component.visitorIdentification.nameOptional": "opcional",
+        "component.visitorIdentification.namePlaceholder": "Ana Pérez",
+        "component.visitorIdentification.submit": "Continuar",
+        "component.visitorIdentification.error.emailRequired":
+                "Introduce un correo electrónico válido.",
+        "component.visitorIdentification.error.generic":
+                "No pudimos guardar tus datos. Inténtalo de nuevo.",
+        "component.navigation.articles": "Artículos",
+        "component.navigation.home": "Inicio",
+        "component.message.timestamp.aiIndicator": "• Agente IA",
 };
 
 export default es;

--- a/packages/react/src/support/text/locales/fr.tsx
+++ b/packages/react/src/support/text/locales/fr.tsx
@@ -72,12 +72,25 @@ const fr: SupportLocaleMessages = {
 		`${variables.actorName} a ajouté une étiquette`,
 	"component.conversationEvent.tagRemoved": ({ variables }) =>
 		`${variables.actorName} a retiré une étiquette`,
-	"component.multimodalInput.placeholder": "Écrivez votre message...",
-	"component.multimodalInput.remove": ({ variables }) =>
-		`Supprimer ${variables.fileName}`,
-	"component.navigation.articles": "Articles",
-	"component.navigation.home": "Accueil",
-	"component.message.timestamp.aiIndicator": "• Agent IA",
+        "component.multimodalInput.placeholder": "Écrivez votre message...",
+        "component.multimodalInput.remove": ({ variables }) =>
+                `Supprimer ${variables.fileName}`,
+        "component.visitorIdentification.title": "Restez en contact",
+        "component.visitorIdentification.description":
+                "Laissez-nous vos coordonnées afin que nous puissions vous répondre si vous vous absentez.",
+        "component.visitorIdentification.emailLabel": "Adresse e-mail",
+        "component.visitorIdentification.emailPlaceholder": "vous@example.com",
+        "component.visitorIdentification.nameLabel": "Nom",
+        "component.visitorIdentification.nameOptional": "optionnel",
+        "component.visitorIdentification.namePlaceholder": "Jean Dupont",
+        "component.visitorIdentification.submit": "Continuer",
+        "component.visitorIdentification.error.emailRequired":
+                "Veuillez saisir une adresse e-mail valide.",
+        "component.visitorIdentification.error.generic":
+                "Nous n'avons pas pu enregistrer vos informations. Veuillez réessayer.",
+        "component.navigation.articles": "Articles",
+        "component.navigation.home": "Accueil",
+        "component.message.timestamp.aiIndicator": "• Agent IA",
 };
 
 export default fr;

--- a/packages/react/src/support/text/locales/keys.ts
+++ b/packages/react/src/support/text/locales/keys.ts
@@ -109,17 +109,27 @@ export const supportTextDefinitions = {
 	"component.conversationEvent.tagRemoved": {
 		variables: { actorName: "" as string },
 	},
-	"component.multimodalInput.placeholder": {
-		variables: undefined,
-	},
-	"component.multimodalInput.remove": {
-		variables: { fileName: "" as string },
-	},
-	"component.navigation.articles": {
-		variables: undefined,
-	},
-	"component.navigation.home": {
-		variables: undefined,
+        "component.multimodalInput.placeholder": {
+                variables: undefined,
+        },
+        "component.multimodalInput.remove": {
+                variables: { fileName: "" as string },
+        },
+        "component.visitorIdentification.title": { variables: undefined },
+        "component.visitorIdentification.description": { variables: undefined },
+        "component.visitorIdentification.emailLabel": { variables: undefined },
+        "component.visitorIdentification.emailPlaceholder": { variables: undefined },
+        "component.visitorIdentification.nameLabel": { variables: undefined },
+        "component.visitorIdentification.nameOptional": { variables: undefined },
+        "component.visitorIdentification.namePlaceholder": { variables: undefined },
+        "component.visitorIdentification.submit": { variables: undefined },
+        "component.visitorIdentification.error.emailRequired": { variables: undefined },
+        "component.visitorIdentification.error.generic": { variables: undefined },
+        "component.navigation.articles": {
+                variables: undefined,
+        },
+        "component.navigation.home": {
+                variables: undefined,
 	},
 	"component.message.timestamp.aiIndicator": {
 		variables: undefined,


### PR DESCRIPTION
## Summary
- add a visitor identification gate that prompts for contact information when no contact is linked to the current session
- wire the new form into the support router and expose localized copy for english, spanish, and french

## Testing
- bun run lint *(fails: turbo: command not found in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa11576408832b8538f3ae7bc5bf10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visitor identification form that collects email and optional name before accessing support
  * Includes email validation with clear error messaging
  * Form persists visitor contact information for improved support experience
  * Available in English, Spanish, and French

<!-- end of auto-generated comment: release notes by coderabbit.ai -->