### PR TITLE
fix: always invalidate website api key cache

### DIFF
--- a/apps/api/src/db/queries/api-keys.ts
+++ b/apps/api/src/db/queries/api-keys.ts
@@ -8,6 +8,10 @@ import type {
 import { apiKey, organization, website } from "@api/db/schema";
 import { env } from "@api/env";
 import { generateApiKey, hashApiKey } from "@api/utils/api-keys";
+import {
+        API_KEY_CACHE_TAG,
+        getApiKeyCacheTagForKey,
+} from "@api/utils/cache/api-key-cache";
 import { generateULID } from "@api/utils/db/ids";
 import { APIKeyType } from "@cossistant/types";
 import { and, desc, eq } from "drizzle-orm";
@@ -31,8 +35,8 @@ export async function getApiKeyByKey(
 		.where(and(eq(apiKey.key, params.key), eq(apiKey.isActive, true)))
 		.innerJoin(organization, eq(apiKey.organizationId, organization.id))
 		.innerJoin(website, eq(apiKey.websiteId, website.id))
-		.limit(1)
-		.$withCache({ tag: "api-key" });
+                .limit(1)
+                .$withCache({ tags: [API_KEY_CACHE_TAG, getApiKeyCacheTagForKey(params.key)] });
 
 	if (res?.website && res.organization && res.api_key) {
 		return {

--- a/apps/api/src/trpc/routers/website.ts
+++ b/apps/api/src/trpc/routers/website.ts
@@ -13,28 +13,29 @@ import {
 	updateWebsite,
 } from "@api/db/queries/website";
 import {
-	member,
-	session as sessionTable,
-	type WebsiteInsert,
-	website,
+        member,
+        session as sessionTable,
+        type WebsiteInsert,
+        website,
 } from "@api/db/schema";
+import { invalidateApiKeyCacheForWebsite } from "@api/utils/cache/api-key-cache";
 import { isOrganizationAdminOrOwner } from "@api/utils/access-control";
 import { generateULID } from "@api/utils/db/ids";
 import { normalizeDomain } from "@api/utils/domain";
 import { domainToSlug } from "@api/utils/domain-slug";
 import {
-	APIKeyType,
-	checkWebsiteDomainRequestSchema,
-	createWebsiteApiKeyRequestSchema,
-	createWebsiteRequestSchema,
-	createWebsiteResponseSchema,
-	listByOrganizationRequestSchema,
-	revokeWebsiteApiKeyRequestSchema,
-	updateWebsiteRequestSchema,
-	websiteApiKeySchema,
-	websiteDeveloperSettingsResponseSchema,
-	websiteListItemSchema,
-	websiteSummarySchema,
+        APIKeyType,
+        checkWebsiteDomainRequestSchema,
+        createWebsiteApiKeyRequestSchema,
+        createWebsiteRequestSchema,
+        createWebsiteResponseSchema,
+        listByOrganizationRequestSchema,
+        revokeWebsiteApiKeyRequestSchema,
+        updateWebsiteRequestSchema,
+        websiteApiKeySchema,
+        websiteDeveloperSettingsResponseSchema,
+        websiteListItemSchema,
+        websiteSummarySchema,
 } from "@cossistant/types";
 import { TRPCError } from "@trpc/server";
 import { and, eq, isNull, ne } from "drizzle-orm";
@@ -51,10 +52,10 @@ type ApiKeyLike =
 	| Awaited<ReturnType<typeof revokeApiKey>>;
 
 const toWebsiteApiKey = (
-	key: ApiKeyLike,
-	options?: { includeRawKey?: boolean }
+        key: ApiKeyLike,
+        options?: { includeRawKey?: boolean }
 ) => ({
-	id: key.id,
+        id: key.id,
 	name:
 		key.name ??
 		`${key.isTest ? "Test " : ""}${
@@ -69,7 +70,7 @@ const toWebsiteApiKey = (
 	isActive: key.isActive,
 	createdAt: key.createdAt,
 	lastUsedAt: key.lastUsedAt ?? null,
-	revokedAt: key.revokedAt ?? null,
+        revokedAt: key.revokedAt ?? null,
 });
 
 export const websiteRouter = createTRPCRouter({
@@ -332,11 +333,11 @@ export const websiteRouter = createTRPCRouter({
 
 			return toWebsiteApiKey(createdKey, { includeRawKey: true });
 		}),
-	revokeApiKey: protectedProcedure
-		.input(revokeWebsiteApiKeyRequestSchema)
-		.output(websiteApiKeySchema)
-		.mutation(async ({ ctx, input }) => {
-			const site = await ctx.db.query.website.findFirst({
+        revokeApiKey: protectedProcedure
+                .input(revokeWebsiteApiKeyRequestSchema)
+                .output(websiteApiKeySchema)
+                .mutation(async ({ ctx, input }) => {
+                        const site = await ctx.db.query.website.findFirst({
 				where: and(
 					eq(website.id, input.websiteId),
 					eq(website.organizationId, input.organizationId),
@@ -390,13 +391,13 @@ export const websiteRouter = createTRPCRouter({
 				});
 			}
 
-			return toWebsiteApiKey(revoked);
-		}),
-	checkDomain: protectedProcedure
-		.input(checkWebsiteDomainRequestSchema)
-		.output(z.boolean())
-		.query(async ({ ctx: { db }, input }) => {
-			let normalizedDomain: string;
+                        return toWebsiteApiKey(revoked);
+                }),
+        checkDomain: protectedProcedure
+                .input(checkWebsiteDomainRequestSchema)
+                .output(z.boolean())
+                .query(async ({ ctx: { db }, input }) => {
+                        let normalizedDomain: string;
 
 			try {
 				normalizedDomain = normalizeDomain(input.domain);
@@ -471,8 +472,9 @@ export const websiteRouter = createTRPCRouter({
 				updateData.description = input.data.description;
 			if (input.data.logoUrl !== undefined)
 				updateData.logoUrl = input.data.logoUrl;
-			if (input.data.whitelistedDomains !== undefined)
-				updateData.whitelistedDomains = input.data.whitelistedDomains;
+                        if (input.data.whitelistedDomains !== undefined) {
+                                updateData.whitelistedDomains = input.data.whitelistedDomains;
+                        }
 			if (input.data.installationTarget !== undefined)
 				updateData.installationTarget = input.data.installationTarget;
 			if (input.data.status !== undefined)
@@ -524,10 +526,11 @@ export const websiteRouter = createTRPCRouter({
 					}
 
 					updateData.isDomainOwnershipVerified = false;
-					updateData.whitelistedDomains = [`https://${normalizedDomain}`];
-				}
+                                        const newDefaultDomain = `https://${normalizedDomain}`;
+                                        updateData.whitelistedDomains = [newDefaultDomain];
+                                }
 
-				updateData.domain = normalizedDomain;
+                                updateData.domain = normalizedDomain;
 			}
 
 			if (updateData.contactEmail !== undefined) {
@@ -539,24 +542,33 @@ export const websiteRouter = createTRPCRouter({
 					trimmedEmail && trimmedEmail.length > 0 ? trimmedEmail : null;
 			}
 
-			const updatedSite = await updateWebsite(ctx.db, {
-				orgId: input.organizationId,
-				websiteId: input.websiteId,
-				data: updateData,
-			});
+                        const updatedSite = await updateWebsite(ctx.db, {
+                                orgId: input.organizationId,
+                                websiteId: input.websiteId,
+                                data: updateData,
+                        });
 
-			if (!updatedSite) {
+                        if (!updatedSite) {
 				throw new TRPCError({
 					code: "NOT_FOUND",
 					message: "Website not found",
 				});
 			}
 
-			return {
-				id: updatedSite.id,
-				slug: updatedSite.slug,
-				name: updatedSite.name,
-				domain: updatedSite.domain,
+                        try {
+                                await invalidateApiKeyCacheForWebsite(ctx.db, site.id);
+                        } catch (error) {
+                                console.error(
+                                        "Failed to invalidate API key cache for website",
+                                        error
+                                );
+                        }
+
+                        return {
+                                id: updatedSite.id,
+                                slug: updatedSite.slug,
+                                name: updatedSite.name,
+                                domain: updatedSite.domain,
 				contactEmail: updatedSite.contactEmail ?? null,
 				logoUrl: updatedSite.logoUrl ?? null,
 				organizationId: updatedSite.organizationId,

--- a/apps/api/src/utils/cache/api-key-cache.ts
+++ b/apps/api/src/utils/cache/api-key-cache.ts
@@ -1,0 +1,34 @@
+import type { Database } from "@api/db";
+import { apiKey } from "@api/db/schema";
+import { eq } from "drizzle-orm";
+
+export const API_KEY_CACHE_TAG = "api-key" as const;
+
+export const getApiKeyCacheTagForKey = (key: string) => `${API_KEY_CACHE_TAG}:${key}`;
+
+export async function invalidateApiKeyCacheForWebsite(
+        db: Database,
+        websiteId: string
+): Promise<void> {
+        const keys = await db
+                .select({ key: apiKey.key })
+                .from(apiKey)
+                .where(eq(apiKey.websiteId, websiteId));
+
+        if (keys.length === 0) {
+                return;
+        }
+
+        const keyTags = keys
+                .map(({ key }) => key)
+                .filter((value): value is string => typeof value === "string" && value.length > 0)
+                .map((value) => getApiKeyCacheTagForKey(value));
+
+        if (keyTags.length === 0) {
+                return;
+        }
+
+        const uniqueTags = Array.from(new Set(keyTags));
+
+        await db.$cache.invalidate({ tags: uniqueTags });
+}

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/settings/developers/allowed-domains-form.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/settings/developers/allowed-domains-form.tsx
@@ -186,17 +186,19 @@ export function AllowedDomainsForm({
 			queryKey: trpc.website.developerSettings.queryKey({ slug: websiteSlug }),
 		});
 
-	const { mutateAsync: updateWebsite, isPending: isSubmitting } = useMutation(
-		trpc.website.update.mutationOptions({
-			onSuccess: async () => {
-				await invalidateDeveloperSettings();
-				toast.success("Allowed domains updated.");
-			},
+        const { mutateAsync: updateWebsite, isPending: isUpdatingWebsite } = useMutation(
+                trpc.website.update.mutationOptions({
+                        onSuccess: async () => {
+                                await invalidateDeveloperSettings();
+                                toast.success("Allowed domains updated.");
+                        },
 			onError: () => {
 				toast.error("Failed to update allowed domains. Please try again.");
 			},
-		})
-	);
+                })
+        );
+
+        const isSubmitting = isUpdatingWebsite;
 
 	const handleSubmit = async (values: AllowedDomainsFormValues) => {
 		const sanitized = values.domains
@@ -218,16 +220,15 @@ export function AllowedDomainsForm({
 			return;
 		}
 
-		const uniqueDomains = Array.from(new Set(normalizedOrigins));
+                const uniqueDomains = Array.from(new Set(normalizedOrigins));
+                await updateWebsite({
+                        organizationId,
+                        websiteId,
+                        data: { whitelistedDomains: uniqueDomains },
+                });
 
-		await updateWebsite({
-			organizationId,
-			websiteId,
-			data: { whitelistedDomains: uniqueDomains },
-		});
-
-		reset({ domains: uniqueDomains });
-	};
+                reset({ domains: uniqueDomains });
+        };
 
 	return (
 		<>

--- a/packages/types/src/api/website.ts
+++ b/packages/types/src/api/website.ts
@@ -218,22 +218,22 @@ const websiteUpdateDataSchema = z
 	});
 
 export const updateWebsiteRequestSchema = z
-	.object({
-		organizationId: z.ulid().openapi({
-			description: "The organization's unique identifier.",
-			example: "01JG000000000000000000000",
-		}),
-		websiteId: z.ulid().openapi({
-			description: "The website's unique identifier.",
-			example: "01JG000000000000000000000",
-		}),
-		data: websiteUpdateDataSchema.openapi({
-			description: "The fields to update on the website.",
-		}),
-	})
-	.openapi({
-		description: "Payload to update website settings.",
-	});
+        .object({
+                organizationId: z.ulid().openapi({
+                        description: "The organization's unique identifier.",
+                        example: "01JG000000000000000000000",
+                }),
+                websiteId: z.ulid().openapi({
+                        description: "The website's unique identifier.",
+                        example: "01JG000000000000000000000",
+                }),
+                data: websiteUpdateDataSchema.openapi({
+                        description: "The fields to update on the website.",
+                }),
+        })
+        .openapi({
+                description: "Payload to update website settings.",
+        });
 
 export type UpdateWebsiteRequest = z.infer<typeof updateWebsiteRequestSchema>;
 


### PR DESCRIPTION
## Summary
- remove the whitelisted domain comparison helper and its conditional cache invalidation logic
- always invalidate the website API key cache after updates since key responses cache organization and site data

## Testing
- not run (biome tooling unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d1225fe5c832ba50fe0333e1a88c3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API key caching and invalidation strategy for better performance and data consistency when managing API credentials and website configurations.
  * Enhanced state management in the developer settings form for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->