### PR TITLE
feat: add view cycling controls to fake dashboard

### DIFF
--- a/apps/web/src/components/landing/fake-dashboard/index.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import { FakeConversation } from "./fake-conversation";
 import { useFakeConversation } from "./fake-conversation/use-fake-conversation";
@@ -10,9 +10,10 @@ import { FakeCentralContainer } from "./fake-layout";
 import { FakeNavigationTopbar } from "./fake-navigation-topbar";
 
 export function FakeDashboard({ className }: { className?: string }) {
-	const [activeView, setActiveView] = useState<"inbox" | "conversation">(
-		"conversation"
-	);
+        const [activeView, setActiveView] = useState<"inbox" | "conversation">(
+                "conversation"
+        );
+        const [isCycling, setIsCycling] = useState(true);
 	const {
 		conversations,
 		typingVisitors: inboxTypingVisitors,
@@ -27,21 +28,87 @@ export function FakeDashboard({ className }: { className?: string }) {
 		resetDemoData: resetConversationDemoData,
 	} = useFakeConversation();
 
-	const resetDemoData = () => {
-		resetInboxDemoData();
-		resetConversationDemoData();
-	};
+        const resetDemoData = useCallback(() => {
+                resetInboxDemoData();
+                resetConversationDemoData();
+        }, [resetInboxDemoData, resetConversationDemoData]);
 
-	return (
-		<div
-			className={cn(
-				"@container size-full overflow-hidden bg-background-100 dark:bg-background",
-				className
-			)}
-		>
-			<FakeNavigationTopbar />
-			<FakeCentralContainer>
-				{activeView === "inbox" ? (
+        useEffect(() => {
+                if (!isCycling) {
+                        return;
+                }
+
+                const interval = window.setInterval(() => {
+                        setActiveView((previousView) => {
+                                const nextView =
+                                        previousView === "inbox"
+                                                ? "conversation"
+                                                : "inbox";
+
+                                resetDemoData();
+
+                                return nextView;
+                        });
+                }, 8000);
+
+                return () => {
+                        window.clearInterval(interval);
+                };
+        }, [isCycling, resetDemoData]);
+
+        const focusInbox = () => {
+                setActiveView("inbox");
+                setIsCycling(false);
+        };
+
+        const focusConversation = () => {
+                setActiveView("conversation");
+                setIsCycling(false);
+        };
+
+        const resumeCycling = () => {
+                if (isCycling) {
+                        return;
+                }
+
+                resetDemoData();
+                setIsCycling(true);
+        };
+
+        return (
+                <div
+                        className={cn(
+                                "@container relative size-full overflow-hidden bg-background-100 dark:bg-background",
+                                className
+                        )}
+                >
+                        <div className="pointer-events-auto absolute left-full top-1/2 z-50 ml-6 flex w-max -translate-y-1/2 flex-col gap-2">
+                                <button
+                                        className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-background-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                        onClick={focusInbox}
+                                        type="button"
+                                >
+                                        Focus inbox
+                                </button>
+                                <button
+                                        className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-background-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring"
+                                        onClick={focusConversation}
+                                        type="button"
+                                >
+                                        Focus conversation
+                                </button>
+                                <button
+                                        className="rounded-md border border-border bg-background px-3 py-1.5 text-sm font-medium shadow-sm transition hover:bg-background-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring disabled:cursor-not-allowed disabled:opacity-60"
+                                        disabled={isCycling}
+                                        onClick={resumeCycling}
+                                        type="button"
+                                >
+                                        Resume cycling
+                                </button>
+                        </div>
+                        <FakeNavigationTopbar />
+                        <FakeCentralContainer>
+                                {activeView === "inbox" ? (
 					<FakeInbox
 						conversations={conversations}
 						typingVisitors={inboxTypingVisitors}


### PR DESCRIPTION
## Summary
- add automatic cycling between the inbox and conversation demos
- add external controls to focus on a single view or resume the automated cycling

## Testing
- bun run lint --filter @cossistant/web *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_69028bbc16ac832b84b9c7b55aad56a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled auto-cycling between inbox and conversation views every 8 seconds.
  * Added control panel with buttons to manually switch views or resume cycling.
  * Demo data automatically resets when switching between views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->