### PR TITLE
Fix types build to externalize zod dependencies

### DIFF
--- a/packages/types/tsdown.config.ts
+++ b/packages/types/tsdown.config.ts
@@ -1,21 +1,22 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["src/index.ts", "src/**/*.ts", "!src/**/*.test.ts"],
-	clean: true,
-	dts: {
-		// Resolve and bundle all type dependencies to avoid exposing zod's .d.cts files
-		resolve: true,
-	},
-	hash: false,
-	minify: false,
-	sourcemap: true,
-	treeshake: true,
-	unbundle: true,
-	outExtensions: () => ({
-		js: ".js",
-		dts: ".d.ts",
-	}),
-	// Don't mark anything as external - bundle everything to avoid module resolution issues
-	external: [],
+        entry: ["src/index.ts", "src/**/*.ts", "!src/**/*.test.ts"],
+        clean: true,
+        dts: {
+                // Resolve and bundle all type dependencies to avoid exposing zod's .d.cts files
+                resolve: true,
+        },
+        hash: false,
+        minify: false,
+        sourcemap: true,
+        treeshake: true,
+        unbundle: true,
+        outExtensions: () => ({
+                js: ".js",
+                dts: ".d.ts",
+        }),
+        // Keep zod and hono helpers external so builds reference their package specifiers
+        // instead of Bun's internal store paths that break in npm installs
+        external: ["@hono/zod-openapi", "zod"],
 });


### PR DESCRIPTION
## Summary
- prevent bundling zod and @hono/zod-openapi in @cossistant/types builds so generated modules reference package specifiers instead of Bun store paths

## Testing
- ⚠️ `bun run build --filter @cossistant/types` (fails: turbo command not available in environment)
- ⚠️ `cd packages/types && bun run build` (fails: tsdown command not available in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6927306e6b54832b939f6c89ee6db795)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to optimize how dependencies are processed during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->