### PR TITLE
fix: block visitor messaging on closed conversations

### DIFF
--- a/apps/api/src/rest/routers/messages.ts
+++ b/apps/api/src/rest/routers/messages.ts
@@ -15,12 +15,17 @@ import {
 	sendTimelineItemResponseSchema,
 	type TimelineItem,
 } from "@cossistant/types/api/timeline-item";
-import { ConversationTimelineType } from "@cossistant/types/enums";
+import {
+	ConversationStatus,
+	ConversationTimelineType,
+} from "@cossistant/types/enums";
 import { OpenAPIHono, z } from "@hono/zod-openapi";
 import { protectedPublicApiKeyMiddleware } from "../middleware";
 import type { RestContext } from "../types";
 
 export const messagesRouter = new OpenAPIHono<RestContext>();
+
+const VISITOR_MESSAGE_ALLOWED_STATUSES = new Set([ConversationStatus.OPEN]);
 
 // Apply middleware to all routes in this router
 messagesRouter.use("/*", ...protectedPublicApiKeyMiddleware);
@@ -137,6 +142,22 @@ messagesRouter.openapi(
 			return c.json(
 				validateResponse(
 					{ error: "Forbidden: visitor does not own the conversation" },
+					z.object({ error: z.string() })
+				),
+				403
+			);
+		}
+
+		if (
+			isPublic &&
+			!VISITOR_MESSAGE_ALLOWED_STATUSES.has(conversation.status)
+		) {
+			return c.json(
+				validateResponse(
+					{
+						error:
+							"Forbidden: visitor cannot reply to this conversation status",
+					},
 					z.object({ error: z.string() })
 				),
 				403

--- a/packages/react/src/support/pages/conversation.tsx
+++ b/packages/react/src/support/pages/conversation.tsx
@@ -1,5 +1,7 @@
+import { ConversationStatus } from "@cossistant/types";
 import type { TimelineItem } from "@cossistant/types/api/timeline-item";
 import type { ReactElement } from "react";
+import { useConversation } from "../../hooks/use-conversation";
 import { useConversationPage } from "../../hooks/use-conversation-page";
 import { useSupport } from "../../provider";
 import { AvatarStack } from "../components/avatar-stack";
@@ -60,6 +62,21 @@ export const ConversationPage: ConversationPageComponent = ({
 		},
 	});
 
+	const activeConversationId = conversation.isPending
+		? null
+		: conversation.conversationId;
+	const { conversation: activeConversation } = useConversation(
+		activeConversationId,
+		{
+			enabled: Boolean(activeConversationId),
+		}
+	);
+
+	const isComposerAllowed =
+		conversation.isPending ||
+		!activeConversation ||
+		activeConversation.status === ConversationStatus.OPEN;
+
 	const handleGoBack = () => {
 		if (canGoBack) {
 			goBack();
@@ -99,20 +116,22 @@ export const ConversationPage: ConversationPageComponent = ({
 				items={conversation.items}
 			/>
 
-			<div className="flex-shrink-0 p-1">
-				<MultimodalInput
-					disabled={conversation.composer.isSubmitting}
-					error={conversation.error}
-					files={conversation.composer.files}
-					isSubmitting={conversation.composer.isSubmitting}
-					onChange={conversation.composer.setMessage}
-					onFileSelect={conversation.composer.addFiles}
-					onRemoveFile={conversation.composer.removeFile}
-					onSubmit={conversation.composer.submit}
-					placeholder={text("component.multimodalInput.placeholder")}
-					value={conversation.composer.message}
-				/>
-			</div>
+			{isComposerAllowed ? (
+				<div className="flex-shrink-0 p-1">
+					<MultimodalInput
+						disabled={conversation.composer.isSubmitting}
+						error={conversation.error}
+						files={conversation.composer.files}
+						isSubmitting={conversation.composer.isSubmitting}
+						onChange={conversation.composer.setMessage}
+						onFileSelect={conversation.composer.addFiles}
+						onRemoveFile={conversation.composer.removeFile}
+						onSubmit={conversation.composer.submit}
+						placeholder={text("component.multimodalInput.placeholder")}
+						value={conversation.composer.message}
+					/>
+				</div>
+			) : null}
 		</div>
 	);
 };


### PR DESCRIPTION
## Summary
- hide the support widget composer when an existing conversation is no longer open
- guard the public messages API so visitors cannot post to closed conversations

## Testing
- bun run lint (packages/react)
- bun run lint (apps/api)

------
https://chatgpt.com/codex/tasks/task_e_68fa119858e8832bba7e5bf3eda4d5c6