### PR TITLE
fix: run formatter directly in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-if bunx turbo run fix; then
+bun run fix
 git add --update
-fi


### PR DESCRIPTION
## Summary
- call `bun run fix` from the Husky pre-commit hook so it formats changes directly
- ensure the hook re-stages formatter output while failing fast on real errors

## Testing
- .husky/pre-commit *(fails in container: npm prompts for confirmation when installing CLI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6902249b3688832bb754f8b612dc4e27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit hook robustness to ensure code quality fixes run consistently during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->