### PR TITLE
Refactor message workflow setup reuse

### DIFF
--- a/apps/api/src/workflows/visitor-email-notifier.tsx
+++ b/apps/api/src/workflows/visitor-email-notifier.tsx
@@ -1,12 +1,15 @@
 import type { Database } from "@api/db";
 import { isEmailSuppressed } from "@api/db/queries/email-bounce";
 import {
-        generateEmailIdempotencyKey,
-        generateInboundReplyAddress,
-        generateThreadingHeaders,
+	generateEmailIdempotencyKey,
+	generateInboundReplyAddress,
+	generateThreadingHeaders,
 } from "@api/utils/email-threading";
 import { getMessagesForEmail } from "@api/utils/notification-helpers";
-import { logEmailSent, logEmailSuppressed } from "@api/utils/notification-monitoring";
+import {
+	logEmailSent,
+	logEmailSuppressed,
+} from "@api/utils/notification-monitoring";
 import { MAX_MESSAGES_IN_EMAIL } from "@api/workflows/constants";
 import { NewMessageInConversation, sendEmail } from "@cossistant/transactional";
 
@@ -14,103 +17,112 @@ import { NewMessageInConversation, sendEmail } from "@cossistant/transactional";
 import React from "react";
 
 export type VisitorRecipient = {
-        kind: "visitor";
-        visitorId: string;
-        email: string;
+	kind: "visitor";
+	visitorId: string;
+	email: string;
 };
 
 export type SendVisitorEmailParams = {
-        db: Database;
-        recipient: VisitorRecipient;
-        conversationId: string;
-        organizationId: string;
-        websiteInfo: {
-                name: string;
-                slug: string;
-                logo: string | null;
-        };
-        workflowState: {
-                initialMessageCreatedAt: string;
-        };
+	db: Database;
+	recipient: VisitorRecipient;
+	conversationId: string;
+	organizationId: string;
+	websiteInfo: {
+		name: string;
+		slug: string;
+		logo: string | null;
+	};
+	workflowState: {
+		initialMessageCreatedAt: string;
+	};
 };
 
