### PR TITLE
fix: restage lint fixes in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
-bunx turbo run fix
+#!/usr/bin/env sh
+
+if bunx turbo run fix; then
+git add --update
+fi


### PR DESCRIPTION
## Summary
- update the Husky pre-commit hook to rerun `git add --update` when lint fixes succeed
- ensure linted files remain staged automatically after running the fix task

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb2f58393c832baf9d9adc981bdd05

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit hook configuration to enhance development workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->