### PR TITLE
feat: add fake dashboard preview component for landing page

### DIFF
--- a/apps/web/src/components/landing/fake-dashboard/conversation-view.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/conversation-view.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import Icon from "@/components/ui/icons";
+import { Page, PageContent, PageHeader } from "@/components/ui/layout";
+import { ResizableSidebar } from "@/components/ui/layout/sidebars/resizable-sidebar";
+import { SidebarContainer } from "@/components/ui/layout/sidebars/container";
+import { TooltipOnHover } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { FakeConversationMessage, FakeVisitorProfile } from "./types";
+
+type FakeConversationViewProps = {
+        messages: FakeConversationMessage[];
+        visitor: FakeVisitorProfile;
+};
+
+export function FakeConversationView({ messages, visitor }: FakeConversationViewProps) {
+        return (
+                <div className="flex h-full w-full">
+                        <Page className="flex-1 border-r border-primary/10 bg-background-50/30 dark:border-primary/5 dark:bg-background-100/10">
+                                <PageHeader className="border-b border-primary/10 bg-transparent pr-6 pl-4 dark:border-primary/5">
+                                        <div className="flex items-center gap-2">
+                                                <TooltipOnHover content="Back to list" shortcuts={["["]}>
+                                                        <Button className="ml-0.5" size="icon-small" variant="ghost">
+                                                                <Icon name="arrow-left" />
+                                                        </Button>
+                                                </TooltipOnHover>
+                                                <ConversationHeaderTitle visitor={visitor} />
+                                        </div>
+                                        <div className="flex items-center gap-2">
+                                                <Button size="sm" variant="ghost">
+                                                        <Icon name="conversation-resolved" />
+                                                        Resolve
+                                                </Button>
+                                                <Button size="sm" variant="ghost">
+                                                        <Icon name="archive" />
+                                                        Archive
+                                                </Button>
+                                                <Button className="hidden sm:flex" size="sm" variant="default">
+                                                        <Icon name="send" />
+                                                        Reply
+                                                </Button>
+                                        </div>
+                                </PageHeader>
+                                <PageContent className="flex flex-1 flex-col gap-3 overflow-hidden bg-transparent px-4 py-6">
+                                        <div className="flex-1 space-y-4 overflow-auto pr-2">
+                                                {messages.map((message) => (
+                                                        <MessageBubble key={message.id} message={message} />
+                                                ))}
+                                        </div>
+                                        <ComposerPlaceholder />
+                                </PageContent>
+                        </Page>
+                        <FakeVisitorSidebar visitor={visitor} />
+                </div>
+        );
+}
+
+type ConversationHeaderTitleProps = {
+        visitor: FakeVisitorProfile;
+};
+
+function ConversationHeaderTitle({ visitor }: ConversationHeaderTitleProps) {
+        return (
+                <div className="flex items-center gap-3">
+                        <Avatar className="size-9" fallbackName={visitor.name} withBoringAvatar />
+                        <div>
+                                <p className="font-semibold text-primary text-sm">{visitor.name}</p>
+                                <p className="text-primary/70 text-xs">Active conversation • {visitor.plan ?? "Trial"}</p>
+                        </div>
+                </div>
+        );
+}
+
+type MessageBubbleProps = {
+        message: FakeConversationMessage;
+};
+
+function MessageBubble({ message }: MessageBubbleProps) {
+        const isAgent = message.sender === "agent";
+        const isSystem = message.sender === "system";
+        return (
+                <div className={cn("flex w-full gap-3", isAgent && "justify-end")} data-role={message.sender}>
+                        {!isAgent ? (
+                                <Avatar className="mt-0.5 size-8" fallbackName={message.name} withBoringAvatar />
+                        ) : null}
+                        <div className={cn("max-w-[70%] space-y-2", isAgent && "items-end text-right")} data-emphasis={message.emphasis}>
+                                <div className="flex items-center gap-2 text-primary/60 text-[11px]">
+                                        <span className="font-medium text-primary/80 text-xs">{message.name}</span>
+                                        <span>{message.timestampLabel}</span>
+                                </div>
+                                <div
+                                        className={cn(
+                                                "rounded-2xl border px-4 py-3 text-left text-sm leading-relaxed shadow-sm",
+                                                isAgent
+                                                        ? "border-primary/20 bg-primary text-primary-foreground"
+                                                        : "border-primary/10 bg-background",
+                                                isSystem && "border-dashed text-primary/70"
+                                        )}
+                                >
+                                        {message.content}
+                                </div>
+                                {message.emphasis === "highlight" ? (
+                                        <Badge className="bg-primary/10 text-primary" variant="outline">
+                                                Suggested automation
+                                        </Badge>
+                                ) : null}
+                        </div>
+                        {isAgent ? (
+                                <Avatar className="mt-0.5 size-8" fallbackName="You" withBoringAvatar />
+                        ) : null}
+                </div>
+        );
+}
+
+function ComposerPlaceholder() {
+        return (
+                <div className="rounded-2xl border border-primary/10 bg-background px-4 py-3 shadow-inner dark:border-primary/5">
+                        <div className="flex items-center justify-between gap-3">
+                                <span className="text-primary/50 text-sm">Type your reply…</span>
+                                <div className="flex items-center gap-2 text-primary/50">
+                                        <Icon name="attachment" />
+                                        <Icon name="command" />
+                                        <Button size="sm">
+                                                <Icon name="send" />
+                                                Send
+                                        </Button>
+                                </div>
+                        </div>
+                </div>
+        );
+}
+
+type FakeVisitorSidebarProps = {
+        visitor: FakeVisitorProfile;
+};
+
+function FakeVisitorSidebar({ visitor }: FakeVisitorSidebarProps) {
+        return (
+                <ResizableSidebar className="hidden border-transparent lg:flex" position="right">
+                        <SidebarContainer>
+                                <div className="flex items-center gap-3 rounded-2xl bg-background px-3 py-3 shadow-sm dark:bg-background-100">
+                                        <Avatar className="size-10" fallbackName={visitor.name} withBoringAvatar />
+                                        <div className="space-y-1">
+                                                <p className="font-semibold text-primary text-sm">{visitor.name}</p>
+                                                <p className="text-primary/60 text-xs">{visitor.email ?? "Not identified yet"}</p>
+                                        </div>
+                                </div>
+                                <div className="mt-5 space-y-3 text-primary/70 text-xs">
+                                        <VisitorFact label="Plan" value={visitor.plan ?? "Growth"} />
+                                        <VisitorFact label="Last seen" value={visitor.lastSeenLabel ?? "2 minutes ago"} />
+                                        <VisitorFact label="Country" value={visitor.country ?? "United States"} />
+                                        <VisitorFact label="Local time" value={visitor.localTimeLabel ?? "12:04 PM (UTC-5)"} />
+                                </div>
+                        </SidebarContainer>
+                </ResizableSidebar>
+        );
+}
+
+type VisitorFactProps = {
+        label: string;
+        value: string;
+};
+
+function VisitorFact({ label, value }: VisitorFactProps) {
+        return (
+                <div className="flex items-center justify-between rounded-lg bg-background-100/60 px-3 py-2 dark:bg-background-200/50">
+                        <span className="font-medium text-primary/60">{label}</span>
+                        <span className="text-primary text-xs">{value}</span>
+                </div>
+        );
+}

