### PR TITLE
fix: resolve realtime lint follow-ups

### DIFF
--- a/examples/next-dashboard/usage.tsx
+++ b/examples/next-dashboard/usage.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import type { JSX } from "react";
+import { useEffect, useState } from "react";
+import {
+	getConnection,
+	type WebSocketClient,
+} from "../../packages/core/client";
+import type { InEvent } from "../../packages/core/events";
+import { useWebSockets } from "../../packages/react/use-web-sockets";
+
+let dashboardClient: WebSocketClient | null = null;
+
+async function requestDashboardToken(): Promise<string> {
+	const response = await fetch("/api/auth/realtime", {
+		credentials: "include",
+	});
+	if (!response.ok) {
+		throw new Error("Failed to refresh realtime token");
+	}
+	const data = (await response.json()) as { token: string };
+	return data.token;
+}
+
+export function getDashboardConnection(): WebSocketClient {
+	if (!dashboardClient) {
+		dashboardClient = getConnection({
+			workerUrl: new URL("../../packages/core/worker.ts", import.meta.url),
+			wsUrl: "wss://api.cossistant.dev/ws/dashboard",
+			requestToken: requestDashboardToken,
+			heartbeatMs: 25_000,
+			maxQueue: 200,
+			debug: process.env.NODE_ENV === "development",
+		});
+	}
+	return dashboardClient;
+}
+
+export function DashboardRealtimeIndicator(): JSX.Element {
+	const client = getDashboardConnection();
+	const status = useWebSockets(client, {
+		selector: (snapshot) => snapshot.status,
+	});
+	return (
+		<div>
+			<strong>Socket:</strong> {status.state}
+			{" · Queue "}
+			{status.queueSize}
+			{" · Dropped "}
+			{status.dropped}
+		</div>
+	);
+}
+
+export function useConversationFeed(conversationId: string): InEvent[] {
+	const client = getDashboardConnection();
+	const [events, setEvents] = useState<InEvent[]>([]);
+	useEffect(
+		() =>
+			client.subscribeAll((event) => {
+				if (
+					"conversationId" in event.payload &&
+					event.payload.conversationId === conversationId
+				) {
+					setEvents((previous) => [...previous.slice(-100), event]);
+				}
+			}),
+		[client, conversationId]
+	);
+	return events;
+}

--- a/examples/widget/usage.ts
+++ b/examples/widget/usage.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback } from "react";
+import {
+	getConnection,
+	type WebSocketClient,
+} from "../../packages/core/client";
+import type { OutEvent } from "../../packages/core/events";
+import { useWebSockets } from "../../packages/react/use-web-sockets";
+
+let widgetClient: WebSocketClient | null = null;
+
+async function fetchWidgetToken(): Promise<string> {
+	const response = await fetch(
+		"https://support.cossistant.dev/api/widget/token",
+		{
+			method: "POST",
+			credentials: "include",
+		}
+	);
+	if (!response.ok) {
+		throw new Error("Failed to obtain widget token");
+	}
+	const { token } = (await response.json()) as { token: string };
+	return token;
+}
+
+function ensureWidgetClient(): WebSocketClient {
+	if (typeof window === "undefined") {
+		throw new Error("Support widget realtime client requires the browser");
+	}
+	if (!widgetClient) {
+		widgetClient = getConnection({
+			workerUrl: new URL("../../packages/core/worker.ts", import.meta.url),
+			wsUrl: "wss://support.cossistant.dev/ws/widget",
+			requestToken: fetchWidgetToken,
+			maxQueue: 100,
+			maxBackoffMs: 30_000,
+			heartbeatMs: 25_000,
+		});
+	}
+	return widgetClient;
+}
+
+export function useSupportWidget(): {
+	readonly status: ReturnType<WebSocketClient["status"]>;
+	readonly send: (event: OutEvent) => Promise<void>;
+} {
+	const client = ensureWidgetClient();
+	const status = useWebSockets(client, {
+		selector: (snapshot) => snapshot.status,
+	});
+	const send = useCallback(
+		async (event: OutEvent) => {
+			await client.send(event);
+		},
+		[client]
+	);
+	return { status, send };
+}

