### PR TITLE
fix: stabilize ConversationPane hook order

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
@@ -249,55 +249,56 @@ export function ConversationPane({
 		}
 	}, [fetchNextPage, hasNextPage]);
 
-	if (!visitor) {
-		return null;
-	}
+        const hasUnreadMessage = useMemo(() => {
+                const lastTimelineItem = selectedConversation?.lastTimelineItem ?? null;
 
-	if (!selectedConversation) {
-		return null;
-	}
+                if (!lastTimelineItem) {
+                        return false;
+                }
 
-	const navigationProps: ConversationHeaderNavigationProps = {
-		onGoBack: goBack,
-		onNavigateToPrevious: navigateToPreviousConversation,
-		onNavigateToNext: navigateToNextConversation,
-		hasPreviousConversation: Boolean(previousConversation),
-		hasNextConversation: Boolean(nextConversation),
+                if (lastTimelineItem.userId === currentUserId) {
+                        return false;
+                }
+
+                const lastTimelineItemCreatedAt = lastTimelineItem.createdAt
+                        ? new Date(lastTimelineItem.createdAt)
+                        : null;
+                const lastSeenAt = selectedConversation?.lastSeenAt
+                        ? new Date(selectedConversation.lastSeenAt)
+                        : null;
+
+                if (!lastTimelineItemCreatedAt) {
+                        return false;
+                }
+
+                if (!lastSeenAt) {
+                        return true;
+                }
+
+                return lastTimelineItemCreatedAt > lastSeenAt;
+        }, [currentUserId, selectedConversation]);
+
+        if (!visitor) {
+                return null;
+        }
+
+        if (!selectedConversation) {
+                return null;
+        }
+
+        const navigationProps: ConversationHeaderNavigationProps = {
+                onGoBack: goBack,
+                onNavigateToPrevious: navigateToPreviousConversation,
+                onNavigateToNext: navigateToNextConversation,
+                hasPreviousConversation: Boolean(previousConversation),
+                hasNextConversation: Boolean(nextConversation),
 		selectedConversationIndex,
 		totalOpenConversations: statusCounts.open,
 	};
 
-	const hasUnreadMessage = useMemo(() => {
-		const lastTimelineItem = selectedConversation.lastTimelineItem ?? null;
-		if (!lastTimelineItem) {
-			return false;
-		}
-
-		if (lastTimelineItem.userId === currentUserId) {
-			return false;
-		}
-
-		const lastTimelineItemCreatedAt = lastTimelineItem.createdAt
-			? new Date(lastTimelineItem.createdAt)
-			: null;
-		const lastSeenAt = selectedConversation.lastSeenAt
-			? new Date(selectedConversation.lastSeenAt)
-			: null;
-
-		if (!lastTimelineItemCreatedAt) {
-			return false;
-		}
-
-		if (!lastSeenAt) {
-			return true;
-		}
-
-		return lastTimelineItemCreatedAt > lastSeenAt;
-	}, [currentUserId, selectedConversation]);
-
-	const conversationProps: ConversationProps = {
-		header: {
-			isLeftSidebarOpen,
+        const conversationProps: ConversationProps = {
+                header: {
+                        isLeftSidebarOpen,
 			isRightSidebarOpen,
 			onToggleLeftSidebar: toggleLeftSidebar,
 			onToggleRightSidebar: toggleRightSidebar,


### PR DESCRIPTION
## Summary
- ensure the ConversationPane hook order remains stable across renders by memoizing unread state before early returns
- guard the unread state calculation against missing conversation data

## Testing
- bun run lint *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb2d07b210832bb640fa1b2e359f69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation headers now display unread message status

* **Refactor**
  * Improved conversation pane initialization logic and state validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->