--- a/apps/web/src/components/landing/fake-dashboard/fake-dashboard.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/fake-dashboard.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import { FakeConversationView } from "./conversation-view";
+import { FakeInboxView } from "./inbox-view";
+import { FakeSidebar } from "./sidebar";
+import { FakeTopbar } from "./topbar";
+import type {
+        FakeConversationMessage,
+        FakeConversationSummary,
+        FakeDashboardProps,
+        FakeDashboardView,
+        FakeVisitorProfile,
+} from "./types";
+
+const DEFAULT_CONVERSATIONS: FakeConversationSummary[] = [
+        {
+                id: "conv-1",
+                visitorName: "Olivia Rhye",
+                lastMessagePreview: "That walkthrough was super helpful—thank you!",
+                lastActiveLabel: "2m ago",
+                unread: true,
+                waitingSinceLabel: "Waiting for 2h",
+                tags: ["Docs", "Onboarding"],
+        },
+        {
+                id: "conv-2",
+                visitorName: "Phoenix Baker",
+                lastMessagePreview: "Could you confirm if the API limit resets daily?",
+                lastActiveLabel: "14m ago",
+        },
+        {
+                id: "conv-3",
+                visitorName: "Lana Steiner",
+                lastMessagePreview: "Amazing. Shipping the update tonight 🚀",
+                lastActiveLabel: "1h ago",
+        },
+        {
+                id: "conv-4",
+                visitorName: "Demi Wilkinson",
+                lastMessagePreview: "Attached the import CSV—let me know if you see the same error.",
+                lastActiveLabel: "2h ago",
+        },
+];
+
+const DEFAULT_MESSAGES: FakeConversationMessage[] = [
+        {
+                id: "msg-1",
+                sender: "visitor",
+                name: "Olivia Rhye",
+                timestampLabel: "9:41 AM",
+                content:
+                        "Morning! I invited our onboarding team and they're already asking about workspace permissions.",
+        },
+        {
+                id: "msg-2",
+                sender: "agent",
+                name: "You",
+                timestampLabel: "9:42 AM",
+                content:
+                        "Happy to help! Team members inherit workspace permissions by default. Do you want them to manage billing as well?",
+        },
+        {
+                id: "msg-3",
+                sender: "visitor",
+                name: "Olivia Rhye",
+                timestampLabel: "9:44 AM",
+                content:
+                        "Yes please—that would let them track usage while we test the AI scenarios.",
+        },
+        {
+                id: "msg-4",
+                sender: "agent",
+                name: "You",
+                timestampLabel: "9:45 AM",
+                content:
+                        "Perfect. I've enabled finance permissions and added a quick primer on suggested automations so they can experiment right away.",
+                emphasis: "highlight",
+        },
+        {
+                id: "msg-5",
+                sender: "system",
+                name: "System",
+                timestampLabel: "9:45 AM",
+                content: "Automation 'Qualified lead follow-up' triggered",
+                emphasis: "subtle",
+        },
+];
+
+const DEFAULT_VISITOR: FakeVisitorProfile = {
+        name: "Olivia Rhye",
+        email: "olivia@untitledui.com",
+        country: "United States",
+        timeZone: "America/Los_Angeles",
+        localTimeLabel: "6:45 AM (UTC-7)",
+        plan: "Growth trial",
+        lastSeenLabel: "Active 2 minutes ago",
+};
+
+export function FakeDashboard({
+        className,
+        initialView = "inbox",
+        onViewChange,
+        conversations = DEFAULT_CONVERSATIONS,
+        messages = DEFAULT_MESSAGES,
+        visitor = DEFAULT_VISITOR,
+}: FakeDashboardProps) {
+        const [view, setView] = useState<FakeDashboardView>(initialView);
+
+        useEffect(() => {
+                setView(initialView);
+        }, [initialView]);
+
+        const totalOpen = useMemo(
+                () => conversations.filter((conversation) => conversation.unread).length || 0,
+                [conversations]
+        );
+
+        const handleViewChange = (nextView: FakeDashboardView) => {
+                setView(nextView);
+                onViewChange?.(nextView);
+        };
+
+        return (
+                <div
+                        className={cn(
+                                "relative flex w-full flex-col overflow-hidden rounded-3xl border border-primary/10 bg-background/95 shadow-[0_30px_80px_-40px_rgba(15,23,42,0.45)] backdrop-blur dark:border-primary/5 dark:bg-background-50/90",
+                                className
+                        )}
+                >
+                        <FakeTopbar onSelectView={handleViewChange} view={view} />
+                        <div className="flex flex-1 gap-0 px-4 pb-5">
+                                <FakeSidebar activeView={view} openCount={totalOpen} />
+                                <section className="flex h-full flex-1 overflow-hidden rounded-2xl border border-primary/10 bg-background/80 shadow-[0_24px_60px_-36px_rgba(15,23,42,0.55)] dark:border-primary/5 dark:bg-background-50/60">
+                                        {view === "inbox" ? (
+                                                <FakeInboxView conversations={conversations} />
+                                        ) : (
+                                                <FakeConversationView messages={messages} visitor={visitor} />
+                                        )}
+                                </section>
+                        </div>
+                </div>
+        );
+}

