### PR TITLE
fix(api): hide internal conversation events from visitors

### DIFF
--- a/apps/api/src/db/mutations/conversation.ts
+++ b/apps/api/src/db/mutations/conversation.ts
@@ -71,6 +71,7 @@ export async function resolveConversation(
 			type: ConversationEventType.RESOLVED,
 			actorUserId: params.actorUserId,
 			createdAt: resolvedAt,
+			visibility: TimelineItemVisibility.PRIVATE,
 		},
 	});
 
@@ -122,6 +123,7 @@ export async function reopenConversation(
 			type: ConversationEventType.REOPENED,
 			actorUserId: params.actorUserId,
 			createdAt: reopenedAt,
+			visibility: TimelineItemVisibility.PRIVATE,
 		},
 	});
 
@@ -283,6 +285,7 @@ export async function archiveConversation(
 				archived: true,
 			},
 			createdAt: archivedAt,
+			visibility: TimelineItemVisibility.PRIVATE,
 		},
 	});
 
@@ -333,6 +336,7 @@ export async function unarchiveConversation(
 				archived: false,
 			},
 			createdAt: unarchivedAt,
+			visibility: TimelineItemVisibility.PRIVATE,
 		},
 	});
 


### PR DESCRIPTION
## Summary
- mark resolved and reopened conversation events as private timeline items
- mark archive and unarchive conversation events as private to keep them internal

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe6d0bdb10832bbba45746f932c2b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy controls for conversation state change events (resolve, reopen, archive, unarchive operations) by marking them as private within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->