### PR TITLE
Fix visitor read receipts for support timeline

### DIFF
--- a/packages/react/src/hooks/private/use-grouped-messages.test.ts
+++ b/packages/react/src/hooks/private/use-grouped-messages.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { SenderType } from "@cossistant/types";
 import type { TimelineItem } from "@cossistant/types/api/timeline-item";
 import type { ConversationSeen } from "@cossistant/types/schemas";
+import { filterSeenByIds } from "./use-grouped-messages";
 
 // Import the internal functions we need to test
 // Since useGroupedMessages is a hook, we'll test the underlying logic directly
@@ -159,6 +160,64 @@ describe("buildTimelineReadReceiptData", () => {
 
 		// Visitor should NOT have seen msg-3 (after 10:07)
 		expect(seenByMap.get("msg-3")?.has("visitor-1")).toBe(false);
+	});
+
+	it("omits the current visitor when inspecting seenBy for their own messages", () => {
+		const visitorMessage = createTimelineItem({
+			id: "msg-visitor",
+			visitorId: "visitor-1",
+			userId: null,
+			createdAt: new Date("2024-01-01T10:00:00.000Z").toISOString(),
+		});
+
+		const agentMessage = createTimelineItem({
+			id: "msg-agent",
+			visitorId: null,
+			userId: "user-1",
+			createdAt: new Date("2024-01-01T10:05:00.000Z").toISOString(),
+		});
+
+		const items: TimelineItem[] = [visitorMessage, agentMessage];
+
+		const seenData: ConversationSeen[] = [
+			createSeenEntry({
+				id: "visitor-seen",
+				visitorId: "visitor-1",
+				userId: null,
+				lastSeenAt: new Date("2024-01-01T10:06:00.000Z").toISOString(),
+			}),
+			createSeenEntry({
+				id: "agent-seen",
+				visitorId: null,
+				userId: "user-2",
+				lastSeenAt: new Date("2024-01-01T10:10:00.000Z").toISOString(),
+			}),
+		];
+
+		const { seenByMap } = buildTimelineReadReceiptData(seenData, items);
+
+		const seenByForVisitorMessage = filterSeenByIds({
+			currentViewerId: "visitor-1",
+			items,
+			messageId: "msg-visitor",
+			seenBy: seenByMap.get("msg-visitor"),
+			viewerType: SenderType.VISITOR,
+		});
+
+		expect(seenByForVisitorMessage).toEqual(["user-2"]);
+
+		const seenByForAgentMessage = filterSeenByIds({
+			currentViewerId: "visitor-1",
+			items,
+			messageId: "msg-agent",
+			seenBy: seenByMap.get("msg-agent"),
+			viewerType: SenderType.VISITOR,
+		});
+
+		expect(seenByForAgentMessage).toEqual(
+			expect.arrayContaining(["visitor-1", "user-2"])
+		);
+		expect(seenByForAgentMessage).toHaveLength(2);
 	});
 
 	it("correctly handles multiple viewers with different lastSeenAt timestamps", () => {

--- a/packages/react/src/hooks/private/use-grouped-messages.ts
+++ b/packages/react/src/hooks/private/use-grouped-messages.ts
@@ -41,6 +41,14 @@ export type UseGroupedMessagesOptions = {
 
 export type UseGroupedMessagesProps = UseGroupedMessagesOptions;
 
+type SeenByFilterOptions = {
+	messageId: string;
+	items: TimelineItem[];
+	seenBy: Set<string> | undefined;
+	currentViewerId?: string;
+	viewerType?: SenderType;
+};
+
 // Helper function to safely get timestamp from Date or string
 const getTimestamp = (date: Date | string | null | undefined): number => {
 	if (!date) {
@@ -224,6 +232,34 @@ const buildTimelineReadReceiptData = (
 	return { seenByMap, lastReadMessageMap, unreadCountMap };
 };
 
+export const filterSeenByIds = ({
+	messageId,
+	items,
+	seenBy,
+	currentViewerId,
+	viewerType,
+}: SeenByFilterOptions): readonly string[] => {
+	if (!seenBy || seenBy.size === 0) {
+		return EMPTY_STRING_ARRAY;
+	}
+
+	let filteredSeenBy = seenBy;
+
+	if (viewerType === SenderType.VISITOR && currentViewerId) {
+		const message = items.find((item) => item.id === messageId);
+		if (message?.visitorId === currentViewerId) {
+			filteredSeenBy = new Set(filteredSeenBy);
+			filteredSeenBy.delete(currentViewerId);
+		}
+	}
+
+	if (filteredSeenBy.size === 0) {
+		return EMPTY_STRING_ARRAY;
+	}
+
+	return Object.freeze(Array.from(filteredSeenBy)) as readonly string[];
+};
+
 /**
  * Batches sequential timeline items from the same sender into groups and enriches
  * them with read-receipt helpers so UIs can render conversation timelines with
@@ -265,8 +301,14 @@ export const useGroupedMessages = ({
 					return seenByArrayCache.get(messageId) ?? EMPTY_STRING_ARRAY;
 				}
 
-				const seenBy = seenByMap.get(messageId);
-				if (!seenBy || seenBy.size === 0) {
+				const seenBy = filterSeenByIds({
+					items,
+					seenBy: seenByMap.get(messageId),
+					messageId,
+					currentViewerId,
+					viewerType,
+				});
+				if (seenBy.length === 0) {
 					seenByArrayCache.set(messageId, EMPTY_STRING_ARRAY);
 					return EMPTY_STRING_ARRAY;
 				}
@@ -297,5 +339,5 @@ export const useGroupedMessages = ({
 				return messageIndex < lastReadIndex;
 			},
 		};
-	}, [items, seenData, currentViewerId]);
+	}, [items, seenData, currentViewerId, viewerType]);
 };


### PR DESCRIPTION
## Summary
- filter visitor-authored message read receipts to exclude the active visitor when deriving seen-by lists
- add helper logic and tests to ensure support timelines only surface agent/AI read indicators

## Testing
- bun test packages/react/src/hooks/private/use-grouped-messages.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c954244d4832ba3a245a07afe6c11)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed read receipt indicators to exclude the current user from appearing in "seen by" lists for their own messages. This ensures that when you view a message you sent, you won't see yourself listed among the users who have read it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->