--- a/apps/web/src/components/landing/fake-dashboard/inbox-view.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/inbox-view.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { Avatar } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import Icon from "@/components/ui/icons";
+import { Page, PageContent, PageHeader, PageHeaderTitle } from "@/components/ui/layout";
+import { TooltipOnHover } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { FakeConversationSummary } from "./types";
+
+type FakeInboxViewProps = {
+        conversations: FakeConversationSummary[];
+};
+
+export function FakeInboxView({ conversations }: FakeInboxViewProps) {
+        return (
+                <Page className="border-r border-primary/10 bg-background-50/40 dark:border-primary/5 dark:bg-background-100/10">
+                        <PageHeader className="border-b border-primary/10 bg-transparent pr-6 pl-4 dark:border-primary/5">
+                                <div className="flex items-center gap-2">
+                                        <TooltipOnHover content="Toggle sidebar" shortcuts={["["]}>
+                                                <Button className="ml-0.5" size="icon-small" variant="ghost">
+                                                        <Icon filledOnHover name="sidebar-collapse" />
+                                                </Button>
+                                        </TooltipOnHover>
+                                        <PageHeaderTitle>Inbox</PageHeaderTitle>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                        <Button size="sm" variant="ghost">
+                                                <Icon name="menu" />
+                                                Views
+                                        </Button>
+                                        <Button className="hidden sm:flex" size="sm">
+                                                <Icon name="plus" />
+                                                New view
+                                        </Button>
+                                </div>
+                        </PageHeader>
+                        <PageContent className="flex-1 overflow-auto px-3 py-4">
+                                <div className="space-y-2">
+                                        {conversations.map((conversation) => (
+                                                <FakeConversationListItem
+                                                        key={conversation.id}
+                                                        conversation={conversation}
+                                                />
+                                        ))}
+                                </div>
+                        </PageContent>
+                </Page>
+        );
+}
+
+type FakeConversationListItemProps = {
+        conversation: FakeConversationSummary;
+};
+
+function FakeConversationListItem({ conversation }: FakeConversationListItemProps) {
+        return (
+                <div
+                        className={cn(
+                                "flex items-center justify-between gap-4 rounded-xl border border-transparent bg-background px-3 py-3",
+                                "shadow-[0_8px_24px_-18px_rgba(15,23,42,0.45)] transition hover:border-primary/10 hover:shadow-[0_18px_42px_-24px_rgba(15,23,42,0.5)] dark:bg-background-100"
+                        )}
+                >
+                        <div className="flex min-w-0 flex-1 items-center gap-3">
+                                <Avatar className="size-10" fallbackName={conversation.visitorName} withBoringAvatar />
+                                <div className="min-w-0">
+                                        <p className="font-medium text-primary text-sm">
+                                                {conversation.visitorName}
+                                        </p>
+                                        <p className="truncate text-primary/70 text-xs">
+                                                {conversation.lastMessagePreview}
+                                        </p>
+                                        <div className="mt-1 flex flex-wrap items-center gap-1">
+                                                {conversation.tags?.map((tag) => (
+                                                        <Badge key={tag} variant="secondary">
+                                                                {tag}
+                                                        </Badge>
+                                                ))}
+                                                {conversation.waitingSinceLabel ? (
+                                                        <span className="rounded-full bg-warning/10 px-2 py-0.5 text-warning text-[10px]">
+                                                                {conversation.waitingSinceLabel}
+                                                        </span>
+                                                ) : null}
+                                        </div>
+                                </div>
+                        </div>
+                        <div className="flex flex-col items-end gap-2 text-primary/60 text-xs">
+                                <span>{conversation.lastActiveLabel}</span>
+                                {conversation.unread ? (
+                                        <span className="inline-flex size-2 rounded-full bg-primary" />
+                                ) : null}
+                        </div>
+                </div>
+        );
+}