-export async function sendVisitorEmailNotification(params: SendVisitorEmailParams): Promise<void> {
-        const { db, recipient, conversationId, organizationId, websiteInfo, workflowState } = params;
+export async function sendVisitorEmailNotification(
+	params: SendVisitorEmailParams
+): Promise<void> {
+	const {
+		db,
+		recipient,
+		conversationId,
+		organizationId,
+		websiteInfo,
+		workflowState,
+	} = params;
 
-        if (!recipient.email) {
-                return;
-        }
+	if (!recipient.email) {
+		return;
+	}
 
-        const { messages, totalCount } = await getMessagesForEmail(db, {
-                conversationId,
-                organizationId,
-                recipientVisitorId: recipient.visitorId,
-                maxMessages: MAX_MESSAGES_IN_EMAIL,
-                earliestCreatedAt: workflowState.initialMessageCreatedAt,
-        });
+	const { messages, totalCount } = await getMessagesForEmail(db, {
+		conversationId,
+		organizationId,
+		recipientVisitorId: recipient.visitorId,
+		maxMessages: MAX_MESSAGES_IN_EMAIL,
+		earliestCreatedAt: workflowState.initialMessageCreatedAt,
+	});
 
-        if (messages.length === 0) {
-                return;
-        }
+	if (messages.length === 0) {
+		return;
+	}
 
-        const isSuppressed = await isEmailSuppressed(db, {
-                email: recipient.email,
-                organizationId,
-        });
+	const isSuppressed = await isEmailSuppressed(db, {
+		email: recipient.email,
+		organizationId,
+	});
 
-        if (isSuppressed) {
-                logEmailSuppressed({
-                        email: recipient.email,
-                        conversationId,
-                        organizationId,
-                        reason: "bounced_or_complained",
-                });
-                return;
-        }
+	if (isSuppressed) {
+		logEmailSuppressed({
+			email: recipient.email,
+			conversationId,
+			organizationId,
+			reason: "bounced_or_complained",
+		});
+		return;
+	}
 
-        const threadingHeaders = generateThreadingHeaders({
-                conversationId,
-        });
+	const threadingHeaders = generateThreadingHeaders({
+		conversationId,
+	});
 
-        const idempotencyKey = generateEmailIdempotencyKey({
-                conversationId,
-                recipientEmail: recipient.email,
-                timestamp: new Date(workflowState.initialMessageCreatedAt).getTime(),
-        });
+	const idempotencyKey = generateEmailIdempotencyKey({
+		conversationId,
+		recipientEmail: recipient.email,
+		timestamp: new Date(workflowState.initialMessageCreatedAt).getTime(),
+	});
 
-        await sendEmail(
-                {
-                        to: recipient.email,
-                        replyTo: generateInboundReplyAddress({
-                                conversationId,
-                        }),
-                        subject:
-                                totalCount > 1
-                                        ? `${totalCount} new messages from ${websiteInfo.name}`
-                                        : `New message from ${websiteInfo.name}`,
-                        react: (
-                                <NewMessageInConversation
-                                        conversationId={conversationId}
-                                        email={recipient.email}
-                                        isReceiverVisitor={true}
-                                        messages={messages}
-                                        totalCount={totalCount}
-                                        website={{
-                                                name: websiteInfo.name,
-                                                slug: websiteInfo.slug,
-                                                logo: websiteInfo.logo,
-                                        }}
-                                />
-                        ),
-                        variant: "notifications",
-                        headers: threadingHeaders,
-                },
-                { idempotencyKey }
-        );
+	await sendEmail(
+		{
+			to: recipient.email,
+			replyTo: generateInboundReplyAddress({
+				conversationId,
+			}),
+			subject:
+				totalCount > 1
+					? `${totalCount} new messages from ${websiteInfo.name}`
+					: `New message from ${websiteInfo.name}`,
+			react: (
+				<NewMessageInConversation
+					conversationId={conversationId}
+					email={recipient.email}
+					isReceiverVisitor={true}
+					messages={messages}
+					totalCount={totalCount}
+					website={{
+						name: websiteInfo.name,
+						slug: websiteInfo.slug,
+						logo: websiteInfo.logo,
+					}}
+				/>
+			),
+			variant: "notifications",
+			headers: threadingHeaders,
+		},
+		{ idempotencyKey }
+	);
 
-        logEmailSent({
-                email: recipient.email,
-                conversationId,
-                organizationId,
-        });
+	logEmailSent({
+		email: recipient.email,
+		conversationId,
+		organizationId,
+	});
 }

--- a/apps/web/src/contexts/inboxes/index.tsx
+++ b/apps/web/src/contexts/inboxes/index.tsx
@@ -39,7 +39,7 @@ type InboxesContextValue = {
 const InboxesContext = createContext<InboxesContextValue | null>(null);
 
 export function useOptionalInboxes() {
-        return useContext(InboxesContext);
+	return useContext(InboxesContext);
 }
 
 type InboxesProviderProps = {
@@ -115,11 +115,11 @@ export function InboxesProvider({
 }
 
 export function useInboxes() {
-        const context = useOptionalInboxes();
+	const context = useOptionalInboxes();
 
-        if (!context) {
-                throw new Error("useInboxes must be used within a InboxesProvider");
-        }
+	if (!context) {
+		throw new Error("useInboxes must be used within a InboxesProvider");
+	}
 
 	if (context.isLoading) {
 		throw new Error("Conversations not found");


### PR DESCRIPTION
## Summary
- extract shared setup and notification preparation helpers for message workflows
- reuse shared logic across member and visitor workflow handlers while keeping visitor-specific email handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ada7692a4832b8f5937a62beeceef)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visitor email notifications for new conversation messages, with threading, idempotent sending, and pluralized subjects.

* **Refactor**
  * Streamlined message workflow setup, unified notification preparation/delivery, consistent workflow state handling and cleanup, and a global delay before notifications.

* **Bug Fixes**
  * Honors email suppression and skips sending when recipient email or conversation messages are missing.

* **UI**
  * Improved action runner feedback with success/error toasts.

* **Style**
  * Minor formatting/whitespace adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->