### PR TITLE
fix: prefetch conversations for unread badge

### DIFF
--- a/packages/react/src/provider.tsx
+++ b/packages/react/src/provider.tsx
@@ -233,9 +233,18 @@ function SupportProviderInner({
 		return count;
 	}, [conversationSnapshots, seenEntriesByConversation, visitorId]);
 
-	React.useEffect(() => {
-		setUnreadCount(derivedUnreadCount);
-	}, [derivedUnreadCount, setUnreadCount]);
+        React.useEffect(() => {
+                setUnreadCount(derivedUnreadCount);
+        }, [derivedUnreadCount, setUnreadCount]);
+
+        // Prime REST client with website/visitor context so headers are sent reliably
+        React.useEffect(() => {
+                if (!website) {
+                        return;
+                }
+
+                client.setWebsiteContext(website.id, website.visitor?.id ?? undefined);
+        }, [client, website]);
 
         React.useEffect(() => {
                 if (isVisitorBlocked) {
@@ -244,6 +253,10 @@ function SupportProviderInner({
                 }
 
                 if (!autoConnect) {
+                        return;
+                }
+
+                if (!website) {
                         return;
                 }
 
@@ -271,18 +284,9 @@ function SupportProviderInner({
                         );
                         prefetchedVisitorRef.current = null;
                 });
-        }, [autoConnect, client, isVisitorBlocked, visitorId]);
+        }, [autoConnect, client, isVisitorBlocked, visitorId, website]);
 
-	const error = websiteError;
-
-	// Prime REST client with website/visitor context so headers are sent reliably
-	React.useEffect(() => {
-		if (!website) {
-			return;
-		}
-
-		client.setWebsiteContext(website.id, website.visitor?.id ?? undefined);
-	}, [client, website]);
+        const error = websiteError;
 
 	React.useEffect(() => {
 		client.setVisitorBlocked(isVisitorBlocked);


### PR DESCRIPTION
## Summary
- prefetch visitor conversations during support provider initialisation so unread counts update before the widget opens

## Testing
- bun run lint --filter @cossistant/react *(fails: turbo command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_6904bfe3b30c832bac4baa9ebdc901b8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Conversations now automatically prefetch in the background when auto-connect is enabled, reducing initial load times.
  * Smart prefetching skips redundant work for blocked visitors or when conversations already exist.

* **Improvements**
  * Backend context priming when website/visitor info changes improves responsiveness.
  * Improved error handling and recovery for background data fetches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->