--- a/apps/web/src/components/landing/fake-dashboard/index.ts
+++ b/apps/web/src/components/landing/fake-dashboard/index.ts
@@ -1,0 +1,2 @@
+export { FakeDashboard } from "./fake-dashboard";
+export type { FakeDashboardProps, FakeDashboardView } from "./types";

--- a/apps/web/src/components/landing/fake-dashboard/sidebar.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/sidebar.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { SidebarContainer } from "@/components/ui/layout/sidebars/container";
+import { ResizableSidebar } from "@/components/ui/layout/sidebars/resizable-sidebar";
+import { SidebarItem } from "@/components/ui/layout/sidebars/sidebar-item";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+import type { FakeDashboardView } from "./types";
+
+type FakeSidebarProps = {
+        activeView: FakeDashboardView;
+        openCount: number;
+};
+
+export function FakeSidebar({ activeView, openCount }: FakeSidebarProps) {
+        return (
+                <ResizableSidebar className="border-transparent" position="left">
+                        <SidebarContainer
+                                footer={
+                                        <div className="mt-6 flex flex-col gap-2 text-xs text-primary/60">
+                                                <Separator className="opacity-20" />
+                                                <p className="font-medium">Quick links</p>
+                                                <div className="grid gap-1">
+                                                        <SidebarPlaceholderLink label="Docs" />
+                                                        <SidebarPlaceholderLink label="Settings" />
+                                                </div>
+                                        </div>
+                                }
+                        >
+                                <SidebarItem active={activeView === "inbox"} iconName="inbox-zero">
+                                        Inbox
+                                        <span className="ml-auto rounded-full bg-primary/10 px-2 py-0.5 text-primary text-[10px]">
+                                                {openCount}
+                                        </span>
+                                </SidebarItem>
+                                <SidebarItem iconName="conversation-resolved">Resolved</SidebarItem>
+                                <SidebarItem iconName="conversation-spam">Spam</SidebarItem>
+                                <SidebarItem iconName="archive">Archived</SidebarItem>
+                        </SidebarContainer>
+                </ResizableSidebar>
+        );
+}
+
+type SidebarPlaceholderLinkProps = {
+        label: string;
+};
+
+function SidebarPlaceholderLink({ label }: SidebarPlaceholderLinkProps) {
+        return (
+                <span
+                        className={cn(
+                                "flex items-center justify-between rounded-md px-3 py-1 text-primary/70 transition-colors",
+                                "bg-background-100/80 dark:bg-background-200/60"
+                        )}
+                >
+                        {label}
+                        <span aria-hidden className="text-primary/30">↗</span>
+                </span>
+        );
+}

