### PR TITLE
fix: strip markdown links in conversation emails

### DIFF
--- a/packages/transactional/emails/new-message-in-conversation.tsx
+++ b/packages/transactional/emails/new-message-in-conversation.tsx
@@ -20,6 +20,9 @@ import React from "react";
 
 const MAX_DISPLAYED_MESSAGES = 5;
 
+const stripMarkdownLinks = (text: string): string =>
+        text.replace(/\[([^\]]+)]\(([^)]+)\)/g, "$2");
+
 import { LOGO_URL, OG_AVATAR_URL } from "../constants";
 
 export function NewMessageInConversation({
@@ -198,12 +201,12 @@ export function NewMessageInConversation({
 														)}
 													</Text>
 												)}
-												<Text
-													className="my-0 rounded-lg rounded-bl-none bg-neutral-100 px-4 py-2.5 text-neutral-800 text-sm leading-5"
-													style={{ whiteSpace: "pre-wrap" }}
-												>
-													{message.text}
-												</Text>
+                                                                                                <Text
+                                                                                                        className="my-0 rounded-lg rounded-bl-none bg-neutral-100 px-4 py-2.5 text-neutral-800 text-sm leading-5"
+                                                                                                        style={{ whiteSpace: "pre-wrap" }}
+                                                                                                >
+                                                                                                        {stripMarkdownLinks(message.text)}
+                                                                                                </Text>
 											</Column>
 										</Row>
 										{lastInGroup && (


### PR DESCRIPTION
## Summary
- add helper to strip markdown link formatting from message content in conversation notification emails
- render messages using plain URLs to avoid markdown showing up in email clients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c98b015c8832ba19a810d9fabdf71)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email notification formatting for conversation messages by removing unnecessary Markdown link syntax from displayed text while maintaining proper layout and styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->