### PR TITLE
fix: unblock profile form submission after avatar upload

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/settings/user-profile-form.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/settings/user-profile-form.tsx
@@ -26,17 +26,20 @@ import { authClient } from "@/lib/auth/client";
 import { useTRPC } from "@/lib/trpc/client";
 
 const avatarValueSchema = z
-	.union([
-		z.string().min(1),
-		z.object({
-			previewUrl: z.string().min(1),
-			url: z.string().optional(),
-			mimeType: z.string(),
-			name: z.string().optional(),
-			size: z.number().optional(),
-		}),
-	])
-	.nullable();
+        .union([
+                z.string().min(1),
+                z
+                        .object({
+                                previewUrl: z.string().min(1),
+                                url: z.string().optional(),
+                                mimeType: z.string(),
+                                name: z.string().optional(),
+                                size: z.number().optional(),
+                                file: z.instanceof(File).optional(),
+                        })
+                        .passthrough(),
+        ])
+        .nullable();
 
 const userProfileFormSchema = z.object({
 	name: z

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/settings/website-information-form.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/settings/website-information-form.tsx
@@ -35,17 +35,20 @@ const LOGO_ACCEPT =
 	"image/png,image/jpeg,image/webp,image/avif,image/gif,image/svg+xml";
 
 const logoValueSchema = z
-	.union([
-		z.string().min(1),
-		z.object({
-			previewUrl: z.string().min(1),
-			url: z.string().optional(),
-			mimeType: z.string(),
-			name: z.string().optional(),
-			size: z.number().optional(),
-		}),
-	])
-	.nullable();
+        .union([
+                z.string().min(1),
+                z
+                        .object({
+                                previewUrl: z.string().min(1),
+                                url: z.string().optional(),
+                                mimeType: z.string(),
+                                name: z.string().optional(),
+                                size: z.number().optional(),
+                                file: z.instanceof(File).optional(),
+                        })
+                        .passthrough(),
+        ])
+        .nullable();
 
 const contactEmailSchema = z
 	.string()

--- a/apps/web/src/components/ui/avatar-input.tsx
+++ b/apps/web/src/components/ui/avatar-input.tsx
@@ -610,29 +610,29 @@ export const AvatarInput =
 			setCroppedArea(null);
 		}, []);
 
-		const applyCrop = useCallback(async () => {
-			if (!(cropState && croppedArea)) {
-				closeCropper();
-				return;
-			}
+                const applyCrop = useCallback(async () => {
+                        if (!(cropState && croppedArea)) {
+                                closeCropper();
+                                return;
+                        }
 
-			try {
-				const croppedFile = await cropImage({
-					file: cropState.file,
-					cropArea: croppedArea,
-					source: cropState.objectUrl,
-				});
-				await commitFile(croppedFile);
-			} catch (error) {
-				const message =
-					error instanceof Error
-						? error
-						: new Error("Unable to crop selected image");
-				onError?.(message);
-			} finally {
-				closeCropper();
-			}
-		}, [commitFile, cropState, croppedArea, closeCropper, onError]);
+                        try {
+                                const croppedFile = await cropImage({
+                                        file: cropState.file,
+                                        cropArea: croppedArea,
+                                        source: cropState.objectUrl,
+                                });
+                                closeCropper();
+                                await commitFile(croppedFile);
+                        } catch (error) {
+                                closeCropper();
+                                const message =
+                                        error instanceof Error
+                                                ? error
+                                                : new Error("Unable to crop selected image");
+                                onError?.(message);
+                        }
+                }, [commitFile, cropState, croppedArea, closeCropper, onError]);
 
 		const removeAvatar = useCallback(() => {
 			setLocalPreviewUrl((previous) => {


### PR DESCRIPTION
## Summary
- allow avatar and logo form schemas to accept temporary File metadata while uploads complete
- close the avatar crop dialog before triggering uploads to avoid concurrent interactions

## Testing
- bun run lint apps/web *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8b48b078832b8b257e0d49b633c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced avatar and logo upload workflows to better handle direct file uploads in addition to URL-based uploads.
  * Optimized image cropping interface for improved responsiveness by refining the timing of cleanup operations during the crop process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->