### PR TITLE
perf: prevent timeline rerenders while composing messages

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
@@ -5,6 +5,7 @@ import { useMultimodalInput } from "@cossistant/react/hooks/private/use-multimod
 import { CONVERSATION_AUTO_SEEN_DELAY_MS } from "@cossistant/react/hooks/use-conversation-auto-seen";
 import { useConversationSeen } from "@cossistant/react/hooks/use-conversation-seen";
 import { useWindowVisibilityFocus } from "@cossistant/react/hooks/use-window-visibility-focus";
+import type { AvailableAIAgent } from "@cossistant/types";
 import type { TimelineItem } from "@cossistant/types/api/timeline-item";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -21,6 +22,12 @@ import { useSendConversationMessage } from "@/hooks/use-send-conversation-messag
 import { useSidebar } from "@/hooks/use-sidebars";
 
 const MESSAGES_PAGE_LIMIT = 50;
+const EMPTY_AVAILABLE_AI_AGENTS: AvailableAIAgent[] = [];
+const MULTIMODAL_ALLOWED_FILE_TYPES: string[] = [
+	"image/*",
+	"application/pdf",
+	"text/*",
+];
 
 type ConversationPaneProps = {
 	conversationId: string;
@@ -128,10 +135,15 @@ export function ConversationPane({
 		initialData: selectedConversation?.seenData ?? [],
 	});
 
-	const lastMessage = useMemo(
-		() => items.filter((item) => item.type === "message").at(-1) ?? null,
-		[items]
-	);
+	const lastMessage = useMemo(() => {
+		for (let index = items.length - 1; index >= 0; index -= 1) {
+			const candidate = items[index];
+			if (candidate.type === "message") {
+				return candidate;
+			}
+		}
+		return null;
+	}, [items]);
 
 	useEffect(() => {
 		if (markSeenTimeoutRef.current) {
@@ -311,7 +323,7 @@ export function ConversationPane({
 			visitorIsBlocked: selectedConversation?.visitor.isBlocked ?? null,
 		},
 		timeline: {
-			availableAIAgents: [],
+			availableAIAgents: EMPTY_AVAILABLE_AI_AGENTS,
 			conversationId,
 			currentUserId,
 			items: items as TimelineItem[],
@@ -321,7 +333,7 @@ export function ConversationPane({
 			visitor,
 		},
 		input: {
-			allowedFileTypes: ["image/*", "application/pdf", "text/*"],
+			allowedFileTypes: MULTIMODAL_ALLOWED_FILE_TYPES,
 			error,
 			files,
 			isSubmitting,

--- a/apps/web/src/components/conversation/messages/conversation-timeline.tsx
+++ b/apps/web/src/components/conversation/messages/conversation-timeline.tsx
@@ -15,7 +15,7 @@ import type {
 import type { ConversationSeen } from "@cossistant/types/schemas";
 import { AnimatePresence } from "motion/react";
 import type { RefObject } from "react";
-import { useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef } from "react";
 import type { ConversationHeader } from "@/contexts/inboxes";
 import { cn } from "@/lib/utils";
 import { ConversationEvent } from "./event";
@@ -35,6 +35,11 @@ function extractEventPart(item: TimelineItem): TimelinePartEvent | null {
 	return eventPart || null;
 }
 
+const EMPTY_TIMELINE_ITEMS: TimelineItem[] = [];
+const EMPTY_TEAM_MEMBERS: RouterOutputs["user"]["getWebsiteMembers"] = [];
+const EMPTY_AVAILABLE_AI_AGENTS: AvailableAIAgent[] = [];
+const EMPTY_SEEN_DATA: ConversationSeen[] = [];
+
 type ConversationTimelineListProps = {
 	ref?: React.RefObject<HTMLDivElement | null>;
 	items: TimelineItem[];
@@ -48,12 +53,12 @@ type ConversationTimelineListProps = {
 	onFetchMoreIfNeeded?: () => void;
 };
 
-export function ConversationTimelineList({
+function ConversationTimelineListComponent({
 	ref,
-	items: timelineItems,
-	teamMembers = [],
-	availableAIAgents = [],
-	seenData = [],
+	items: timelineItems = EMPTY_TIMELINE_ITEMS,
+	teamMembers = EMPTY_TEAM_MEMBERS,
+	availableAIAgents = EMPTY_AVAILABLE_AI_AGENTS,
+	seenData = EMPTY_SEEN_DATA,
 	currentUserId,
 	conversationId,
 	className,
@@ -196,3 +201,28 @@ export function ConversationTimelineList({
 		</PrimitiveConversationTimeline>
 	);
 }
+
+const areConversationTimelinePropsEqual = (
+	prev: ConversationTimelineListProps,
+	next: ConversationTimelineListProps
+) => {
+	return (
+		prev.ref === next.ref &&
+		prev.items === next.items &&
+		prev.teamMembers === next.teamMembers &&
+		prev.availableAIAgents === next.availableAIAgents &&
+		prev.seenData === next.seenData &&
+		prev.currentUserId === next.currentUserId &&
+		prev.conversationId === next.conversationId &&
+		prev.className === next.className &&
+		prev.onFetchMoreIfNeeded === next.onFetchMoreIfNeeded &&
+		prev.visitor === next.visitor
+	);
+};
+
+export const ConversationTimelineList = memo(
+	ConversationTimelineListComponent,
+	areConversationTimelinePropsEqual
+);
+
+ConversationTimelineList.displayName = "ConversationTimelineList";

--- a/apps/web/src/data/use-conversation-timeline-items.tsx
+++ b/apps/web/src/data/use-conversation-timeline-items.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useInfiniteQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useTRPC } from "@/lib/trpc/client";
 
 type UseConversationTimelineItemsOptions = {
@@ -53,13 +54,20 @@ export function useConversationTimelineItems({
 		staleTime: STALE_TIME,
 	});
 
-	const items =
-		query.data?.pages
+	const pages = query.data?.pages;
+
+	const items = useMemo(() => {
+		if (!pages) {
+			return [];
+		}
+
+		return pages
 			.flatMap((page) => page.items)
 			.sort(
 				(a, b) =>
 					new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-			) ?? [];
+			);
+	}, [pages]);
 
 	return {
 		items,


### PR DESCRIPTION
## Summary
- memoize the dashboard conversation timeline list and reuse stable default collections so typing no longer forces expensive rerenders
- reuse shared constants for empty AI agent lists and input file types in the conversation pane while optimizing last-message lookup to avoid needless array work

## Testing
- bun run lint *(fails: turbo command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68fcdaaf3720832ba0212aa871a8ead1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized conversation timeline rendering through memoization techniques
  * Enhanced data transformation caching for conversation items
  * Standardized AI agent and file type handling across conversation components
  * Improved message filtering logic for conversation display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->