### PR TITLE
fix: hide closed conversations in support widget lists

### DIFF
--- a/packages/react/src/hooks/use-conversation-history-page.ts
+++ b/packages/react/src/hooks/use-conversation-history-page.ts
@@ -1,5 +1,6 @@
 import type { Conversation } from "@cossistant/types";
 import { useCallback, useMemo, useState } from "react";
+import { shouldDisplayConversation } from "../utils/conversation";
 import { useConversations } from "./use-conversations";
 
 export type UseConversationHistoryPageOptions = {
@@ -102,12 +103,21 @@ export function useConversationHistoryPage(
 	} = options;
 
 	// Fetch conversations
-	const { conversations, isLoading, error } = useConversations({
+	const {
+		conversations: allConversations,
+		isLoading,
+		error,
+	} = useConversations({
 		enabled,
 		// Most recent first
 		orderBy: "updatedAt",
 		order: "desc",
 	});
+
+	const conversations = useMemo(
+		() => allConversations.filter(shouldDisplayConversation),
+		[allConversations]
+	);
 
 	// Manage visible count for pagination
 	const [visibleCount, setVisibleCount] = useState(initialVisibleCount);
@@ -115,7 +125,7 @@ export function useConversationHistoryPage(
 	// Compute visible conversations and pagination state
 	const { visibleConversations, hasMore, remainingCount } = useMemo(() => {
 		const visible = conversations.slice(0, visibleCount);
-		const remaining = Math.max(conversations.length - visibleCount, 0);
+		const remaining = Math.max(conversations.length - visible.length, 0);
 
 		return {
 			visibleConversations: visible,

--- a/packages/react/src/utils/conversation.ts
+++ b/packages/react/src/utils/conversation.ts
@@ -1,0 +1,28 @@
+import { type Conversation, ConversationStatus } from "@cossistant/types";
+
+const HIDDEN_STATUSES = new Set<ConversationStatus | "closed">([
+	ConversationStatus.RESOLVED,
+	"closed",
+]);
+
+function hasDisplayableTitle(conversation: Conversation): boolean {
+	const title = conversation.title?.trim();
+
+	return Boolean(title && title.length > 0);
+}
+
+export function shouldDisplayConversation(conversation: Conversation): boolean {
+	if (!hasDisplayableTitle(conversation)) {
+		return false;
+	}
+
+	if (conversation.deletedAt) {
+		return false;
+	}
+
+	if (HIDDEN_STATUSES.has(conversation.status)) {
+		return false;
+	}
+
+	return true;
+}

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from "./conversation";
 export * from "./id";
 export * from "./use-render-element";


### PR DESCRIPTION
## Summary
- add a shared guard to decide when a conversation should appear in widget lists
- filter the home and conversation history hooks to hide closed, resolved, or untitled threads

## Testing
- bun run lint --filter @cossistant/react *(fails: missing `lint` task in project)*
- bun run lint *(fails: missing `lint` task in project)*

------
https://chatgpt.com/codex/tasks/task_e_690a19d60894832ba585185d8db8c9f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented conversation filtering to exclude resolved, closed, and deleted conversations from display.
  * Conversations without proper titles are now automatically hidden from view.

* **Bug Fixes**
  * Corrected pagination calculations to accurately count filtered conversation lists.
  * Improved conversation status detection for more reliable filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->