### PR TITLE
feat: finish onboarding installation guidance

### DIFF
--- a/apps/web/src/app/(dashboard)/welcome/[organizationSlug]/creation-flow/index.tsx
+++ b/apps/web/src/app/(dashboard)/welcome/[organizationSlug]/creation-flow/index.tsx
@@ -1,47 +1,229 @@
 "use client";
 
-import type { CreateWebsiteResponse } from "@cossistant/types";
+import {
+        APIKeyType,
+        type CreateWebsiteResponse,
+        WebsiteInstallationTarget,
+} from "@cossistant/types";
 import { useMutation } from "@tanstack/react-query";
+import Link from "next/link";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { CodeBlockCommand } from "@/components/code-block-command";
+import { DashboardCodeBlock } from "@/components/dashboard-code-block";
+import { Button } from "@/components/ui/button";
+import { Step, Steps } from "@/components/ui/steps";
 import { useTRPC } from "@/lib/trpc/client";
 import WebsiteCreationForm from "./website-creation-form";
 
 type CreationFlowWrapperProps = {
-	organizationId: string;
+        organizationId: string;
+};
+
+type WebsiteSetupState = {
+        website: CreateWebsiteResponse;
+        installationTarget: WebsiteInstallationTarget;
 };
 
 export default function CreationFlowWrapper({
-	organizationId,
+        organizationId,
 }: CreationFlowWrapperProps) {
-	const trpc = useTRPC();
-	const [website, setWebsite] = useState<CreateWebsiteResponse | null>(null);
+        const trpc = useTRPC();
+        const [websiteSetup, setWebsiteSetup] = useState<WebsiteSetupState | null>(
+                null
+        );
 
-	const { mutate: createWebsite, isPending: isSubmitting } = useMutation(
-		trpc.website.create.mutationOptions({
-			onSuccess: (data) => {
-				setWebsite(data);
-			},
-		})
-	);
+        const { mutate: createWebsite, isPending: isSubmitting } = useMutation(
+                trpc.website.create.mutationOptions({
+                        onSuccess: (data, variables) => {
+                                setWebsiteSetup({
+                                        website: data,
+                                        installationTarget:
+                                                variables.installationTarget,
+                                });
+                        },
+                })
+        );
 
-	if (!website) {
-		return (
-			<motion.div
-				animate={{ opacity: 1, y: 0 }}
-				initial={{ opacity: 0, y: 10 }}
-				transition={{ duration: 0.5, delay: 1 }}
-			>
-				<WebsiteCreationForm
-					isSubmitting={isSubmitting}
-					onSubmit={createWebsite}
-					organizationId={organizationId}
-				/>
-			</motion.div>
-		);
-	}
+        const publicApiKey = useMemo(() => {
+                if (!websiteSetup) {
+                        return null;
+                }
 
-	console.log({ website });
+                return (
+                        websiteSetup.website.apiKeys.find(
+                                (key) => key.keyType === APIKeyType.PUBLIC
+                        )?.key ?? null
+                );
+        }, [websiteSetup]);
 
-	return <div>Creation Flow</div>;
+        const isNextInstallation =
+                websiteSetup?.installationTarget ===
+                WebsiteInstallationTarget.NEXTJS;
+
+        return (
+                <Steps
+                        className="mt-10"
+                        interactive
+                >
+                        <Step completed={Boolean(websiteSetup)}>
+                                <div className="text-lg font-semibold">
+                                        Create your website
+                                </div>
+                                <motion.div
+                                        animate={{ opacity: 1, y: 0 }}
+                                        className="mt-3 space-y-4"
+                                        initial={{ opacity: 0, y: 10 }}
+                                        transition={{ duration: 0.5, delay: 0.4 }}
+                                >
+                                        <p className="text-muted-foreground text-sm">
+                                                Search for your welcome page so we can set up
+                                                the correct organization and domain for your
+                                                team.
+                                        </p>
+
+                                        {websiteSetup ? (
+                                                <div className="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 text-sm">
+                                                        <p className="font-medium text-primary">
+                                                                {websiteSetup.website.name} is ready.
+                                                        </p>
+                                                        <p className="text-muted-foreground">
+                                                                We generated your default API keys and
+                                                                allowed localhost so you can start building
+                                                                immediately.
+                                                        </p>
+                                                </div>
+                                        ) : (
+                                                <WebsiteCreationForm
+                                                        isSubmitting={isSubmitting}
+                                                        onSubmit={createWebsite}
+                                                        organizationId={organizationId}
+                                                />
+                                        )}
+                                </motion.div>
+                        </Step>
+
+                        <Step enabled={Boolean(websiteSetup)}>
+                                <div className="text-lg font-semibold">
+                                        Install Cossistant
+                                </div>
+                                <motion.div
+                                        animate={{ opacity: 1, y: 0 }}
+                                        className="mt-3 space-y-6"
+                                        initial={{ opacity: 0, y: 10 }}
+                                        transition={{ duration: 0.5, delay: 0.7 }}
+                                >
+                                        {!websiteSetup ? null : isNextInstallation ? (
+                                                <>
+                                                        <p className="text-muted-foreground text-sm">
+                                                                Bring Cossistant into your Next.js app with
+                                                                the steps below. We included your freshly
+                                                                minted public key so you can copy and paste it
+                                                                straight into your environment.
+                                                        </p>
+
+                                                        <div className="space-y-3">
+                                                                <h4 className="font-medium text-sm uppercase tracking-wide text-primary">
+                                                                        Install the SDK
+                                                                </h4>
+                                                                <CodeBlockCommand
+                                                                        __bun__="bun add @cossistant/next"
+                                                                        __npm__="npm install @cossistant/next"
+                                                                        __pnpm__="pnpm add @cossistant/next"
+                                                                        __yarn__="yarn add @cossistant/next"
+                                                                />
+                                                        </div>
+
+                                                        <div className="space-y-3">
+                                                                <h4 className="font-medium text-sm uppercase tracking-wide text-primary">
+                                                                        Add your public key
+                                                                </h4>
+                                                                <DashboardCodeBlock
+                                                                        code={`NEXT_PUBLIC_COSSISTANT_API_KEY=${publicApiKey ?? "pk_test_replace_me"}`}
+                                                                        fileName=".env.local"
+                                                                        language="bash"
+                                                                />
+                                                                {!publicApiKey ? (
+                                                                        <p className="text-destructive text-xs">
+                                                                                We couldn't load your key automatically.
+                                                                                Grab it from Settings → Developers.
+                                                                        </p>
+                                                                ) : null}
+                                                        </div>
+
+                                                        <div className="space-y-3">
+                                                                <h4 className="font-medium text-sm uppercase tracking-wide text-primary">
+                                                                        Wrap your layout
+                                                                </h4>
+                                                                <DashboardCodeBlock
+                                                                        code={`import { SupportProvider } from "@cossistant/next";
+
+import "./globals.css";
+import "@cossistant/react/support.css";
+
+export default function RootLayout({
+        children,
+}: Readonly<{
+        children: React.ReactNode;
+}>) {
+        return (
+                <html lang="en">
+                        <body>
+                                <SupportProvider>{children}</SupportProvider>
+                        </body>
+                </html>
+        );
+}
+`}
+                                                                        fileName="app/layout.tsx"
+                                                                />
+                                                        </div>
+
+                                                        <div className="space-y-3">
+                                                                <h4 className="font-medium text-sm uppercase tracking-wide text-primary">
+                                                                        Drop the widget anywhere
+                                                                </h4>
+                                                                <DashboardCodeBlock
+                                                                        code={`import { Support } from "@cossistant/next";
+
+export default function Page() {
+        return (
+                <main>
+                        <h1>You're ready to chat!</h1>
+                        <Support />
+                </main>
+        );
+}
+`}
+                                                                        fileName="app/page.tsx"
+                                                                />
+                                                        </div>
+
+                                                        <div className="flex flex-col gap-2 rounded-lg border border-dashed border-primary/40 bg-primary/5 px-4 py-3 text-sm">
+                                                                <p className="font-medium">
+                                                                        Ready for the next step?
+                                                                </p>
+                                                                <p className="text-muted-foreground">
+                                                                        Open the dashboard to finish customizing your
+                                                                        support experience.
+                                                                </p>
+                                                                <div>
+                                                                        <Button asChild size="sm">
+                                                                                <Link href="/select">
+                                                                                        Open dashboard
+                                                                                </Link>
+                                                                        </Button>
+                                                                </div>
+                                                        </div>
+                                                </>
+                                        ) : (
+                                                <div className="rounded-lg border border-dashed border-primary/40 bg-primary/5 px-4 py-3 text-sm text-muted-foreground">
+                                                        React installation is coming soon. In the meantime,
+                                                        reach out to us and we’ll help you get early access.
+                                                </div>
+                                        )}
+                                </motion.div>
+                        </Step>
+                </Steps>
+        );
 }

--- a/apps/web/src/components/framework-picker.tsx
+++ b/apps/web/src/components/framework-picker.tsx
@@ -107,8 +107,14 @@ export function FrameworkPicker({
 			type="single"
 			value={value}
 		>
-			<FrameworkPickerItem icon={NextJsIcon} label="Next.js" value="nextjs" />
-			<FrameworkPickerItem icon={ReactIcon} label="React" value="react" />
+                        <FrameworkPickerItem icon={NextJsIcon} label="Next.js" value="nextjs" />
+                        <FrameworkPickerItem
+                                disabled
+                                icon={ReactIcon}
+                                label="React"
+                                showSoon
+                                value="react"
+                        />
 			<FrameworkPickerItem
 				disabled
 				icon={TanstackStarterIcon}


### PR DESCRIPTION
## Summary
- replace the onboarding creation flow with interactive Steps that capture the created site and show tailored Next.js installation instructions
- surface the generated public API key in the setup snippets and provide a dashboard hand-off CTA once installation is done
- temporarily disable the React option in the framework picker so only the supported Next.js stack can be chosen

## Testing
- bun run lint --filter @cossistant/web *(fails: turbo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_690b6dcccac8832bb2b747f7c951f96d