### PR TITLE
Fix avatar form validation after avatar updates

### DIFF
--- a/apps/web/src/app/(dashboard)/[websiteSlug]/settings/user-profile-form.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/settings/user-profile-form.tsx
@@ -322,19 +322,22 @@ export function UserProfileForm({
 					<FormField
 						control={form.control}
 						name="avatar"
-						render={({ field }) => (
-							<FormItem className="flex flex-col gap-2">
-								<FormLabel>Profile picture</FormLabel>
-								<FormControl>
-									<AvatarInput
-										fallbackInitials={fallbackInitials}
-										name={field.name}
-										onBlur={field.onBlur}
-										onChange={field.onChange}
-										onError={(error) => {
-											if (
-												!(
-													error as Error & {
+                                                render={({ field }) => (
+                                                        <FormItem className="flex flex-col gap-2">
+                                                                <FormLabel>Profile picture</FormLabel>
+                                                                <FormControl>
+                                                                        <AvatarInput
+                                                                                fallbackInitials={fallbackInitials}
+                                                                                name={field.name}
+                                                                                onBlur={field.onBlur}
+                                                                                onChange={(value) => {
+                                                                                        field.onChange(value);
+                                                                                        void form.trigger("avatar");
+                                                                                }}
+                                                                                onError={(error) => {
+                                                                                        if (
+                                                                                                !(
+                                                                                                        error as Error & {
 														handledByToast?: boolean;
 													}
 												)?.handledByToast


### PR DESCRIPTION
## Summary
- trigger validation when updating the avatar in the profile form
- keep the submit button tied to the refreshed validation state after avatar-only changes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692722a9b6dc832ba6c790dd24c9d2b3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved avatar upload validation in user profile form with independent field validation
  * Enhanced error handling for avatar uploads with better state management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->