### PR TITLE
Fix visitor timestamp serialization in contact details

### DIFF
--- a/apps/api/src/db/queries/contact.ts
+++ b/apps/api/src/db/queries/contact.ts
@@ -588,13 +588,18 @@ export async function getContactWithVisitors(
 		)
 		.orderBy(desc(visitor.lastSeenAt), desc(visitor.createdAt));
 
-	return {
-		contact: contactRecord,
-		visitors: visitorsList.map((visitorRecord) => ({
-			...visitorRecord,
-			isBlocked: visitorRecord.blockedAt !== null,
-		})),
-	};
+        return {
+                contact: contactRecord,
+                visitors: visitorsList.map((visitorRecord) => ({
+                        ...visitorRecord,
+                        lastSeenAt:
+                                visitorRecord.lastSeenAt?.toISOString() ?? null,
+                        createdAt: visitorRecord.createdAt.toISOString(),
+                        blockedAt:
+                                visitorRecord.blockedAt?.toISOString() ?? null,
+                        isBlocked: visitorRecord.blockedAt !== null,
+                })),
+        };
 }
 
 // Contact Organisation queries


### PR DESCRIPTION
## Summary
- normalize visitor timestamps to ISO strings when returning contact visitor lists
- ensure contact.get output aligns with contactVisitorSummarySchema expectations

## Testing
- bun run lint --filter @cossistant/api (fails: turbo not found in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248c453a10832bb9456cfa6920e5f3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date field serialization in API responses to ensure consistent ISO string formatting and proper null-handling for date-related fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->