--- a/packages/core/client.ts
+++ b/packages/core/client.ts
@@ -1,0 +1,459 @@
+import { z } from "zod";
+import type { InEvent, OutEvent, ParseError, RawEnvelope } from "./events";
+import { OutEventSchema, parseOutbound } from "./events";
+import { createLeaderConnection, type LeaderClient } from "./fallback/leader";
+import type { ClientStatus, ConnectionConfig, WebSocketClient } from "./types";
+
+export type { ClientStatus, ConnectionConfig, WebSocketClient } from "./types";
+
+type PendingSend = {
+	readonly resolve: () => void;
+	readonly reject: (error: Error) => void;
+};
+
+const WorkerEventSchema = z.discriminatedUnion("op", [
+	z.object({
+		op: z.literal("event"),
+		event: z.custom<InEvent>(),
+	}),
+	z.object({
+		op: z.literal("unknown"),
+		envelope: z.custom<RawEnvelope>(),
+		error: z.custom<ParseError>(),
+	}),
+	z.object({
+		op: z.literal("ack"),
+		requestId: z.string(),
+	}),
+	z.object({
+		op: z.literal("nack"),
+		requestId: z.string(),
+		error: z.object({ code: z.string(), message: z.string() }),
+	}),
+	z.object({
+		op: z.literal("status"),
+		status: z.object({
+			state: z.enum(["connecting", "open", "closed", "waiting"]),
+			attempts: z.number().int().nonnegative(),
+			since: z.number().int().nonnegative(),
+			queueSize: z.number().int().nonnegative(),
+			dropped: z.number().int().nonnegative(),
+		}),
+	}),
+	z.object({
+		op: z.literal("tokenRequest"),
+		requestId: z.string(),
+	}),
+	z.object({
+		op: z.literal("log"),
+		level: z.enum(["error", "warn", "info", "debug"]),
+		message: z.string(),
+		details: z.record(z.unknown()).optional(),
+	}),
+]);
+
+const WorkerOutboundSchema = z.discriminatedUnion("op", [
+	z.object({
+		op: z.literal("init"),
+		config: z.object({
+			wsUrl: z.string(),
+			heartbeatMs: z.number().int().positive(),
+			maxQueue: z.number().int().positive(),
+			maxBackoffMs: z.number().int().positive(),
+			debug: z.boolean(),
+		}),
+	}),
+	z.object({
+		op: z.literal("send"),
+		event: OutEventSchema,
+		requestId: z.string(),
+	}),
+	z.object({
+		op: z.literal("stop"),
+	}),
+	z.object({
+		op: z.literal("status"),
+	}),
+	z.object({
+		op: z.literal("tokenResponse"),
+		requestId: z.string(),
+		token: z.string(),
+	}),
+	z.object({
+		op: z.literal("tokenError"),
+		requestId: z.string(),
+		reason: z.string(),
+	}),
+	z.object({
+		op: z.literal("lifecycle"),
+		state: z.enum(["online", "offline", "visible", "hidden"]),
+	}),
+]);
+
+type WorkerInboundMessage = z.infer<typeof WorkerEventSchema>;
+type WorkerOutboundMessage = z.infer<typeof WorkerOutboundSchema>;
+
+const DEFAULT_HEARTBEAT = 25_000;
+const DEFAULT_QUEUE = 100;
+const DEFAULT_BACKOFF = 30_000;
+
+type SharedClient = {
+	readonly port: MessagePort;
+	readonly worker: SharedWorker;
+};
+
+type RegistryEntry = {
+	client: WebSocketClient;
+	stop: () => void;
+};
+
+const registry: Map<string, RegistryEntry> = getRegistry();
+
+function getRegistry(): Map<string, RegistryEntry> {
+	const globalKey = "__cossistant_ws_clients__";
+	const existing = (globalThis as Record<string, unknown>)[globalKey];
+	if (existing && existing instanceof Map) {
+		return existing as Map<string, RegistryEntry>;
+	}
+	const map = new Map<string, RegistryEntry>();
+	(globalThis as Record<string, unknown>)[globalKey] = map;
+	return map;
+}
+
+function assertBrowser(): void {
+	if (typeof window === "undefined") {
+		throw new Error("WebSocket client must only run in the browser");
+	}
+}
+
+function makeKey(config: ConnectionConfig): string {
+	return `${config.wsUrl}`;
+}
+
+class SharedWorkerClient implements WebSocketClient {
+	private readonly config: Required<ConnectionConfig>;
+	private readonly port: MessagePort;
+	private readonly worker: SharedWorker;
+	private readonly pending = new Map<string, PendingSend>();
+	private readonly typeSubscribers = new Map<
+		InEvent["type"],
+		Set<(event: InEvent) => void>
+	>();
+	private readonly allSubscribers = new Set<(event: InEvent) => void>();
+	private readonly statusSubscribers = new Set<
+		(status: ClientStatus) => void
+	>();
+	private statusSnapshot: ClientStatus = {
+		state: "connecting",
+		attempts: 0,
+		since: Date.now(),
+		queueSize: 0,
+		dropped: 0,
+	};
+	private requestCounter = 0;
+	private stopped = false;
+	private tokenPromise: Promise<string> | null = null;
+	private readonly onlineHandler = () => this.sendLifecycle("online");
+	private readonly offlineHandler = () => this.sendLifecycle("offline");
+	private readonly visibilityHandler = () =>
+		this.sendLifecycle(
+			document.visibilityState === "hidden" ? "hidden" : "visible"
+		);
+
+	constructor(config: ConnectionConfig, shared: SharedClient) {
+		this.config = {
+			...config,
+			heartbeatMs: config.heartbeatMs ?? DEFAULT_HEARTBEAT,
+			maxQueue: config.maxQueue ?? DEFAULT_QUEUE,
+			maxBackoffMs: Math.min(
+				config.maxBackoffMs ?? DEFAULT_BACKOFF,
+				DEFAULT_BACKOFF
+			),
+			maxQueueDropWarnThreshold:
+				config.maxQueueDropWarnThreshold ??
+				Math.floor((config.maxQueue ?? DEFAULT_QUEUE) * 0.8),
+			onUnknown: config.onUnknown ?? (() => {}),
+			debug: config.debug ?? false,
+		};
+		this.worker = shared.worker;
+		this.port = shared.port;
+		this.port.start();
+		this.port.addEventListener("message", this.onMessage as EventListener);
+		this.port.postMessage({
+			op: "init",
+			config: {
+				wsUrl: this.config.wsUrl,
+				heartbeatMs: this.config.heartbeatMs,
+				maxQueue: this.config.maxQueue,
+				maxBackoffMs: this.config.maxBackoffMs,
+				debug: this.config.debug,
+			},
+		} satisfies WorkerOutboundMessage);
+		if (typeof window !== "undefined") {
+			window.addEventListener("online", this.onlineHandler);
+			window.addEventListener("offline", this.offlineHandler);
+			if (typeof document !== "undefined") {
+				document.addEventListener("visibilitychange", this.visibilityHandler);
+			}
+		}
+	}
+
+	send<T extends OutEvent>(event: T): Promise<void> {
+		if (this.stopped) {
+			return Promise.reject(new Error("Connection has been stopped"));
+		}
+		const validation = parseOutbound(event);
+		if (!validation.ok) {
+			return Promise.reject(new Error(validation.error.message));
+		}
+		const requestId = `req-${Date.now()}-${this.requestCounter++}`;
+		return new Promise<void>((resolve, reject) => {
+			this.pending.set(requestId, { resolve, reject });
+			this.port.postMessage({
+				op: "send",
+				event: validation.value,
+				requestId,
+			} satisfies WorkerOutboundMessage);
+		});
+	}
+
+	subscribe<E extends InEvent["type"]>(
+		type: E,
+		handler: (event: Extract<InEvent, { type: E }>) => void
+	): () => void {
+		const set =
+			this.typeSubscribers.get(type) ?? new Set<(event: InEvent) => void>();
+		set.add(handler as unknown as (incoming: InEvent) => void);
+		this.typeSubscribers.set(type, set);
+		return () => {
+			set.delete(handler as unknown as (incoming: InEvent) => void);
+			if (set.size === 0) {
+				this.typeSubscribers.delete(type);
+			}
+		};
+	}
+
+	subscribeAll(handler: (event: InEvent) => void): () => void {
+		this.allSubscribers.add(handler);
+		return () => {
+			this.allSubscribers.delete(handler);
+		};
+	}
+
+	status(): ClientStatus {
+		return { ...this.statusSnapshot };
+	}
+
+	subscribeStatus(handler: (status: ClientStatus) => void): () => void {
+		this.statusSubscribers.add(handler);
+		handler(this.status());
+		return () => {
+			this.statusSubscribers.delete(handler);
+		};
+	}
+
+	stop(): void {
+		if (this.stopped) {
+			return;
+		}
+		this.stopped = true;
+		this.port.postMessage({ op: "stop" } satisfies WorkerOutboundMessage);
+		this.port.removeEventListener("message", this.onMessage as EventListener);
+		if (typeof window !== "undefined") {
+			window.removeEventListener("online", this.onlineHandler);
+			window.removeEventListener("offline", this.offlineHandler);
+			if (typeof document !== "undefined") {
+				document.removeEventListener(
+					"visibilitychange",
+					this.visibilityHandler
+				);
+			}
+		}
+		for (const [, pending] of this.pending) {
+			pending.reject(new Error("Connection stopped"));
+		}
+		this.pending.clear();
+		this.statusSubscribers.clear();
+	}
+
+	private sendLifecycle(
+		state: "online" | "offline" | "visible" | "hidden"
+	): void {
+		if (this.stopped) {
+			return;
+		}
+		this.port.postMessage({
+			op: "lifecycle",
+			state,
+		} satisfies WorkerOutboundMessage);
+	}
+
+	private onMessage = (event: MessageEvent): void => {
+		const parsed = WorkerEventSchema.safeParse(event.data);
+		if (!parsed.success) {
+			if (this.config.debug) {
+				console.warn(
+					"[ws-client] Ignored malformed worker message",
+					parsed.error
+				);
+			}
+			return;
+		}
+		this.handleWorkerMessage(parsed.data);
+	};
+
+	private handleWorkerMessage(message: WorkerInboundMessage): void {
+		switch (message.op) {
+			case "event": {
+				this.emit(message.event);
+				break;
+			}
+			case "unknown": {
+				this.config.onUnknown(message.envelope, message.error);
+				break;
+			}
+			case "ack": {
+				const pending = this.pending.get(message.requestId);
+				if (pending) {
+					pending.resolve();
+					this.pending.delete(message.requestId);
+				}
+				break;
+			}
+			case "nack": {
+				const pending = this.pending.get(message.requestId);
+				if (pending) {
+					pending.reject(
+						new Error(`${message.error.code}: ${message.error.message}`)
+					);
+					this.pending.delete(message.requestId);
+				}
+				break;
+			}
+			case "status": {
+				this.statusSnapshot = message.status;
+				if (
+					message.status.dropped >
+					(this.config.maxQueueDropWarnThreshold ?? this.config.maxQueue * 0.8)
+				) {
+					console.warn(
+						"[ws-client] outbound queue drops detected",
+						message.status.dropped
+					);
+				}
+				for (const listener of this.statusSubscribers) {
+					listener({ ...this.statusSnapshot });
+				}
+				break;
+			}
+			case "tokenRequest": {
+				this.provideToken(message.requestId);
+				break;
+			}
+			case "log": {
+				if (this.config.debug) {
+					console[message.level === "error" ? "error" : "info"](
+						`[ws-worker] ${message.message}`,
+						message.details ?? {}
+					);
+				}
+				break;
+			}
+			default: {
+				if (this.config.debug) {
+					console.warn("[ws-client] unhandled worker op", message);
+				}
+				break;
+			}
+		}
+	}
+
+	private provideToken(requestId: string): void {
+		if (this.tokenPromise) {
+			this.tokenPromise
+				.then((token) => {
+					this.port.postMessage({
+						op: "tokenResponse",
+						requestId,
+						token,
+					} satisfies WorkerOutboundMessage);
+				})
+				.catch((error) => {
+					this.port.postMessage({
+						op: "tokenError",
+						requestId,
+						reason: error.message,
+					} satisfies WorkerOutboundMessage);
+				});
+			return;
+		}
+		this.tokenPromise = this.config.requestToken();
+		this.tokenPromise
+			.then((token) => {
+				this.port.postMessage({
+					op: "tokenResponse",
+					requestId,
+					token,
+				} satisfies WorkerOutboundMessage);
+			})
+			.catch((error) => {
+				this.port.postMessage({
+					op: "tokenError",
+					requestId,
+					reason: error.message,
+				} satisfies WorkerOutboundMessage);
+			})
+			.finally(() => {
+				this.tokenPromise = null;
+			});
+	}
+
+	private emit(event: InEvent): void {
+		const specific = this.typeSubscribers.get(event.type);
+		if (specific) {
+			for (const subscriber of specific) {
+				(subscriber as (incoming: InEvent) => void)(event);
+			}
+		}
+		for (const subscriber of this.allSubscribers) {
+			subscriber(event);
+		}
+	}
+}
+
+function createSharedWorker(config: ConnectionConfig): SharedClient | null {
+	if (typeof SharedWorker === "undefined") {
+		return null;
+	}
+	try {
+		const worker = new SharedWorker(config.workerUrl, {
+			type: "module",
+			name: `ws:${config.wsUrl}`,
+		});
+		return { worker, port: worker.port };
+	} catch (error) {
+		console.warn(
+			"[ws-client] SharedWorker creation failed, falling back",
+			error
+		);
+		return null;
+	}
+}
+
+export function getConnection(config: ConnectionConfig): WebSocketClient {
+	assertBrowser();
+	const key = makeKey(config);
+	const existing = registry.get(key);
+	if (existing) {
+		return existing.client;
+	}
+	const shared = createSharedWorker(config);
+	if (shared) {
+		const client = new SharedWorkerClient(config, shared);
+		registry.set(key, { client, stop: () => client.stop() });
+		return client;
+	}
+	const fallback: LeaderClient = createLeaderConnection(config);
+	registry.set(key, { client: fallback, stop: () => fallback.stop() });
+	return fallback;
+}

