### PR TITLE
chore: soften contacts visitor filters

### DIFF
--- a/apps/web/src/components/ui/layout/sidebars/contacts-navigation/index.tsx
+++ b/apps/web/src/components/ui/layout/sidebars/contacts-navigation/index.tsx
@@ -142,26 +142,41 @@ export function ContactsNavigationSidebar() {
 						Reset
 					</Button>
 				</div>
-				<div className="space-y-2">
-					{VISITOR_FILTER_OPTIONS.map((option) => (
-						<button
-							className="flex w-full flex-col gap-0.5 rounded-md border border-primary/10 bg-background/60 px-3 py-2 text-left transition hover:border-primary/30 hover:bg-background"
-							key={option.value}
-							onClick={() => setVisitorStatus(option.value)}
-							type="button"
-						>
-							<div className="flex items-center justify-between text-xs">
-								<span className="font-medium">{option.title}</span>
-								{visitorStatus === option.value ? (
-									<ListFilter className="h-3.5 w-3.5 text-primary" />
-								) : null}
-							</div>
-							<span className="text-[11px] text-muted-foreground">
-								{option.description}
-							</span>
-						</button>
-					))}
-				</div>
+                                <div className="space-y-2">
+                                        {VISITOR_FILTER_OPTIONS.map((option) => {
+                                                const isSelected = visitorStatus === option.value;
+
+                                                return (
+                                                        <button
+                                                                aria-pressed={isSelected}
+                                                                className={`group flex w-full flex-col rounded-lg px-3 py-2 text-left transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary/40 ${
+                                                                        isSelected
+                                                                                ? "bg-primary/5"
+                                                                                : "hover:bg-muted/60"
+                                                                }`}
+                                                                key={option.value}
+                                                                onClick={() => setVisitorStatus(option.value)}
+                                                                type="button"
+                                                        >
+                                                                <div className="flex items-center justify-between text-sm font-medium">
+                                                                        <span>{option.title}</span>
+                                                                        <span
+                                                                                className={`flex h-4 w-4 items-center justify-center rounded-full text-primary transition-opacity ${
+                                                                                        isSelected
+                                                                                                ? "opacity-100"
+                                                                                                : "opacity-0 group-hover:opacity-70"
+                                                                                }`}
+                                                                        >
+                                                                                <ListFilter className="h-3.5 w-3.5" />
+                                                                        </span>
+                                                                </div>
+                                                                <span className="text-xs text-muted-foreground">
+                                                                        {option.description}
+                                                                </span>
+                                                        </button>
+                                                );
+                                        })}
+                                </div>
 
 				<div className="flex items-center justify-between text-muted-foreground text-xs uppercase tracking-wide">
 					<span>Ordering</span>


### PR DESCRIPTION
## Summary
- reduce visual weight of visitor filter buttons by removing heavy borders and softening hover/active styling
- align filter button spacing and typography with other sidebar controls while keeping active indication via icon visibility

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69248c4cc3c8832bacb30d652312ed2d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced contact filter buttons with improved accessibility attributes (aria-pressed), visual design, focus states, and status indicators
  * Updated button layout to display titles with status information and descriptions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->