--- a/apps/web/src/components/landing/fake-dashboard/topbar.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/topbar.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import Icon, { type IconName } from "@/components/ui/icons";
+import { Logo } from "@/components/ui/logo";
+import { cn } from "@/lib/utils";
+import type { FakeDashboardView } from "./types";
+
+type FakeTopbarProps = {
+        view: FakeDashboardView;
+        onSelectView?: (view: FakeDashboardView) => void;
+};
+
+export function FakeTopbar({ view, onSelectView }: FakeTopbarProps) {
+        return (
+                <header className="flex h-16 min-h-16 items-center justify-between gap-4 px-6">
+                        <div className="flex items-center gap-4">
+                                <div className="flex items-center gap-3">
+                                        <Logo className="size-6 text-primary" />
+                                        <span className="font-semibold text-primary text-sm">Cossistant</span>
+                                </div>
+                                <nav className="flex items-center gap-2">
+                                        <TopbarChip
+                                                active={view === "inbox"}
+                                                iconName="inbox-zero"
+                                                label="Inbox"
+                                                onClick={() => onSelectView?.("inbox")}
+                                        />
+                                        <TopbarChip
+                                                active={view === "conversation"}
+                                                iconName="conversation"
+                                                label="Conversation"
+                                                onClick={() => onSelectView?.("conversation")}
+                                        />
+                                </nav>
+                        </div>
+                        <div className="flex items-center gap-3 text-muted-foreground text-xs">
+                                <span className="flex items-center gap-2">
+                                        <span aria-hidden className="size-2 animate-pulse rounded-full bg-cossistant-green" />
+                                        <span>3 visitors online</span>
+                                </span>
+                                <div className="hidden items-center gap-2 md:flex">
+                                        <span className="rounded-full bg-background-100 px-3 py-1 text-primary text-xs dark:bg-background-200">
+                                                Demo mode
+                                        </span>
+                                </div>
+                        </div>
+                </header>
+        );
+}
+
+type TopbarChipProps = {
+        active: boolean;
+        iconName: IconName;
+        label: string;
+        onClick: () => void;
+};
+
+function TopbarChip({ active, iconName, label, onClick }: TopbarChipProps) {
+        return (
+                <Button
+                        className={cn(
+                                "flex items-center gap-2 px-3 text-xs",
+                                active
+                                        ? "bg-primary text-primary-foreground"
+                                        : "bg-background-100 text-primary/70 hover:text-primary"
+                        )}
+                        onClick={onClick}
+                        size="sm"
+                        type="button"
+                        variant="ghost"
+                >
+                        <Icon name={iconName} />
+                        {label}
+                </Button>
+        );
+}