--- a/packages/core/events.ts
+++ b/packages/core/events.ts
@@ -1,0 +1,390 @@
+import { z } from "zod";
+
+/**
+ * Current envelope protocol version. Increment when breaking changes occur.
+ */
+export const ENVELOPE_VERSION = 1 as const;
+
+/**
+ * Base fields shared by every envelope exchanged over the socket.
+ */
+export type EnvelopeBase<TType extends string, TPayload> = {
+	readonly v: typeof ENVELOPE_VERSION;
+	readonly type: TType;
+	readonly ts: number;
+	readonly id: string;
+	readonly payload: TPayload;
+};
+
+/**
+ * Raw envelope shape prior to runtime validation.
+ */
+export type RawEnvelope = {
+	readonly v: number;
+	readonly type: string;
+	readonly ts: number;
+	readonly id: string;
+	readonly payload: unknown;
+};
+
+/**
+ * Outbound event describing actions initiated by the client.
+ */
+export type OutEvent =
+	| EnvelopeBase<
+			"support.message",
+			{
+				conversationId: string;
+				body: string;
+				attachments?: Array<{ id: string; url: string }>;
+			}
+	  >
+	| EnvelopeBase<
+			"support.presence",
+			{
+				conversationId: string;
+				status: "typing" | "idle" | "offline";
+			}
+	  >
+	| EnvelopeBase<
+			"dashboard.query",
+			{
+				query: string;
+				params?: Record<string, string | number | boolean>;
+			}
+	  >
+	| EnvelopeBase<"ping", { sequence: number }>;
+
+/**
+ * Inbound events originating from the server.
+ */
+export type InEvent =
+	| EnvelopeBase<
+			"support.message.received",
+			{
+				conversationId: string;
+				messageId: string;
+				body: string;
+				from: "agent" | "customer";
+			}
+	  >
+	| EnvelopeBase<
+			"support.presence.updated",
+			{
+				conversationId: string;
+				participantId: string;
+				status: "typing" | "idle" | "offline";
+			}
+	  >
+	| EnvelopeBase<
+			"dashboard.metrics",
+			{
+				name: string;
+				value: number;
+				window: "1m" | "5m" | "1h";
+			}
+	  >
+	| EnvelopeBase<
+			"auth.expired",
+			{
+				reason: "token_expired" | "revoked";
+			}
+	  >
+	| EnvelopeBase<"pong", { sequence: number }>;
+
+/**
+ * Strict zod schema representing the envelope with version 1.
+ */
+const EnvelopeSchemaV1 = z.object({
+	v: z.literal(ENVELOPE_VERSION),
+	type: z.string().min(1),
+	ts: z.number({ description: "Unix epoch timestamp in milliseconds" }).min(0),
+	id: z.string().min(8),
+	payload: z.unknown(),
+});
+
+const SupportMessageSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("support.message"),
+	payload: z.object({
+		conversationId: z.string().min(1),
+		body: z.string().min(1),
+		attachments: z
+			.array(z.object({ id: z.string().min(1), url: z.string().url() }))
+			.optional(),
+	}),
+});
+
+const SupportPresenceSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("support.presence"),
+	payload: z.object({
+		conversationId: z.string().min(1),
+		status: z.enum(["typing", "idle", "offline"]),
+	}),
+});
+
+const DashboardQuerySchema = EnvelopeSchemaV1.extend({
+	type: z.literal("dashboard.query"),
+	payload: z.object({
+		query: z.string().min(1),
+		params: z.record(z.union([z.string(), z.number(), z.boolean()])).optional(),
+	}),
+});
+
+const PingSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("ping"),
+	payload: z.object({ sequence: z.number().int().nonnegative() }),
+});
+
+const SupportMessageReceivedSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("support.message.received"),
+	payload: z.object({
+		conversationId: z.string().min(1),
+		messageId: z.string().min(1),
+		body: z.string().min(1),
+		from: z.enum(["agent", "customer"]),
+	}),
+});
+
+const SupportPresenceUpdatedSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("support.presence.updated"),
+	payload: z.object({
+		conversationId: z.string().min(1),
+		participantId: z.string().min(1),
+		status: z.enum(["typing", "idle", "offline"]),
+	}),
+});
+
+const DashboardMetricsSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("dashboard.metrics"),
+	payload: z.object({
+		name: z.string().min(1),
+		value: z.number(),
+		window: z.enum(["1m", "5m", "1h"]),
+	}),
+});
+
+const AuthExpiredSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("auth.expired"),
+	payload: z.object({ reason: z.enum(["token_expired", "revoked"]) }),
+});
+
+const PongSchema = EnvelopeSchemaV1.extend({
+	type: z.literal("pong"),
+	payload: z.object({ sequence: z.number().int().nonnegative() }),
+});
+
+/**
+ * Runtime schema validating every supported outbound event.
+ */
+export const OutEventSchema = z.discriminatedUnion("type", [
+	SupportMessageSchema,
+	SupportPresenceSchema,
+	DashboardQuerySchema,
+	PingSchema,
+]);
+
+/**
+ * Runtime schema validating every supported inbound event.
+ */
+export const InEventSchema = z.discriminatedUnion("type", [
+	SupportMessageReceivedSchema,
+	SupportPresenceUpdatedSchema,
+	DashboardMetricsSchema,
+	AuthExpiredSchema,
+	PongSchema,
+]);
+
+export type ParseError = {
+	readonly ok: false;
+	readonly error: {
+		readonly code: "invalid_envelope" | "unsupported_version";
+		readonly message: string;
+		readonly issues?: z.ZodIssue[];
+	};
+};
+
+export type ParseSuccess<T> = {
+	readonly ok: true;
+	readonly value: T;
+};
+
+/**
+ * Parse an inbound envelope and return a typed discriminated union or
+ * a structured error payload to bubble up to diagnostics.
+ */
+export function parseInbound(raw: unknown): ParseSuccess<InEvent> | ParseError {
+	const versionResult = EnvelopeSchemaV1.safeParse(raw);
+	if (!versionResult.success) {
+		const candidate = raw as RawEnvelope;
+		if (typeof candidate?.v === "number" && candidate.v !== ENVELOPE_VERSION) {
+			return {
+				ok: false,
+				error: {
+					code: "unsupported_version",
+					message: `Unsupported envelope version: ${candidate.v}`,
+					issues: versionResult.error.issues,
+				},
+			};
+		}
+		return {
+			ok: false,
+			error: {
+				code: "invalid_envelope",
+				message: "Inbound envelope failed validation",
+				issues: versionResult.error.issues,
+			},
+		};
+	}
+
+	const typed = InEventSchema.safeParse(versionResult.data);
+	if (!typed.success) {
+		return {
+			ok: false,
+			error: {
+				code: "invalid_envelope",
+				message: "Inbound envelope payload failed validation",
+				issues: typed.error.issues,
+			},
+		};
+	}
+
+	return { ok: true, value: typed.data };
+}
+
+/**
+ * Parse an outbound envelope, returning the typed value or a structured error.
+ */
+export function parseOutbound(
+	raw: unknown
+): ParseSuccess<OutEvent> | ParseError {
+	const result = OutEventSchema.safeParse(raw);
+	if (!result.success) {
+		const candidate = raw as RawEnvelope;
+		if (typeof candidate?.v === "number" && candidate.v !== ENVELOPE_VERSION) {
+			return {
+				ok: false,
+				error: {
+					code: "unsupported_version",
+					message: `Unsupported envelope version: ${candidate.v}`,
+					issues: result.error.issues,
+				},
+			};
+		}
+		return {
+			ok: false,
+			error: {
+				code: "invalid_envelope",
+				message: "Outbound envelope failed validation",
+				issues: result.error.issues,
+			},
+		};
+	}
+
+	return { ok: true, value: result.data };
+}
+
+/**
+ * Narrow an inbound event by type while preserving payload typing.
+ */
+export function isEventType<TType extends InEvent["type"]>(
+	event: InEvent,
+	type: TType
+): event is Extract<InEvent, { type: TType }> {
+	return event.type === type;
+}
+
+/**
+ * Helper returning all inbound events that match a specific discriminator.
+ */
+export function filterEvents<TType extends InEvent["type"]>(
+	events: readonly InEvent[],
+	type: TType
+): Extract<InEvent, { type: TType }>[] {
+	return events.filter(
+		(evt): evt is Extract<InEvent, { type: TType }> => evt.type === type
+	);
+}
+
+/**
+ * Recognised versions for the transport protocol.
+ */
+export const SUPPORTED_VERSIONS = [ENVELOPE_VERSION] as const;
+
+/**
+ * Attempt to migrate an unknown envelope into the current shape.
+ * The implementation is intentionally strict: it only accepts envelopes that
+ * already comply with the current version, allowing future extension points
+ * to plug in custom migration strategies without risking silent corruption.
+ */
+export function migrateUnknown(raw: RawEnvelope): InEvent | null {
+	if (raw.v === ENVELOPE_VERSION) {
+		const parsed = parseInbound(raw);
+		return parsed.ok ? parsed.value : null;
+	}
+	return null;
+}
+
+/**
+ * Compute an exponential backoff delay with full jitter.
+ * @param attempt 1-based retry attempt counter.
+ * @param baseMs Minimum backoff interval in milliseconds.
+ * @param maxMs Maximum backoff interval cap in milliseconds.
+ */
+export function computeBackoffDelay(
+	attempt: number,
+	baseMs: number,
+	maxMs: number
+): number {
+	const exp = 2 ** Math.max(0, attempt - 1);
+	const raw = baseMs * exp;
+	const capped = Math.min(maxMs, raw);
+	const jitter = Math.random() * capped * 0.5;
+	return Math.min(maxMs, Math.round(capped / 2 + jitter));
+}
+
+/**
+ * A bounded queue that drops the oldest entry when capacity is exceeded.
+ */
+export class DroppingQueue<T> {
+	private readonly items: T[] = [];
+	private dropped = 0;
+	private readonly capacity: number;
+
+	constructor(capacity: number) {
+		this.capacity = capacity;
+		if (capacity <= 0) {
+			throw new Error("Queue capacity must be positive");
+		}
+	}
+
+	push(value: T): { dropped: boolean; droppedValue?: T } {
+		let droppedValue: T | undefined;
+		if (this.items.length >= this.capacity) {
+			droppedValue = this.items.shift();
+			this.dropped += 1;
+		}
+		this.items.push(value);
+		return { dropped: droppedValue !== undefined, droppedValue };
+	}
+
+	shift(): T | undefined {
+		return this.items.shift();
+	}
+
+	clear(): void {
+		this.items.splice(0, this.items.length);
+		this.dropped = 0;
+	}
+
+	size(): number {
+		return this.items.length;
+	}
+
+	droppedCount(): number {
+		return this.dropped;
+	}
+
+	toArray(): T[] {
+		return [...this.items];
+	}
+}

--- a/packages/core/fallback/leader.ts
+++ b/packages/core/fallback/leader.ts
@@ -1,0 +1,681 @@
+import { z } from "zod";
+import {
+	computeBackoffDelay,
+	DroppingQueue,
+	ENVELOPE_VERSION,
+	type InEvent,
+	migrateUnknown,
+	type OutEvent,
+	type ParseError,
+	parseInbound,
+	parseOutbound,
+	type RawEnvelope,
+} from "../events";
+import type { ClientStatus, ConnectionConfig, WebSocketClient } from "../types";
+
+const CHANNEL_PREFIX = "cossistant-ws";
+const HEARTBEAT_INTERVAL = 2500;
+const HEARTBEAT_STALE_MS = HEARTBEAT_INTERVAL * 3;
+const BACKOFF_BASE_MS = 500;
+const PING_FAILURE_THRESHOLD = 2;
+const AUTH_CLOSE_CODES = new Set([4001, 4401, 4403, 4003]);
+
+type PendingSend = {
+	readonly resolve: () => void;
+	readonly reject: (error: Error) => void;
+};
+
+type LeaderPendingSend = {
+	readonly requestId: string;
+	readonly event: OutEvent;
+	readonly originId: string;
+};
+
+const ChannelSchema = z.discriminatedUnion("op", [
+	z.object({ op: z.literal("announce"), id: z.string(), ts: z.number() }),
+	z.object({ op: z.literal("leader"), id: z.string(), ts: z.number() }),
+	z.object({ op: z.literal("heartbeat"), id: z.string(), ts: z.number() }),
+	z.object({
+		op: z.literal("send"),
+		id: z.string(),
+		ts: z.number(),
+		requestId: z.string(),
+		event: z.any(),
+	}),
+	z.object({
+		op: z.literal("ack"),
+		id: z.string(),
+		ts: z.number(),
+		requestId: z.string(),
+	}),
+	z.object({
+		op: z.literal("nack"),
+		id: z.string(),
+		ts: z.number(),
+		requestId: z.string(),
+		error: z.object({ code: z.string(), message: z.string() }),
+	}),
+	z.object({
+		op: z.literal("event"),
+		id: z.string(),
+		ts: z.number(),
+		event: z.custom<InEvent>(),
+	}),
+	z.object({
+		op: z.literal("unknown"),
+		id: z.string(),
+		ts: z.number(),
+		envelope: z.custom<RawEnvelope>(),
+		error: z.custom<ParseError>(),
+	}),
+	z.object({
+		op: z.literal("status"),
+		id: z.string(),
+		ts: z.number(),
+		status: z.object({
+			state: z.enum(["connecting", "open", "closed", "waiting"]),
+			attempts: z.number(),
+			since: z.number(),
+			queueSize: z.number(),
+			dropped: z.number(),
+		}),
+	}),
+]);
+
+type ChannelMessage = z.infer<typeof ChannelSchema>;
+
+export type LeaderClient = WebSocketClient;
+
+function hashChannel(wsUrl: string): string {
+	let hash = 0;
+	for (let i = 0; i < wsUrl.length; i += 1) {
+		hash = (hash * 31 + wsUrl.charCodeAt(i)) | 0;
+	}
+	return `${CHANNEL_PREFIX}:${hash.toString(16)}`;
+}
+
+function now(): number {
+	return Date.now();
+}
+
+class LeaderConnection implements LeaderClient {
+	private readonly id = `${now()}-${Math.random().toString(16).slice(2)}`;
+	private readonly config: Required<ConnectionConfig>;
+	private readonly channel: BroadcastChannel;
+	private readonly knownIds = new Map<string, number>();
+	private readonly pending = new Map<string, PendingSend>();
+	private readonly outboundQueue: DroppingQueue<LeaderPendingSend>;
+	private socket: WebSocket | null = null;
+	private isLeader = false;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+	private missedPongs = 0;
+	private statusSnapshot: ClientStatus = {
+		state: "connecting",
+		attempts: 0,
+		since: now(),
+		queueSize: 0,
+		dropped: 0,
+	};
+	private readonly listeners = new Map<
+		InEvent["type"],
+		Set<(event: InEvent) => void>
+	>();
+	private readonly allListeners = new Set<(event: InEvent) => void>();
+	private readonly statusListeners = new Set<(status: ClientStatus) => void>();
+	private readonly onlineHandler = () => this.handleOnline();
+	private readonly offlineHandler = () => this.handleOffline();
+	private readonly visibilityHandler = () => this.resetHeartbeat();
+	private requestCounter = 0;
+	private stopped = false;
+	private readonly input: ConnectionConfig;
+
+	constructor(input: ConnectionConfig) {
+		if (typeof BroadcastChannel === "undefined") {
+			throw new Error("BroadcastChannel is required for leader fallback");
+		}
+		this.input = input;
+		this.config = {
+			...input,
+			heartbeatMs: input.heartbeatMs ?? 25_000,
+			maxQueue: input.maxQueue ?? 100,
+			maxBackoffMs: Math.min(input.maxBackoffMs ?? 30_000, 30_000),
+			maxQueueDropWarnThreshold:
+				input.maxQueueDropWarnThreshold ??
+				Math.floor((input.maxQueue ?? 100) * 0.8),
+			onUnknown: input.onUnknown ?? (() => {}),
+			debug: input.debug ?? false,
+		};
+		this.channel = new BroadcastChannel(hashChannel(this.config.wsUrl));
+		this.channel.addEventListener("message", (event) => {
+			this.handleChannelMessage(event.data);
+		});
+		this.outboundQueue = new DroppingQueue<LeaderPendingSend>(
+			this.config.maxQueue
+		);
+		this.knownIds.set(this.id, now());
+		this.sendChannel({ op: "announce", id: this.id, ts: now() });
+		if (typeof window !== "undefined") {
+			window.addEventListener("online", this.onlineHandler);
+			window.addEventListener("offline", this.offlineHandler);
+			if (typeof document !== "undefined") {
+				document.addEventListener("visibilitychange", this.visibilityHandler);
+			}
+		}
+		this.evaluateLeadership();
+	}
+
+	send<T extends OutEvent>(event: T): Promise<void> {
+		if (this.stopped) {
+			return Promise.reject(new Error("Connection stopped"));
+		}
+		const validation = parseOutbound(event);
+		if (!validation.ok) {
+			return Promise.reject(new Error(validation.error.message));
+		}
+		const requestId = `req-${now()}-${this.requestCounter++}`;
+		return new Promise<void>((resolve, reject) => {
+			this.pending.set(requestId, { resolve, reject });
+			if (this.isLeader) {
+				this.enqueueForLeader({
+					requestId,
+					event: validation.value,
+					originId: this.id,
+				});
+				this.flushQueue();
+			} else {
+				this.sendChannel({
+					op: "send",
+					id: this.id,
+					ts: now(),
+					requestId,
+					event: validation.value,
+				});
+			}
+		});
+	}
+
+	subscribe<E extends InEvent["type"]>(
+		type: E,
+		handler: (event: Extract<InEvent, { type: E }>) => void
+	): () => void {
+		const set = this.listeners.get(type) ?? new Set<(event: InEvent) => void>();
+		set.add(handler as unknown as (incoming: InEvent) => void);
+		this.listeners.set(type, set);
+		return () => {
+			set.delete(handler as unknown as (incoming: InEvent) => void);
+			if (set.size === 0) {
+				this.listeners.delete(type);
+			}
+		};
+	}
+
+	subscribeAll(handler: (event: InEvent) => void): () => void {
+		this.allListeners.add(handler);
+		return () => {
+			this.allListeners.delete(handler);
+		};
+	}
+
+	subscribeStatus(handler: (status: ClientStatus) => void): () => void {
+		this.statusListeners.add(handler);
+		handler(this.status());
+		return () => {
+			this.statusListeners.delete(handler);
+		};
+	}
+
+	status(): ClientStatus {
+		return { ...this.statusSnapshot };
+	}
+
+	stop(): void {
+		if (this.stopped) {
+			return;
+		}
+		this.stopped = true;
+		this.channel.close();
+		if (typeof window !== "undefined") {
+			window.removeEventListener("online", this.onlineHandler);
+			window.removeEventListener("offline", this.offlineHandler);
+			if (typeof document !== "undefined") {
+				document.removeEventListener(
+					"visibilitychange",
+					this.visibilityHandler
+				);
+			}
+		}
+		this.teardownSocket(1000, "Client stop");
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+		if (this.heartbeatTimer) {
+			clearInterval(this.heartbeatTimer);
+			this.heartbeatTimer = null;
+		}
+		for (const [, pending] of this.pending) {
+			pending.reject(new Error("Connection stopped"));
+		}
+		this.pending.clear();
+		this.statusListeners.clear();
+	}
+
+	private handleOnline(): void {
+		if (this.isLeader) {
+			this.connect();
+		}
+	}
+
+	private handleOffline(): void {
+		if (this.isLeader) {
+			this.updateStatus({ state: "waiting" });
+		}
+	}
+
+	private resetHeartbeat(): void {
+		if (this.isLeader) {
+			this.missedPongs = 0;
+		}
+	}
+
+	private enqueueForLeader(entry: LeaderPendingSend): void {
+		const result = this.outboundQueue.push(entry);
+		if (result.dropped && result.droppedValue) {
+			this.sendChannel({
+				op: "nack",
+				id: this.id,
+				ts: now(),
+				requestId: result.droppedValue.requestId,
+				error: {
+					code: "queue_full",
+					message: "Outbound queue full; message dropped",
+				},
+			});
+		}
+		this.updateStatus({
+			queueSize: this.outboundQueue.size(),
+			dropped: this.outboundQueue.droppedCount(),
+		});
+	}
+
+	private flushQueue(): void {
+		if (
+			!(this.isLeader && this.socket) ||
+			this.socket.readyState !== WebSocket.OPEN
+		) {
+			return;
+		}
+		let next: LeaderPendingSend | undefined = this.outboundQueue.shift();
+		while (next) {
+			this.sendEnvelope(next);
+			next = this.outboundQueue.shift();
+		}
+		this.updateStatus({ queueSize: this.outboundQueue.size() });
+	}
+
+	private sendEnvelope(entry: LeaderPendingSend): void {
+		if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+			this.enqueueForLeader(entry);
+			return;
+		}
+		try {
+			this.socket.send(JSON.stringify(entry.event));
+			if (entry.originId === this.id) {
+				const pending = this.pending.get(entry.requestId);
+				pending?.resolve();
+				if (pending) {
+					this.pending.delete(entry.requestId);
+				}
+			} else {
+				this.sendChannel({
+					op: "ack",
+					id: this.id,
+					ts: now(),
+					requestId: entry.requestId,
+				});
+			}
+		} catch (error) {
+			const message = {
+				op: "nack" as const,
+				id: this.id,
+				ts: now(),
+				requestId: entry.requestId,
+				error: { code: "send_failed", message: (error as Error).message },
+			};
+			if (entry.originId === this.id) {
+				this.pending
+					.get(entry.requestId)
+					?.reject(new Error(message.error.message));
+				this.pending.delete(entry.requestId);
+			} else {
+				this.sendChannel(message);
+			}
+		}
+	}
+
+	private connect(): void {
+		if (!this.isLeader || this.stopped) {
+			return;
+		}
+		if (
+			this.socket &&
+			(this.socket.readyState === WebSocket.OPEN ||
+				this.socket.readyState === WebSocket.CONNECTING)
+		) {
+			return;
+		}
+		if (typeof navigator !== "undefined" && navigator.onLine === false) {
+			this.updateStatus({ state: "waiting" });
+			return;
+		}
+		const attempts =
+			this.statusSnapshot.attempts === 0 ? 1 : this.statusSnapshot.attempts;
+		this.updateStatus({ state: "connecting", attempts, since: now() });
+		this.input
+			.requestToken()
+			.then((token) => {
+				const url = new URL(this.config.wsUrl);
+				url.searchParams.set("token", token);
+				this.socket = new WebSocket(url.toString(), "json.v1");
+				this.socket.addEventListener("open", this.handleOpen);
+				this.socket.addEventListener("close", this.handleClose);
+				this.socket.addEventListener("error", this.handleError);
+				this.socket.addEventListener("message", this.handleMessage);
+			})
+			.catch((error) => {
+				this.scheduleReconnect("token", error.message);
+			});
+	}
+
+	private teardownSocket(code: number, reason: string): void {
+		if (this.socket) {
+			this.socket.removeEventListener("open", this.handleOpen);
+			this.socket.removeEventListener("close", this.handleClose);
+			this.socket.removeEventListener("error", this.handleError);
+			this.socket.removeEventListener("message", this.handleMessage);
+			try {
+				this.socket.close(code, reason);
+			} catch (error) {
+				if (this.config.debug) {
+					console.error("[leader] failed to close socket", error);
+				}
+			}
+		}
+		this.socket = null;
+		this.stopHeartbeat();
+	}
+
+	private handleOpen = (): void => {
+		this.missedPongs = 0;
+		this.updateStatus({ state: "open", attempts: 0, since: now() });
+		this.flushQueue();
+		this.startHeartbeat();
+	};
+
+	private handleClose = (event: CloseEvent): void => {
+		this.stopHeartbeat();
+		if (AUTH_CLOSE_CODES.has(event.code)) {
+			this.scheduleReconnect("auth", event.reason);
+			return;
+		}
+		if (event.wasClean && event.code === 1000) {
+			this.updateStatus({ state: "closed", attempts: 0, since: now() });
+			return;
+		}
+		this.scheduleReconnect(`close_${event.code}`, event.reason);
+	};
+
+	private handleError = (event: Event): void => {
+		if (this.config.debug) {
+			console.error("[leader] socket error", event);
+		}
+	};
+
+	private handleMessage = (event: MessageEvent): void => {
+		this.missedPongs = 0;
+		let data: unknown;
+		try {
+			data = JSON.parse(event.data as string);
+		} catch (error) {
+			if (this.config.debug) {
+				console.warn("[leader] invalid JSON", error);
+			}
+			return;
+		}
+		const parsed = parseInbound(data);
+		if (!parsed.ok) {
+			const raw = data as RawEnvelope;
+			const migrated = migrateUnknown(raw);
+			if (migrated) {
+				this.broadcastEvent(migrated);
+				return;
+			}
+			this.sendChannel({
+				op: "unknown",
+				id: this.id,
+				ts: now(),
+				envelope: raw,
+				error: parsed,
+			});
+			this.config.onUnknown(raw, parsed.error);
+			return;
+		}
+		if (parsed.value.type === "pong") {
+			this.missedPongs = 0;
+		}
+		this.broadcastEvent(parsed.value);
+	};
+
+	private broadcastEvent(event: InEvent): void {
+		this.sendChannel({ op: "event", id: this.id, ts: now(), event });
+		for (const subscriber of this.allListeners) {
+			subscriber(event);
+		}
+		const set = this.listeners.get(event.type);
+		if (set) {
+			for (const subscriber of set) {
+				(subscriber as (incoming: InEvent) => void)(event);
+			}
+		}
+	}
+
+	private startHeartbeat(): void {
+		this.stopHeartbeat();
+		this.heartbeatTimer = setInterval(() => {
+			if (!this.socket || this.socket.readyState !== WebSocket.OPEN) {
+				return;
+			}
+			if (this.missedPongs >= PING_FAILURE_THRESHOLD) {
+				this.socket.close(4000, "Heartbeat timeout");
+				return;
+			}
+			const ping: OutEvent = {
+				v: ENVELOPE_VERSION,
+				type: "ping",
+				ts: now(),
+				id: `${now()}-${Math.random().toString(16).slice(2)}`,
+				payload: { sequence: this.missedPongs + 1 },
+			};
+			this.sendEnvelope({
+				requestId: `heartbeat-${now()}`,
+				event: ping,
+				originId: this.id,
+			});
+			this.missedPongs += 1;
+		}, this.config.heartbeatMs);
+	}
+
+	private stopHeartbeat(): void {
+		if (this.heartbeatTimer) {
+			clearInterval(this.heartbeatTimer);
+			this.heartbeatTimer = null;
+		}
+	}
+
+	private scheduleReconnect(reason: string, detail?: string): void {
+		if (!this.isLeader) {
+			return;
+		}
+		if (this.reconnectTimer) {
+			clearTimeout(this.reconnectTimer);
+		}
+		const attempt = this.statusSnapshot.attempts + 1;
+		const delay = computeBackoffDelay(
+			attempt,
+			BACKOFF_BASE_MS,
+			this.config.maxBackoffMs
+		);
+		this.updateStatus({ state: "waiting", attempts: attempt, since: now() });
+		this.reconnectTimer = setTimeout(() => {
+			this.reconnectTimer = null;
+			this.connect();
+		}, delay);
+		if (this.config.debug) {
+			console.info("[leader] scheduling reconnect", { reason, detail, delay });
+		}
+	}
+
+	private updateStatus(partial: Partial<ClientStatus>): void {
+		this.statusSnapshot = {
+			...this.statusSnapshot,
+			...partial,
+		};
+		if (this.isLeader) {
+			this.sendChannel({
+				op: "status",
+				id: this.id,
+				ts: now(),
+				status: this.statusSnapshot,
+			});
+		}
+		for (const listener of this.statusListeners) {
+			listener({ ...this.statusSnapshot });
+		}
+	}
+
+	private sendChannel(message: ChannelMessage): void {
+		this.channel.postMessage(message);
+	}
+
+	private handleChannelMessage(data: unknown): void {
+		const parsed = ChannelSchema.safeParse(data);
+		if (!parsed.success) {
+			return;
+		}
+		const message = parsed.data;
+		if (message.id === this.id) {
+			return;
+		}
+		this.knownIds.set(message.id, message.ts);
+		switch (message.op) {
+			case "announce":
+			case "leader":
+			case "heartbeat":
+				this.evaluateLeadership();
+				break;
+			case "send": {
+				if (this.isLeader) {
+					const validation = parseOutbound(message.event);
+					if (!validation.ok) {
+						this.sendChannel({
+							op: "nack",
+							id: this.id,
+							ts: now(),
+							requestId: message.requestId,
+							error: {
+								code: validation.error.code,
+								message: validation.error.message,
+							},
+						});
+						return;
+					}
+					this.enqueueForLeader({
+						requestId: message.requestId,
+						event: validation.value,
+						originId: message.id,
+					});
+					this.flushQueue();
+				}
+				break;
+			}
+			case "ack": {
+				const pending = this.pending.get(message.requestId);
+				if (pending) {
+					pending.resolve();
+					this.pending.delete(message.requestId);
+				}
+				break;
+			}
+			case "nack": {
+				const pending = this.pending.get(message.requestId);
+				if (pending) {
+					pending.reject(new Error(message.error.message));
+					this.pending.delete(message.requestId);
+				}
+				break;
+			}
+			case "event": {
+				for (const subscriber of this.allListeners) {
+					subscriber(message.event);
+				}
+				const set = this.listeners.get(message.event.type);
+				if (set) {
+					for (const subscriber of set) {
+						(subscriber as (incoming: InEvent) => void)(message.event);
+					}
+				}
+				break;
+			}
+			case "unknown": {
+				this.input.onUnknown?.(message.envelope, message.error);
+				break;
+			}
+			case "status": {
+				this.statusSnapshot = message.status;
+				break;
+			}
+			default: {
+				break;
+			}
+		}
+	}
+
+	private evaluateLeadership(): void {
+		const timestamp = now();
+		this.knownIds.set(this.id, timestamp);
+		for (const [peerId, lastSeen] of this.knownIds) {
+			if (peerId !== this.id && timestamp - lastSeen > HEARTBEAT_STALE_MS) {
+				this.knownIds.delete(peerId);
+			}
+		}
+		const highest = [...this.knownIds.keys()].sort().pop() ?? this.id;
+		const shouldLead = highest === this.id;
+		if (shouldLead && !this.isLeader) {
+			this.becomeLeader();
+		} else if (!shouldLead && this.isLeader) {
+			this.resignLeader();
+		}
+		if (this.isLeader) {
+			this.sendChannel({ op: "leader", id: this.id, ts: now() });
+			this.sendChannel({ op: "heartbeat", id: this.id, ts: now() });
+		}
+	}
+
+	private becomeLeader(): void {
+		this.isLeader = true;
+		this.connect();
+		this.updateStatus({ state: "connecting", attempts: 1, since: now() });
+		this.flushQueue();
+	}
+
+	private resignLeader(): void {
+		this.isLeader = false;
+		this.teardownSocket(1000, "leader resign");
+		this.updateStatus({ state: "waiting" });
+	}
+}
+
+export function createLeaderConnection(config: ConnectionConfig): LeaderClient {
+	return new LeaderConnection(config);
+}