--- a/apps/web/src/components/landing/fake-dashboard/types.ts
+++ b/apps/web/src/components/landing/fake-dashboard/types.ts
@@ -1,0 +1,39 @@
+export type FakeDashboardView = "inbox" | "conversation";
+
+export type FakeConversationSummary = {
+        id: string;
+        visitorName: string;
+        lastMessagePreview: string;
+        lastActiveLabel: string;
+        unread?: boolean;
+        waitingSinceLabel?: string | null;
+        tags?: string[];
+};
+
+export type FakeConversationMessage = {
+        id: string;
+        sender: "visitor" | "agent" | "system";
+        name: string;
+        timestampLabel: string;
+        content: string;
+        emphasis?: "highlight" | "subtle";
+};
+
+export type FakeVisitorProfile = {
+        name: string;
+        email?: string;
+        country?: string;
+        timeZone?: string;
+        localTimeLabel?: string;
+        plan?: string;
+        lastSeenLabel?: string;
+};
+
+export type FakeDashboardProps = {
+        className?: string;
+        initialView?: FakeDashboardView;
+        onViewChange?: (view: FakeDashboardView) => void;
+        conversations?: FakeConversationSummary[];
+        messages?: FakeConversationMessage[];
+        visitor?: FakeVisitorProfile;
+};


### PR DESCRIPTION
## Summary
- add a reusable FakeDashboard component for the landing page with inbox and conversation previews
- build supporting topbar, sidebar, inbox, and conversation preview UIs with stub data and configurable props

## Testing
- bun run lint --filter @cossistant/web *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_6900d2dad028832b9ec6c8d2f2361837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a demo dashboard interface featuring inbox and conversation views
  * Implemented conversation viewer with message display and visitor profile sidebar
  * Created conversation list showing message previews and status indicators
  * Added navigation components including top bar and resizable sidebar for switching views and actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->