--- a/packages/core/test/utils.spec.ts
+++ b/packages/core/test/utils.spec.ts
@@ -1,0 +1,101 @@
+import {
+	computeBackoffDelay,
+	DroppingQueue,
+	ENVELOPE_VERSION,
+	type InEvent,
+	parseInbound,
+} from "../events";
+
+type TestCase = {
+	readonly name: string;
+	readonly fn: () => void | Promise<void>;
+};
+
+const tests: TestCase[] = [];
+
+function test(name: string, fn: () => void | Promise<void>): void {
+	tests.push({ name, fn });
+}
+
+function expect(condition: unknown, message: string): void {
+	if (!condition) {
+		throw new Error(message);
+	}
+}
+
+function expectEqual<T>(actual: T, expected: T, message: string): void {
+	if (actual !== expected) {
+		throw new Error(`${message} (expected ${expected}, received ${actual})`);
+	}
+}
+
+test("computeBackoffDelay stays within bounds", () => {
+	const originalRandom = Math.random;
+	Math.random = () => 0.5;
+	try {
+		const delay = computeBackoffDelay(3, 500, 30_000);
+		expect(delay >= 500, "delay should be at least base interval");
+		expect(delay <= 30_000, "delay should not exceed cap");
+	} finally {
+		Math.random = originalRandom;
+	}
+});
+
+test("DroppingQueue discards oldest entries when full", () => {
+	const queue = new DroppingQueue<number>(2);
+	queue.push(1);
+	queue.push(2);
+	const result = queue.push(3);
+	expect(result.dropped, "queue push should drop when capacity exceeded");
+	expectEqual(result.droppedValue, 1, "oldest value must be dropped");
+	expectEqual(queue.size(), 2, "queue should stay at capacity");
+	expectEqual(queue.droppedCount(), 1, "dropped counter increments");
+});
+
+test("parseInbound validates correct envelopes", () => {
+	const envelope = {
+		v: ENVELOPE_VERSION,
+		type: "pong",
+		ts: Date.now(),
+		id: "pong-id-1234",
+		payload: { sequence: 1 },
+	};
+	const parsed = parseInbound(envelope);
+	expect(parsed.ok, "expected parser to accept valid envelope");
+	if (parsed.ok) {
+		const event: InEvent = parsed.value;
+		expectEqual(event.type, "pong", "expected pong event");
+	}
+});
+
+test("parseInbound rejects unsupported versions", () => {
+	const parsed = parseInbound({
+		v: 999,
+		type: "pong",
+		ts: Date.now(),
+		id: "bad",
+		payload: { sequence: 1 },
+	});
+	expect(!parsed.ok, "expected parse to fail");
+	if (!parsed.ok) {
+		expectEqual(parsed.error.code, "unsupported_version", "wrong error code");
+	}
+});
+
+async function run(): Promise<void> {
+	let passed = 0;
+	for (const { name, fn } of tests) {
+		try {
+			await fn();
+			passed += 1;
+			console.log(`✔ ${name}`);
+		} catch (error) {
+			console.error(`✖ ${name}: ${(error as Error).message}`);
+		}
+	}
+	console.log(
+		`Executed ${tests.length} tests: ${passed} passed, ${tests.length - passed} failed.`
+	);
+}
+
+void run();

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -1,0 +1,33 @@
+import type { InEvent, OutEvent, ParseError, RawEnvelope } from "./events";
+
+export type ConnectionConfig = {
+	readonly workerUrl: URL;
+	readonly wsUrl: string;
+	readonly requestToken: () => Promise<string>;
+	readonly heartbeatMs?: number;
+	readonly maxQueue?: number;
+	readonly maxBackoffMs?: number;
+	readonly maxQueueDropWarnThreshold?: number;
+	readonly debug?: boolean;
+	readonly onUnknown?: (envelope: RawEnvelope, error: ParseError) => void;
+};
+
+export type ClientStatus = {
+	readonly state: "connecting" | "open" | "closed" | "waiting";
+	readonly attempts: number;
+	readonly since: number;
+	readonly queueSize: number;
+	readonly dropped: number;
+};
+
+export type WebSocketClient = {
+	send<T extends OutEvent>(event: T): Promise<void>;
+	subscribe<E extends InEvent["type"]>(
+		type: E,
+		handler: (event: Extract<InEvent, { type: E }>) => void
+	): () => void;
+	subscribeAll(handler: (event: InEvent) => void): () => void;
+	subscribeStatus?(handler: (status: ClientStatus) => void): () => void;
+	status(): ClientStatus;
+	stop(): void;
+};

--- a/packages/core/worker.ts
+++ b/packages/core/worker.ts
@@ -1,0 +1,605 @@
+import { z } from "zod";
+import {
+	computeBackoffDelay,
+	DroppingQueue,
+	ENVELOPE_VERSION,
+	type InEvent,
+	migrateUnknown,
+	type OutEvent,
+	type ParseError,
+	parseInbound,
+	parseOutbound,
+	type RawEnvelope,
+} from "./events";
+
+type WorkerConfig = {
+	readonly wsUrl: string;
+	readonly heartbeatMs: number;
+	readonly maxQueue: number;
+	readonly maxBackoffMs: number;
+	readonly debug: boolean;
+};
+
+type StatusSnapshot = {
+	state: "connecting" | "open" | "closed" | "waiting";
+	attempts: number;
+	since: number;
+	queueSize: number;
+	dropped: number;
+};
+
+type LogLevel = "error" | "warn" | "info" | "debug";
+
+type PendingToken = {
+	resolve: (token: string) => void;
+	reject: (err: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+};
+
+type PendingSend = {
+	readonly port?: MessagePort;
+	readonly requestId: string;
+	readonly event: OutEvent;
+};
+
+const DEFAULTS: WorkerConfig = {
+	wsUrl: "",
+	heartbeatMs: 25_000,
+	maxQueue: 100,
+	maxBackoffMs: 30_000,
+	debug: false,
+};
+
+const TOKEN_TIMEOUT_MS = 10_000;
+const PING_FAILURE_THRESHOLD = 2;
+const BACKOFF_BASE_MS = 500;
+const AUTH_CLOSE_CODES = new Set([4001, 4401, 4403, 4003]);
+
+const WorkerPortMessageSchema = z.discriminatedUnion("op", [
+	z.object({
+		op: z.literal("init"),
+		config: z.object({
+			wsUrl: z.string().url(),
+			heartbeatMs: z.number().int().positive().optional(),
+			maxQueue: z.number().int().positive().optional(),
+			maxBackoffMs: z.number().int().positive().optional(),
+			debug: z.boolean().optional(),
+		}),
+	}),
+	z.object({
+		op: z.literal("send"),
+		event: z.any(),
+		requestId: z.string().min(1),
+	}),
+	z.object({
+		op: z.literal("stop"),
+	}),
+	z.object({
+		op: z.literal("status"),
+	}),
+	z.object({
+		op: z.literal("tokenResponse"),
+		requestId: z.string().min(1),
+		token: z.string().min(1),
+	}),
+	z.object({
+		op: z.literal("tokenError"),
+		requestId: z.string().min(1),
+		reason: z.string().min(1),
+	}),
+	z.object({
+		op: z.literal("lifecycle"),
+		state: z.enum(["online", "offline", "visible", "hidden"]),
+	}),
+]);
+
+type WorkerPortMessage = z.infer<typeof WorkerPortMessageSchema>;
+
+type WorkerOutboundEvent = {
+	readonly op: "event";
+	readonly event: InEvent;
+};
+
+type WorkerUnknownEvent = {
+	readonly op: "unknown";
+	readonly envelope: RawEnvelope;
+	readonly error: ParseError;
+};
+
+type WorkerAckMessage = {
+	readonly op: "ack";
+	readonly requestId: string;
+};
+
+type WorkerNackMessage = {
+	readonly op: "nack";
+	readonly requestId: string;
+	readonly error: { code: string; message: string };
+};
+
+type WorkerStatusMessage = {
+	readonly op: "status";
+	readonly status: StatusSnapshot;
+};
+
+type WorkerTokenRequest = {
+	readonly op: "tokenRequest";
+	readonly requestId: string;
+};
+
+type WorkerLogMessage = {
+	readonly op: "log";
+	readonly level: LogLevel;
+	readonly message: string;
+	readonly details?: Record<string, unknown>;
+};
+
+type PortOutboundMessage =
+	| WorkerOutboundEvent
+	| WorkerUnknownEvent
+	| WorkerAckMessage
+	| WorkerNackMessage
+	| WorkerStatusMessage
+	| WorkerTokenRequest
+	| WorkerLogMessage;
+
+const ports = new Set<MessagePort>();
+const portHandlers = new WeakMap<MessagePort, (event: MessageEvent) => void>();
+let config: WorkerConfig = DEFAULTS;
+let socket: WebSocket | null = null;
+let state: StatusSnapshot = {
+	state: "closed",
+	attempts: 0,
+	since: Date.now(),
+	queueSize: 0,
+	dropped: 0,
+};
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let missedPongs = 0;
+let lastPingSequence = 0;
+let currentTokenPromise: Promise<string> | null = null;
+const pendingTokenRequests = new Map<string, PendingToken>();
+let outboundQueue = new DroppingQueue<PendingSend>(DEFAULTS.maxQueue);
+let isOffline = false;
+let visibilityState: "visible" | "hidden" = "visible";
+
+function broadcast(message: PortOutboundMessage): void {
+	for (const port of ports) {
+		try {
+			port.postMessage(message);
+		} catch (error) {
+			console.error("[ws-worker] failed to postMessage", error);
+		}
+	}
+}
+
+function log(
+	level: LogLevel,
+	message: string,
+	details?: Record<string, unknown>
+): void {
+	if (level === "error" || config.debug) {
+		broadcast({ op: "log", level, message, details });
+	}
+}
+
+function updateState(partial: Partial<StatusSnapshot>): void {
+	state = {
+		...state,
+		...partial,
+		queueSize: outboundQueue.size(),
+		dropped: outboundQueue.droppedCount(),
+	};
+	broadcast({ op: "status", status: state });
+}
+
+function stopHeartbeat(): void {
+	if (heartbeatTimer) {
+		clearInterval(heartbeatTimer);
+		heartbeatTimer = null;
+	}
+}
+
+function startHeartbeat(): void {
+	stopHeartbeat();
+	heartbeatTimer = setInterval(() => {
+		if (!socket || socket.readyState !== WebSocket.OPEN) {
+			return;
+		}
+		if (missedPongs >= PING_FAILURE_THRESHOLD) {
+			log("warn", "Heartbeat threshold exceeded, closing socket");
+			socket.close(4000, "Heartbeat timeout");
+			return;
+		}
+		lastPingSequence += 1;
+		const pingEvent: OutEvent = {
+			v: ENVELOPE_VERSION,
+			type: "ping",
+			ts: Date.now(),
+			id: `${Date.now()}-${lastPingSequence}`,
+			payload: { sequence: lastPingSequence },
+		};
+		sendNow({
+			event: pingEvent,
+			requestId: `heartbeat-${lastPingSequence}`,
+		});
+		missedPongs += 1;
+	}, config.heartbeatMs);
+}
+
+function clearReconnectTimer(): void {
+	if (reconnectTimer) {
+		clearTimeout(reconnectTimer);
+		reconnectTimer = null;
+	}
+}
+
+function scheduleReconnect(reason: string): void {
+	if (isOffline) {
+		log("info", "Offline detected, postponing reconnect", { reason });
+		updateState({ state: "waiting" });
+		return;
+	}
+	clearReconnectTimer();
+	const delay = computeBackoffDelay(
+		state.attempts + 1,
+		BACKOFF_BASE_MS,
+		config.maxBackoffMs
+	);
+	log("info", "Scheduling reconnect", { delay, reason });
+	reconnectTimer = setTimeout(() => {
+		reconnectTimer = null;
+		connect();
+	}, delay);
+	updateState({
+		state: "waiting",
+		attempts: state.attempts + 1,
+		since: Date.now(),
+	});
+}
+
+function requestToken(): Promise<string> {
+	if (currentTokenPromise) {
+		return currentTokenPromise;
+	}
+	const requestId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+	broadcast({ op: "tokenRequest", requestId });
+	currentTokenPromise = new Promise<string>((resolve, reject) => {
+		const timer = setTimeout(() => {
+			pendingTokenRequests.delete(requestId);
+			reject(new Error("Timed out waiting for token"));
+		}, TOKEN_TIMEOUT_MS);
+		pendingTokenRequests.set(requestId, {
+			resolve: (token) => {
+				clearTimeout(timer);
+				pendingTokenRequests.delete(requestId);
+				resolve(token);
+			},
+			reject: (err) => {
+				clearTimeout(timer);
+				pendingTokenRequests.delete(requestId);
+				reject(err);
+			},
+			timer,
+		});
+	}).finally(() => {
+		currentTokenPromise = null;
+	});
+	return currentTokenPromise;
+}
+
+function flushQueue(): void {
+	if (!socket || socket.readyState !== WebSocket.OPEN) {
+		return;
+	}
+	let entry: PendingSend | undefined = outboundQueue.shift();
+	while (entry) {
+		sendNow(entry);
+		entry = outboundQueue.shift();
+	}
+	updateState({ queueSize: outboundQueue.size() });
+}
+
+function sendNow(entry: PendingSend): void {
+	if (!socket || socket.readyState !== WebSocket.OPEN) {
+		const pushResult = outboundQueue.push({
+			port: entry.port,
+			requestId: entry.requestId,
+			event: entry.event,
+		});
+		if (pushResult.dropped && pushResult.droppedValue) {
+			const targetPort = pushResult.droppedValue.port;
+			if (targetPort) {
+				targetPort.postMessage({
+					op: "nack",
+					requestId: pushResult.droppedValue.requestId,
+					error: {
+						code: "queue_full",
+						message: "Outbound queue at capacity; oldest entry dropped",
+					},
+				});
+			}
+		}
+		updateState({ queueSize: outboundQueue.size() });
+		return;
+	}
+	try {
+		socket.send(JSON.stringify(entry.event));
+		if (entry.port) {
+			entry.port.postMessage({ op: "ack", requestId: entry.requestId });
+		}
+	} catch (error) {
+		const port = entry.port;
+		if (port) {
+			port.postMessage({
+				op: "nack",
+				requestId: entry.requestId,
+				error: { code: "send_failed", message: (error as Error).message },
+			});
+		}
+		outboundQueue.push(entry);
+	}
+}
+
+function connect(): void {
+	if (
+		socket &&
+		(socket.readyState === WebSocket.OPEN ||
+			socket.readyState === WebSocket.CONNECTING)
+	) {
+		return;
+	}
+	if (!config.wsUrl) {
+		log("error", "Cannot connect without wsUrl");
+		return;
+	}
+	const nextAttempts = state.attempts === 0 ? 1 : state.attempts;
+	updateState({
+		state: "connecting",
+		attempts: nextAttempts,
+		since: Date.now(),
+	});
+	requestToken()
+		.then((token) => {
+			const url = new URL(config.wsUrl);
+			url.searchParams.set("token", token);
+			socket = new WebSocket(url.toString(), "json.v1");
+			socket.addEventListener("open", handleOpen);
+			socket.addEventListener("close", handleClose);
+			socket.addEventListener("error", handleError);
+			socket.addEventListener("message", handleMessage);
+		})
+		.catch((error) => {
+			log("error", "Failed to obtain token", { message: error.message });
+			scheduleReconnect("token_error");
+		});
+}
+
+function teardownSocket(code = 1000, reason = "Client stop"): void {
+	if (socket) {
+		socket.removeEventListener("open", handleOpen);
+		socket.removeEventListener("close", handleClose);
+		socket.removeEventListener("error", handleError);
+		socket.removeEventListener("message", handleMessage);
+		try {
+			socket.close(code, reason);
+		} catch (error) {
+			log("error", "Error closing socket", {
+				message: (error as Error).message,
+			});
+		}
+	}
+	socket = null;
+	stopHeartbeat();
+}
+
+function handleOpen(): void {
+	missedPongs = 0;
+	updateState({ state: "open", attempts: 0, since: Date.now() });
+	flushQueue();
+	startHeartbeat();
+}
+
+function handleClose(event: CloseEvent): void {
+	stopHeartbeat();
+	log("info", "Socket closed", { code: event.code, reason: event.reason });
+	if (AUTH_CLOSE_CODES.has(event.code)) {
+		scheduleReconnect("auth_refresh");
+		return;
+	}
+	if (event.wasClean && event.code === 1000) {
+		updateState({ state: "closed", attempts: 0, since: Date.now() });
+		return;
+	}
+	scheduleReconnect(`close_${event.code}`);
+}
+
+function handleError(event: Event): void {
+	log("error", "Socket error", { message: (event as ErrorEvent).message });
+}
+
+function handleMessage(event: MessageEvent): void {
+	missedPongs = 0;
+	let data: unknown;
+	try {
+		data = JSON.parse(event.data as string);
+	} catch (error) {
+		log("warn", "Failed to parse inbound payload", {
+			error: (error as Error).message,
+		});
+		return;
+	}
+	const parsed = parseInbound(data);
+	if (!parsed.ok) {
+		const raw = data as RawEnvelope;
+		const migrated = migrateUnknown(raw);
+		if (migrated) {
+			broadcast({ op: "event", event: migrated });
+			return;
+		}
+		broadcast({
+			op: "unknown",
+			envelope: raw,
+			error: parsed,
+		});
+		return;
+	}
+	if (parsed.value.type === "pong") {
+		missedPongs = 0;
+	}
+	broadcast({ op: "event", event: parsed.value });
+}
+
+function handleTokenResponse(
+	message: Extract<WorkerPortMessage, { op: "tokenResponse" }>
+): void {
+	const pending = pendingTokenRequests.get(message.requestId);
+	if (!pending) {
+		return;
+	}
+	pending.resolve(message.token);
+}
+
+function handleTokenError(
+	message: Extract<WorkerPortMessage, { op: "tokenError" }>
+): void {
+	const pending = pendingTokenRequests.get(message.requestId);
+	if (!pending) {
+		return;
+	}
+	pending.reject(new Error(message.reason));
+}
+
+function handleLifecycle(
+	message: Extract<WorkerPortMessage, { op: "lifecycle" }>
+): void {
+	if (message.state === "online") {
+		isOffline = false;
+		if (!socket || socket.readyState === WebSocket.CLOSED) {
+			connect();
+		}
+	} else if (message.state === "offline") {
+		isOffline = true;
+		clearReconnectTimer();
+		updateState({ state: "waiting" });
+	} else {
+		visibilityState = message.state;
+		if (
+			visibilityState === "visible" &&
+			socket &&
+			socket.readyState === WebSocket.OPEN
+		) {
+			missedPongs = 0;
+		}
+	}
+}
+
+function handleSend(
+	port: MessagePort,
+	message: Extract<WorkerPortMessage, { op: "send" }>
+): void {
+	const parsed = parseOutbound(message.event);
+	if (!parsed.ok) {
+		port.postMessage({
+			op: "nack",
+			requestId: message.requestId,
+			error: { code: parsed.error.code, message: parsed.error.message },
+		});
+		return;
+	}
+	sendNow({ port, requestId: message.requestId, event: parsed.value });
+}
+
+function handlePortMessage(port: MessagePort, data: unknown): void {
+	const parsed = WorkerPortMessageSchema.safeParse(data);
+	if (!parsed.success) {
+		log("warn", "Ignoring malformed worker message", {
+			issues: parsed.error.issues,
+		});
+		return;
+	}
+	switch (parsed.data.op) {
+		case "init": {
+			const nextConfig: WorkerConfig = {
+				wsUrl: parsed.data.config.wsUrl,
+				heartbeatMs: parsed.data.config.heartbeatMs ?? DEFAULTS.heartbeatMs,
+				maxQueue: parsed.data.config.maxQueue ?? DEFAULTS.maxQueue,
+				maxBackoffMs: Math.min(
+					parsed.data.config.maxBackoffMs ?? DEFAULTS.maxBackoffMs,
+					30_000
+				),
+				debug: parsed.data.config.debug ?? DEFAULTS.debug,
+			};
+			const queueNeedsResize = nextConfig.maxQueue !== config.maxQueue;
+			config = nextConfig;
+			if (queueNeedsResize) {
+				const existing = outboundQueue.toArray();
+				outboundQueue = new DroppingQueue<PendingSend>(config.maxQueue);
+				for (const item of existing.slice(-config.maxQueue)) {
+					outboundQueue.push(item);
+				}
+			}
+			updateState({});
+			if (!socket || socket.readyState === WebSocket.CLOSED) {
+				connect();
+			}
+			break;
+		}
+		case "send":
+			handleSend(port, parsed.data);
+			break;
+		case "stop": {
+			ports.delete(port);
+			const handler = portHandlers.get(port);
+			if (handler) {
+				port.removeEventListener("message", handler as EventListener);
+				portHandlers.delete(port);
+			}
+			if (ports.size === 0) {
+				clearReconnectTimer();
+				teardownSocket(1000, "All ports closed");
+				outboundQueue.clear();
+			}
+			break;
+		}
+		case "status":
+			port.postMessage({ op: "status", status: state });
+			break;
+		case "tokenResponse":
+			handleTokenResponse(parsed.data);
+			break;
+		case "tokenError":
+			handleTokenError(parsed.data);
+			break;
+		case "lifecycle":
+			handleLifecycle(parsed.data);
+			break;
+		default:
+			log("warn", "Unhandled worker message op", { op: parsed.data.op });
+			break;
+	}
+}
+
+function onConnect(event: MessageEvent): void {
+	const port = event.ports[0];
+	if (!port) {
+		return;
+	}
+	if (ports.has(port)) {
+		return;
+	}
+	ports.add(port);
+	port.start();
+	const handler = (evt: MessageEvent) => handlePortMessage(port, evt.data);
+	portHandlers.set(port, handler);
+	port.addEventListener("message", handler as EventListener);
+	port.postMessage({ op: "status", status: state });
+}
+
+if (typeof self !== "undefined" && "addEventListener" in self) {
+	(self as unknown as SharedWorkerGlobalScope).addEventListener(
+		"connect",
+		onConnect as EventListener
+	);
+}

--- a/packages/react/use-web-sockets.ts
+++ b/packages/react/use-web-sockets.ts
@@ -1,0 +1,121 @@
+import { useMemo, useRef, useSyncExternalStore } from "react";
+import type { ClientStatus, WebSocketClient } from "../core/client";
+import type { InEvent } from "../core/events";
+
+export type WebSocketSnapshot = {
+	readonly status: ClientStatus;
+	readonly lastEvent: InEvent | null;
+};
+
+export type UseWebSocketsOptions<T> = {
+	readonly selector?: (snapshot: WebSocketSnapshot) => T;
+	readonly equality?: (left: T, right: T) => boolean;
+};
+
+type ExternalStore = {
+	subscribe(listener: () => void): () => void;
+	getSnapshot(): WebSocketSnapshot;
+};
+
+function createStore(client: WebSocketClient): ExternalStore {
+	let snapshot: WebSocketSnapshot = {
+		status: client.status(),
+		lastEvent: null,
+	};
+	const listeners = new Set<() => void>();
+	let unsubscribeAll: (() => void) | null = null;
+	let unsubscribeStatus: (() => void) | null = null;
+	let pollTimer: ReturnType<typeof setInterval> | null = null;
+
+	const notify = () => {
+		for (const listener of listeners) {
+			listener();
+		}
+	};
+
+	const ensureSubscriptions = () => {
+		if (listeners.size > 0 && !unsubscribeAll) {
+			unsubscribeAll = client.subscribeAll((event) => {
+				snapshot = { ...snapshot, lastEvent: event };
+				notify();
+			});
+			if (typeof client.subscribeStatus === "function") {
+				unsubscribeStatus = client.subscribeStatus((status) => {
+					snapshot = { ...snapshot, status };
+					notify();
+				});
+			} else {
+				pollTimer = setInterval(() => {
+					const nextStatus = client.status();
+					if (
+						nextStatus.state !== snapshot.status.state ||
+						nextStatus.attempts !== snapshot.status.attempts ||
+						nextStatus.queueSize !== snapshot.status.queueSize ||
+						nextStatus.dropped !== snapshot.status.dropped
+					) {
+						snapshot = { ...snapshot, status: nextStatus };
+						notify();
+					}
+				}, 500);
+			}
+		}
+	};
+
+	const teardown = () => {
+		if (listeners.size === 0) {
+			if (unsubscribeAll) {
+				unsubscribeAll();
+				unsubscribeAll = null;
+			}
+			if (unsubscribeStatus) {
+				unsubscribeStatus();
+				unsubscribeStatus = null;
+			}
+			if (pollTimer) {
+				clearInterval(pollTimer);
+				pollTimer = null;
+			}
+		}
+	};
+
+	return {
+		subscribe(listener: () => void): () => void {
+			listeners.add(listener);
+			ensureSubscriptions();
+			return () => {
+				listeners.delete(listener);
+				teardown();
+			};
+		},
+		getSnapshot(): WebSocketSnapshot {
+			return snapshot;
+		},
+	};
+}
+
+const defaultSelector = (snapshot: WebSocketSnapshot): WebSocketSnapshot =>
+	snapshot;
+const defaultEquality = <T>(left: T, right: T): boolean =>
+	Object.is(left, right);
+
+export function useWebSockets<T = WebSocketSnapshot>(
+	client: WebSocketClient,
+	options: UseWebSocketsOptions<T> = {}
+): T {
+	const store = useMemo(() => createStore(client), [client]);
+	const optionSelector = options.selector ?? (defaultSelector as unknown);
+	const selectSnapshot = optionSelector as (snapshot: WebSocketSnapshot) => T;
+	const equality = options.equality ?? defaultEquality<T>;
+	const currentSnapshot = useSyncExternalStore(
+		store.subscribe,
+		store.getSnapshot,
+		store.getSnapshot
+	);
+	const selection = selectSnapshot(currentSnapshot);
+	const lastSelection = useRef(selection);
+	const stableSelection = lastSelection.current;
+	if (!equality(selection, stableSelection)) {
+		lastSelection.current = selection;
+	}
+	return lastSelection.current;
+}

--- a/packages/react/useWebSockets.ts
+++ b/packages/react/useWebSockets.ts
@@ -1,0 +1,2 @@
+// biome-ignore lint/style/useFilenamingConvention: maintain backwards compatible camelCase entrypoint for existing imports.
+export * from "./use-web-sockets";


### PR DESCRIPTION
## Summary
- rewrite the Next.js dashboard example as a TSX client component that consumes the shared websocket client and feed helper
- simplify the embeddable widget example and hook export, and add the new typed React hook entrypoint
- tighten core queue/backoff utilities and websocket lifecycle handlers to satisfy lint rules across client, worker, and leader implementations
- format shared websocket type declarations for consistency

## Testing
- bunx biome check examples/next-dashboard/usage.tsx examples/widget/usage.ts packages/core/events.ts packages/core/fallback/leader.ts packages/core/worker.ts packages/react/use-web-sockets.ts packages/react/useWebSockets.ts packages/core/client.ts
- bun test packages/core/test/utils.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68fcd5bd6808832ba92bfa798450db69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time WebSocket client with SharedWorker support and automatic fallback mechanisms
  * Introduced React hooks for WebSocket state management and live status monitoring
  * Created type-safe event system with runtime validation and filtering
  * Added dashboard and widget example implementations with live connection indicators
  * Implemented automatic reconnection with exponential backoff and heartbeat monitoring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->