### PR TITLE
Upload chat attachments via S3

### DIFF
--- a/apps/api/src/trpc/routers/conversation.ts
+++ b/apps/api/src/trpc/routers/conversation.ts
@@ -27,11 +27,12 @@ import {
 } from "@api/utils/participant-helpers";
 import { createMessageTimelineItem } from "@api/utils/timeline-item";
 import {
-	type ContactMetadata,
-	conversationMutationResponseSchema,
-	listConversationHeadersResponseSchema,
-	visitorResponseSchema,
+        type ContactMetadata,
+        conversationMutationResponseSchema,
+        listConversationHeadersResponseSchema,
+        visitorResponseSchema,
 } from "@cossistant/types";
+import { timelineItemPartsSchema } from "@cossistant/types/api/timeline-item";
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 import { createTRPCRouter, protectedProcedure } from "../init";
@@ -145,17 +146,18 @@ export const conversationRouter = createTRPCRouter({
 			};
 		}),
 
-	sendMessage: protectedProcedure
-		.input(
-			z.object({
-				conversationId: z.string(),
-				websiteSlug: z.string(),
-				text: z.string().min(1),
-				visibility: z.enum(["public", "private"]).default("public"),
-				timelineItemId: z.ulid().optional(),
-			})
-		)
-		.mutation(async ({ ctx: { db, user }, input }) => {
+        sendMessage: protectedProcedure
+                .input(
+                        z.object({
+                                conversationId: z.string(),
+                                websiteSlug: z.string(),
+                                text: z.string().default(""),
+                                parts: timelineItemPartsSchema.optional(),
+                                visibility: z.enum(["public", "private"]).default("public"),
+                                timelineItemId: z.ulid().optional(),
+                        })
+                )
+                .mutation(async ({ ctx: { db, user }, input }) => {
 			const [websiteData, conversation] = await Promise.all([
 				getWebsiteBySlugWithAccess(db, {
 					userId: user.id,
@@ -201,22 +203,28 @@ export const conversationRouter = createTRPCRouter({
 					organizationId: websiteData.organizationId,
 					targetUserId: user.id,
 					isAutoAdded: true,
-				});
-			}
+                                });
+                        }
 
-			const { item: createdTimelineItem } = await createMessageTimelineItem({
-				db,
-				organizationId: websiteData.organizationId,
-				websiteId: websiteData.id,
-				conversationId: input.conversationId,
-				conversationOwnerVisitorId: conversation.visitorId,
-				id: input.timelineItemId,
-				text: input.text,
-				visibility: input.visibility,
-				userId: user.id,
-				visitorId: null,
-				aiAgentId: null,
-			});
+                        const parts = input.parts ?? [];
+                        const textPart = parts.find((part) => part.type === "text");
+                        const resolvedText = (textPart?.text ?? input.text).trim();
+                        const extraParts = parts.filter((part) => part.type !== "text");
+
+                        const { item: createdTimelineItem } = await createMessageTimelineItem({
+                                db,
+                                organizationId: websiteData.organizationId,
+                                websiteId: websiteData.id,
+                                conversationId: input.conversationId,
+                                conversationOwnerVisitorId: conversation.visitorId,
+                                id: input.timelineItemId,
+                                text: resolvedText,
+                                extraParts,
+                                visibility: input.visibility,
+                                userId: user.id,
+                                visitorId: null,
+                                aiAgentId: null,
+                        });
 
 			// Mark conversation as read by user after sending timeline item
 			const { lastSeenAt } = await markConversationAsRead(db, {

--- a/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
+++ b/apps/web/src/app/(dashboard)/[websiteSlug]/inbox/[[...slug]]/conversation-pane.tsx
@@ -22,6 +22,7 @@ import { useDashboardNewMessageSound } from "@/hooks/use-dashboard-new-message-s
 import { useSendConversationMessage } from "@/hooks/use-send-conversation-message";
 import { useSidebar } from "@/hooks/use-sidebars";
 import { useSoundPreferences } from "@/hooks/use-sound-preferences";
+import { useWebsite } from "@/contexts/website";
 
 const MESSAGES_PAGE_LIMIT = 50;
 const EMPTY_AVAILABLE_AI_AGENTS: AvailableAIAgent[] = [];
@@ -39,21 +40,25 @@ type ConversationPaneProps = {
 };
 
 export function ConversationPane({
-	conversationId,
-	visitorId,
-	websiteSlug,
-	currentUserId,
+        conversationId,
+        visitorId,
+        websiteSlug,
+        currentUserId,
 }: ConversationPaneProps) {
-	const { newMessageEnabled } = useSoundPreferences({ websiteSlug });
-	const playNewMessageSound = useDashboardNewMessageSound(newMessageEnabled);
-	const previousItemsRef = useRef<readonly TimelineItem[]>([]);
+        const { newMessageEnabled } = useSoundPreferences({ websiteSlug });
+        const playNewMessageSound = useDashboardNewMessageSound(newMessageEnabled);
+        const previousItemsRef = useRef<readonly TimelineItem[]>([]);
 
-	const { submit: submitConversationMessage } = useSendConversationMessage({
-		conversationId,
-		websiteSlug,
-		currentUserId,
-		pageLimit: MESSAGES_PAGE_LIMIT,
-	});
+        const website = useWebsite();
+
+        const { submit: submitConversationMessage } = useSendConversationMessage({
+                conversationId,
+                websiteSlug,
+                websiteId: website.id,
+                organizationId: website.organizationId,
+                currentUserId,
+                pageLimit: MESSAGES_PAGE_LIMIT,
+        });
 
 	const {
 		handleInputChange: handleTypingChange,

--- a/apps/web/src/components/conversation/messages/timeline-message-item.tsx
+++ b/apps/web/src/components/conversation/messages/timeline-message-item.tsx
@@ -1,72 +1,154 @@
 import {
-	TimelineItem as PrimitiveTimelineItem,
-	TimelineItemContent,
-	TimelineItemTimestamp,
+        TimelineItem as PrimitiveTimelineItem,
+        TimelineItemContent,
+        TimelineItemTimestamp,
 } from "@cossistant/next/primitives";
-import type { TimelineItem } from "@cossistant/types/api/timeline-item";
+import type {
+        TimelineItem,
+        TimelinePartFile,
+        TimelinePartImage,
+} from "@cossistant/types/api/timeline-item";
 import type React from "react";
 import { cn } from "@/lib/utils";
 
 export type TimelineMessageItemProps = {
-	item: TimelineItem;
-	isLast?: boolean;
-	isSentByViewer?: boolean;
+        item: TimelineItem;
+        isLast?: boolean;
+        isSentByViewer?: boolean;
 };
 
 export function TimelineMessageItem({
-	item,
-	isLast = false,
-	isSentByViewer = false,
+        item,
+        isLast = false,
+        isSentByViewer = false,
 }: TimelineMessageItemProps) {
-	return (
-		<PrimitiveTimelineItem item={item}>
-			{({ isAI, timestamp }) => (
-				<div
-					className={cn(
-						"flex w-full gap-2",
-						isSentByViewer && "flex-row-reverse",
-						!isSentByViewer && "flex-row"
-					)}
-				>
-					<div
-						className={cn(
-							"flex w-full min-w-0 flex-1 flex-col gap-3",
-							isSentByViewer && "items-end"
-						)}
-					>
-						<TimelineItemContent
-							className={cn(
-								"block w-fit min-w-0 max-w-full whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm md:max-w-[420px]",
-								{
-									"bg-background-300 text-foreground dark:bg-background-600":
-										!isSentByViewer,
-									"bg-primary text-primary-foreground": isSentByViewer,
-									"rounded-br-[2px]": isLast && isSentByViewer,
-									"rounded-bl-[2px]": isLast && !isSentByViewer,
-								}
-							)}
-							renderMarkdown
-							text={item.text}
-						/>
-						{isLast && (
-							<TimelineItemTimestamp
-								className="px-1 text-muted-foreground text-xs"
-								timestamp={timestamp}
-							>
-								{() => (
-									<>
-										{timestamp.toLocaleTimeString([], {
-											hour: "2-digit",
-											minute: "2-digit",
-										})}
-										{isAI && " • AI agent"}
-									</>
-								)}
-							</TimelineItemTimestamp>
-						)}
-					</div>
-				</div>
-			)}
-		</PrimitiveTimelineItem>
-	);
+        const textPart = item.parts.find((part) => part.type === "text");
+        const textContent = textPart?.text ?? item.text ?? "";
+        const attachments = item.parts.filter(
+                (part): part is TimelinePartImage | TimelinePartFile =>
+                        part.type === "image" || part.type === "file"
+        );
+
+        const imageParts = attachments.filter(
+                (part): part is TimelinePartImage => part.type === "image"
+        );
+        const fileParts = attachments.filter(
+                (part): part is TimelinePartFile => part.type === "file"
+        );
+
+        const bubbleClass = cn(
+                "block min-w-0 max-w-full whitespace-pre-wrap break-words rounded-lg px-3 py-2 text-sm md:max-w-[420px]",
+                {
+                        "bg-background-300 text-foreground dark:bg-background-600": !isSentByViewer,
+                        "bg-primary text-primary-foreground": isSentByViewer,
+                        "rounded-br-[2px]": isLast && isSentByViewer,
+                        "rounded-bl-[2px]": isLast && !isSentByViewer,
+                }
+        );
+
+        return (
+                <PrimitiveTimelineItem item={item}>
+                        {({ isAI, timestamp }) => (
+                                <div
+                                        className={cn(
+                                                "flex w-full gap-2",
+                                                isSentByViewer && "flex-row-reverse",
+                                                !isSentByViewer && "flex-row"
+                                        )}
+                                >
+                                        <div
+                                                className={cn(
+                                                        "flex w-full min-w-0 flex-1 flex-col gap-3",
+                                                        isSentByViewer && "items-end"
+                                                )}
+                                        >
+                                                <div className={bubbleClass}>
+                                                        <div className="flex flex-col gap-2">
+                                                                {textContent && (
+                                                                        <TimelineItemContent
+                                                                                className="break-words p-0 text-inherit"
+                                                                                renderMarkdown
+                                                                                text={textContent}
+                                                                        />
+                                                                )}
+
+                                                                {imageParts.length > 0 && (
+                                                                        <div className="flex flex-col gap-2">
+                                                                                {imageParts.map((part, index) => (
+                                                                                        <a
+                                                                                                key={`${part.url}-${index}`}
+                                                                                                className="group block overflow-hidden rounded-md border border-border/50"
+                                                                                                href={part.url}
+                                                                                                rel="noreferrer"
+                                                                                                target="_blank"
+                                                                                        >
+                                                                                                <img
+                                                                                                        alt={
+                                                                                                                part.fileName ??
+                                                                                                                "Attached image"
+                                                                                                        }
+                                                                                                        className="h-auto max-h-48 w-full object-cover transition group-hover:scale-[1.01]"
+                                                                                                        src={part.url}
+                                                                                                />
+                                                                                        </a>
+                                                                                ))}
+                                                                        </div>
+                                                                )}
+
+                                                                {fileParts.length > 0 && (
+                                                                        <div className="flex flex-col gap-2">
+                                                                                {fileParts.map((part, index) => (
+                                                                                        <a
+                                                                                                key={`${part.url}-${index}`}
+                                                                                                className="flex items-center gap-2 rounded-md bg-background/60 px-3 py-2 text-sm underline-offset-2 hover:underline"
+                                                                                                href={part.url}
+                                                                                                rel="noreferrer"
+                                                                                                target="_blank"
+                                                                                                download={part.fileName ?? undefined}
+                                                                                        >
+                                                                                                <span className="font-medium">
+                                                                                                        {part.fileName ?? "Attachment"}
+                                                                                                </span>
+                                                                                                {typeof part.size === "number" && (
+                                                                                                        <span className="text-xs opacity-70">
+                                                                                                                {formatFileSize(part.size)}
+                                                                                                        </span>
+                                                                                                )}
+                                                                                        </a>
+                                                                                ))}
+                                                                        </div>
+                                                                )}
+                                                        </div>
+                                                </div>
+                                                {isLast && (
+                                                        <TimelineItemTimestamp
+                                                                className="px-1 text-muted-foreground text-xs"
+                                                                timestamp={timestamp}
+                                                        >
+                                                                {() => (
+                                                                        <>
+                                                                                {timestamp.toLocaleTimeString([], {
+                                                                                        hour: "2-digit",
+                                                                                        minute: "2-digit",
+                                                                                })}
+                                                                                {isAI && " • AI agent"}
+                                                                        </>
+                                                                )}
+                                                        </TimelineItemTimestamp>
+                                                )}
+                                        </div>
+                                </div>
+                        )}
+                </PrimitiveTimelineItem>
+        );
+}
+
+function formatFileSize(bytes: number): string {
+        if (bytes < 1024) {
+                return `${bytes} B`;
+        }
+        if (bytes < 1024 * 1024) {
+                return `${(bytes / 1024).toFixed(1)} KB`;
+        }
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/apps/web/src/components/conversation/multimodal-input/index.tsx
+++ b/apps/web/src/components/conversation/multimodal-input/index.tsx
@@ -164,50 +164,62 @@ export const MultimodalInput: React.FC<MultimodalInputProps> = ({
 						/>
 					</div>
 					<div className="flex items-center justify-end pr-1 pb-1 pl-3">
-						<div className="flex items-center gap-0.5">
-							{/* File attachment button */}
-							{/* {onFileSelect && (
-                <>
-                  <TooltipOnHover content="Attach files">
-                    <Button
-                      className={cn(files.length >= maxFiles && "opacity-50")}
-                      disabled={
-                        disabled || isSubmitting || files.length >= maxFiles
-                      }
-                      onClick={handleAttachClick}
-                      size="icon"
-                      type="button"
-                      variant="ghost"
-                    >
-                      <Icon className="h-4 w-4" name="attachment" />
-                    </Button>
-                  </TooltipOnHover>
+                                                <div className="flex items-center gap-0.5">
+                                                        {/* File attachment button */}
+                                                        {onFileSelect && (
+                                                                <>
+                                                                        <TooltipOnHover content="Attach files">
+                                                                                <Button
+                                                                                        className={cn(
+                                                                                                files.length >= maxFiles &&
+                                                                                                        "opacity-50"
+                                                                                        )}
+                                                                                        disabled={
+                                                                                                disabled ||
+                                                                                                isSubmitting ||
+                                                                                                files.length >= maxFiles
+                                                                                        }
+                                                                                        onClick={handleAttachClick}
+                                                                                        size="icon"
+                                                                                        type="button"
+                                                                                        variant="ghost"
+                                                                                >
+                                                                                        <Icon
+                                                                                                className="h-4 w-4"
+                                                                                                name="attachment"
+                                                                                        />
+                                                                                </Button>
+                                                                        </TooltipOnHover>
 
-                  <input
-                    type="file"
-                    accept={allowedFileTypes.join(",")}
-                    className="hidden"
-                    disabled={
-                      disabled || isSubmitting || files.length >= maxFiles
-                    }
-                    onChange={(e) => {
-                      const files = Array.from(e.target.files || []);
-                      if (files.length > 0 && onFileSelect) {
-                        onFileSelect(files);
-                        // Reset input to allow selecting the same file again
-                        e.target.value = "";
-                      }
-                    }}
-                    ref={fileInputRef}
-                    multiple
-                  />
-                </>
-              )} */}
+                                                                        <input
+                                                                                type="file"
+                                                                                accept={allowedFileTypes.join(",")}
+                                                                                className="hidden"
+                                                                                disabled={
+                                                                                        disabled ||
+                                                                                        isSubmitting ||
+                                                                                        files.length >= maxFiles
+                                                                                }
+                                                                                onChange={(e) => {
+                                                                                        const files = Array.from(
+                                                                                                e.target.files || []
+                                                                                        );
+                                                                                        if (files.length > 0 && onFileSelect) {
+                                                                                                onFileSelect(files);
+                                                                                                // Reset input to allow selecting the same file again
+                                                                                                e.target.value = "";
+                                                                                        }
+                                                                                }}
+                                                                                ref={fileInputRef}
+                                                                                multiple
+                                                                        />
+                                                                </>
+                                                        )}
 
-							<TooltipOnHover
-								content="Send message"
-								shortcuts={["mod", "enter"]}
-							>
+                                                        <TooltipOnHover
+                                                                content="Send message"
+                                                                shortcuts={["mod", "enter"]}
+                                                        >
 								<Button
 									className={cn(
 										canSubmit

--- a/apps/web/src/hooks/use-send-conversation-message.ts
+++ b/apps/web/src/hooks/use-send-conversation-message.ts
@@ -3,24 +3,35 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
 import { ulid } from "ulid";
+import type {
+        TimelinePartFile,
+        TimelinePartImage,
+} from "@cossistant/types/api/timeline-item";
+import type {
+        GenerateUploadUrlRequest,
+        GenerateUploadUrlResponse,
+} from "@cossistant/types/api/upload";
 import {
-	type ConversationTimelineItem,
-	createConversationTimelineItemsInfiniteQueryKey,
-	removeConversationTimelineItemFromCache,
-	upsertConversationTimelineItemInCache,
+        type ConversationTimelineItem,
+        createConversationTimelineItemsInfiniteQueryKey,
+        removeConversationTimelineItemFromCache,
+        upsertConversationTimelineItemInCache,
 } from "@/data/conversation-message-cache";
 import { useTRPC } from "@/lib/trpc/client";
+import { uploadToPresignedUrl } from "@/components/ui/avatar-input";
 
 type SubmitPayload = {
-	message: string;
-	files: File[];
+        message: string;
+        files: File[];
 };
 
 type UseSendConversationMessageOptions = {
-	conversationId: string;
-	websiteSlug: string;
-	currentUserId: string;
-	pageLimit?: number;
+        conversationId: string;
+        websiteSlug: string;
+        websiteId: string;
+        organizationId: string;
+        currentUserId: string;
+        pageLimit?: number;
 };
 
 type UseSendConversationMessageReturn = {
@@ -31,13 +42,15 @@ type UseSendConversationMessageReturn = {
 const DEFAULT_PAGE_LIMIT = 50;
 
 export function useSendConversationMessage({
-	conversationId,
-	websiteSlug,
-	currentUserId,
-	pageLimit = DEFAULT_PAGE_LIMIT,
+        conversationId,
+        websiteSlug,
+        websiteId,
+        organizationId,
+        currentUserId,
+        pageLimit = DEFAULT_PAGE_LIMIT,
 }: UseSendConversationMessageOptions): UseSendConversationMessageReturn {
-	const trpc = useTRPC();
-	const queryClient = useQueryClient();
+        const trpc = useTRPC();
+        const queryClient = useQueryClient();
 
 	const timelineItemsQueryKey = useMemo(
 		() =>
@@ -51,35 +64,55 @@ export function useSendConversationMessage({
 		[conversationId, pageLimit, trpc, websiteSlug]
 	);
 
-	const { mutateAsync: sendMessage, isPending } = useMutation(
-		trpc.conversation.sendMessage.mutationOptions()
-	);
+        const { mutateAsync: sendMessage, isPending } = useMutation(
+                trpc.conversation.sendMessage.mutationOptions()
+        );
 
-	const submit = useCallback(
-		async ({ message, files }: SubmitPayload) => {
-			const trimmedMessage = message.trim();
+        const { mutateAsync: createSignedUrl } = useMutation(
+                trpc.upload.createSignedUrl.mutationOptions()
+        );
 
-			if (!trimmedMessage) {
-				return;
-			}
+        const submit = useCallback(
+                async ({ message, files }: SubmitPayload) => {
+                        const trimmedMessage = message.trim();
 
-			if (files.length > 0) {
-				throw new Error("File attachments are not supported yet.");
-			}
+                        if (!trimmedMessage && files.length === 0) {
+                                return;
+                        }
 
-			const timelineItemId = ulid();
-			const timestamp = new Date().toISOString();
+                        const timelineItemId = ulid();
+                        const timestamp = new Date().toISOString();
 
-			const optimisticItem: ConversationTimelineItem = {
-				id: timelineItemId,
-				conversationId,
-				organizationId: "", // Will be set by backend
-				type: "message",
-				text: trimmedMessage,
-				parts: [{ type: "text", text: trimmedMessage }],
-				visibility: "public",
-				userId: currentUserId,
-				aiAgentId: null,
+                        const fileParts = await Promise.all(
+                                files.map((file) =>
+                                        uploadFileToTimelinePart({
+                                                createSignedUrl,
+                                                file,
+                                                conversationId,
+                                                organizationId,
+                                                websiteId,
+                                                timelineItemId,
+                                        })
+                                )
+                        );
+
+                        const parts: ConversationTimelineItem["parts"] = [
+                                ...(trimmedMessage
+                                        ? ([{ type: "text", text: trimmedMessage }] as const)
+                                        : []),
+                                ...fileParts,
+                        ];
+
+                        const optimisticItem: ConversationTimelineItem = {
+                                id: timelineItemId,
+                                conversationId,
+                                organizationId: "", // Will be set by backend
+                                type: "message",
+                                text: trimmedMessage,
+                                parts,
+                                visibility: "public",
+                                userId: currentUserId,
+                                aiAgentId: null,
 				visitorId: null,
 				createdAt: timestamp,
 				deletedAt: null,
@@ -95,12 +128,13 @@ export function useSendConversationMessage({
 
 			try {
 				const response = await sendMessage({
-					conversationId,
-					websiteSlug,
-					text: trimmedMessage,
-					visibility: "public",
-					timelineItemId,
-				});
+                                        conversationId,
+                                        websiteSlug,
+                                        text: trimmedMessage,
+                                        parts,
+                                        visibility: "public",
+                                        timelineItemId,
+                                });
 
 				const { item: createdItem } = response;
 
@@ -122,18 +156,84 @@ export function useSendConversationMessage({
 				throw error;
 			}
 		},
-		[
-			conversationId,
-			currentUserId,
-			timelineItemsQueryKey,
-			queryClient,
-			sendMessage,
-			websiteSlug,
-		]
-	);
+                [
+                        conversationId,
+                        currentUserId,
+                        timelineItemsQueryKey,
+                        queryClient,
+                        sendMessage,
+                        createSignedUrl,
+                        organizationId,
+                        websiteId,
+                        websiteSlug,
+                ]
+        );
 
-	return {
-		submit,
-		isPending,
-	};
+        return {
+                submit,
+                isPending,
+        };
+}
+
+async function uploadFileToTimelinePart({
+        createSignedUrl,
+        file,
+        conversationId,
+        organizationId,
+        websiteId,
+        timelineItemId,
+}: {
+        createSignedUrl: (
+                params: Omit<GenerateUploadUrlRequest, "scope"> & {
+                        scope: Extract<
+                                GenerateUploadUrlRequest["scope"],
+                                { type: "conversation" }
+                        >;
+                }
+        ) => Promise<GenerateUploadUrlResponse>;
+        file: File;
+        conversationId: string;
+        organizationId: string;
+        websiteId: string;
+        timelineItemId: string;
+}): Promise<TimelinePartImage | TimelinePartFile> {
+        const contentType = file.type || "application/octet-stream";
+
+        const uploadDetails = await createSignedUrl({
+                contentType,
+                fileName: file.name,
+                websiteId,
+                path: `conversations/${conversationId}/timeline-items/${timelineItemId}`,
+                scope: {
+                        type: "conversation",
+                        conversationId,
+                        organizationId,
+                        websiteId,
+                },
+                useCdn: false,
+        });
+
+        await uploadToPresignedUrl({
+                file,
+                url: uploadDetails.uploadUrl,
+                headers: { "Content-Type": contentType },
+        });
+
+        if (contentType.startsWith("image/")) {
+                return {
+                        type: "image",
+                        url: uploadDetails.publicUrl,
+                        mediaType: contentType,
+                        fileName: file.name,
+                        size: file.size,
+                } satisfies TimelinePartImage;
+        }
+
+        return {
+                type: "file",
+                url: uploadDetails.publicUrl,
+                mediaType: contentType,
+                fileName: file.name,
+                size: file.size,
+        } satisfies TimelinePartFile;
 }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -6,10 +6,10 @@ import {
 	type RealtimeEvent,
 } from "@cossistant/types";
 import type {
-	CreateConversationRequestBody,
-	CreateConversationResponseBody,
-	GetConversationRequest,
-	GetConversationResponse,
+        CreateConversationRequestBody,
+        CreateConversationResponseBody,
+        GetConversationRequest,
+        GetConversationResponse,
 	ListConversationsRequest,
 	ListConversationsResponse,
 	MarkConversationSeenRequestBody,
@@ -20,9 +20,13 @@ import type {
 	GetConversationTimelineItemsRequest,
 	GetConversationTimelineItemsResponse,
 	SendTimelineItemRequest,
-	SendTimelineItemResponse,
-	TimelineItem,
+        SendTimelineItemResponse,
+        TimelineItem,
 } from "@cossistant/types/api/timeline-item";
+import type {
+        GenerateUploadUrlRequest,
+        GenerateUploadUrlResponse,
+} from "@cossistant/types/api/upload";
 import {
 	ConversationStatus,
 	ConversationTimelineType,
@@ -147,14 +151,20 @@ export class CossistantClient {
 		this.restClient.setWebsiteContext(websiteId, visitorId);
 	}
 
-	setVisitorBlocked(isBlocked: boolean): void {
-		this.restClient.setVisitorBlocked(isBlocked);
-	}
+        setVisitorBlocked(isBlocked: boolean): void {
+                this.restClient.setVisitorBlocked(isBlocked);
+        }
 
-	async updateVisitorMetadata(
-		metadata: VisitorMetadata
-	): Promise<VisitorResponse> {
-		return this.restClient.updateVisitorMetadata(metadata);
+        async createUploadUrl(
+                payload: GenerateUploadUrlRequest
+        ): Promise<GenerateUploadUrlResponse> {
+                return this.restClient.createUploadUrl(payload);
+        }
+
+        async updateVisitorMetadata(
+                metadata: VisitorMetadata
+        ): Promise<VisitorResponse> {
+                return this.restClient.updateVisitorMetadata(metadata);
 	}
 
 	async identify(params: {

--- a/packages/core/src/rest-client.ts
+++ b/packages/core/src/rest-client.ts
@@ -13,11 +13,15 @@ import type {
 	SetConversationTypingResponseBody,
 } from "@cossistant/types/api/conversation";
 import type {
-	GetConversationTimelineItemsRequest,
-	GetConversationTimelineItemsResponse,
-	SendTimelineItemRequest,
-	SendTimelineItemResponse,
+        GetConversationTimelineItemsRequest,
+        GetConversationTimelineItemsResponse,
+        SendTimelineItemRequest,
+        SendTimelineItemResponse,
 } from "@cossistant/types/api/timeline-item";
+import type {
+        GenerateUploadUrlRequest,
+        GenerateUploadUrlResponse,
+} from "@cossistant/types/api/upload";
 import { logger } from "./logger";
 import {
 	CossistantAPIError,
@@ -289,13 +293,32 @@ export class CossistantRestClient {
 		}
 	}
 
-	setVisitorBlocked(isBlocked: boolean): void {
-		this.visitorBlocked = isBlocked;
-	}
+        setVisitorBlocked(isBlocked: boolean): void {
+                this.visitorBlocked = isBlocked;
+        }
 
-	getCurrentWebsiteId(): string | null {
-		return this.websiteId;
-	}
+        async createUploadUrl(
+                payload: GenerateUploadUrlRequest
+        ): Promise<GenerateUploadUrlResponse> {
+                const headers: Record<string, string> = {};
+
+                if (this.websiteId) {
+                        const storedVisitorId = getVisitorId(this.websiteId);
+                        if (storedVisitorId) {
+                                headers["X-Visitor-Id"] = storedVisitorId;
+                        }
+                }
+
+                return this.request<GenerateUploadUrlResponse>("/uploads/sign-url", {
+                        method: "POST",
+                        body: JSON.stringify(payload),
+                        headers,
+                });
+        }
+
+        getCurrentWebsiteId(): string | null {
+                return this.websiteId;
+        }
 
 	getCurrentVisitorId(): string | null {
 		if (this.visitorId) {

--- a/packages/react/src/hooks/use-send-message.ts
+++ b/packages/react/src/hooks/use-send-message.ts
@@ -1,7 +1,12 @@
 import type { CossistantClient } from "@cossistant/core";
 import { generateMessageId } from "@cossistant/core";
 import type { CreateConversationResponseBody } from "@cossistant/types/api/conversation";
-import type { TimelineItem } from "@cossistant/types/api/timeline-item";
+import type {
+        TimelineItem,
+        TimelinePartFile,
+        TimelinePartImage,
+} from "@cossistant/types/api/timeline-item";
+import type { GenerateUploadUrlRequest } from "@cossistant/types/api/upload";
 import { useCallback, useState } from "react";
 
 import { useSupport } from "../provider";
@@ -54,29 +59,133 @@ function toError(error: unknown): Error {
 	return new Error("Unknown error");
 }
 
-function buildTimelineItemPayload(
-	body: string,
-	conversationId: string,
-	visitorId: string | null,
-	messageId?: string
-): TimelineItem {
-	const nowIso = typeof window !== "undefined" ? new Date().toISOString() : "";
-	const id = messageId ?? generateMessageId();
+type UploadScope = Extract<GenerateUploadUrlRequest["scope"], { type: "conversation" }>;
 
-	return {
-		id,
-		conversationId,
-		organizationId: "", // Will be set by backend
-		type: "message" as const,
-		text: body,
-		parts: [{ type: "text" as const, text: body }],
-		visibility: "public" as const,
-		userId: null,
-		aiAgentId: null,
-		visitorId: visitorId ?? null,
-		createdAt: nowIso,
-		deletedAt: null,
-	} satisfies TimelineItem;
+async function buildTimelineItemPayload(
+        body: string,
+        parts: TimelineItem["parts"],
+        conversationId: string,
+        visitorId: string | null,
+        messageId?: string
+): Promise<TimelineItem> {
+        const nowIso = typeof window !== "undefined" ? new Date().toISOString() : "";
+        const id = messageId ?? generateMessageId();
+
+        const payloadParts = parts.length
+                ? parts
+                : body
+                        ? ([{ type: "text" as const, text: body }] satisfies TimelineItem["parts"])
+                        : [];
+
+        return {
+                id,
+                conversationId,
+                organizationId: "", // Will be set by backend
+                type: "message" as const,
+                text: body,
+                parts: payloadParts,
+                visibility: "public" as const,
+                userId: null,
+                aiAgentId: null,
+                visitorId: visitorId ?? null,
+                createdAt: nowIso,
+                deletedAt: null,
+        } satisfies TimelineItem;
+}
+
+async function uploadToSignedUrl({
+        file,
+        url,
+        contentType,
+}: {
+        file: File;
+        url: string;
+        contentType: string;
+}): Promise<void> {
+        const response = await fetch(url, {
+                method: "PUT",
+                headers: { "Content-Type": contentType },
+                body: file,
+        });
+
+        if (!response.ok) {
+                throw new Error(`Upload failed with status ${response.status}`);
+        }
+}
+
+async function uploadFileToTimelinePart({
+        client,
+        file,
+        scope,
+        websiteId,
+        messageId,
+}: {
+        client: CossistantClient;
+        file: File;
+        scope: UploadScope;
+        websiteId: string;
+        messageId: string;
+}): Promise<TimelinePartImage | TimelinePartFile> {
+        const contentType = file.type || "application/octet-stream";
+
+        const uploadDetails = await client.createUploadUrl({
+                contentType,
+                fileName: file.name,
+                websiteId,
+                path: `conversations/${scope.conversationId}/timeline-items/${messageId}`,
+                scope,
+                useCdn: false,
+        });
+
+        await uploadToSignedUrl({
+                file,
+                url: uploadDetails.uploadUrl,
+                contentType,
+        });
+
+        if (contentType.startsWith("image/")) {
+                return {
+                        type: "image",
+                        url: uploadDetails.publicUrl,
+                        mediaType: contentType,
+                        fileName: file.name,
+                        size: file.size,
+                } satisfies TimelinePartImage;
+        }
+
+        return {
+                type: "file",
+                url: uploadDetails.publicUrl,
+                mediaType: contentType,
+                fileName: file.name,
+                size: file.size,
+        } satisfies TimelinePartFile;
+}
+
+async function uploadFilesToTimelineParts({
+        client,
+        files,
+        scope,
+        websiteId,
+        messageId,
+}: {
+        client: CossistantClient;
+        files: File[];
+        scope: UploadScope;
+        websiteId: string;
+        messageId: string;
+}): Promise<Array<TimelinePartImage | TimelinePartFile>> {
+        return Promise.all(
+                files.map((file) =>
+                        uploadFileToTimelinePart({
+                                client,
+                                file,
+                                scope,
+                                websiteId,
+                                messageId,
+                        })
+                )
+        );
 }
 
 /**
@@ -94,49 +203,90 @@ export function useSendMessage(
 
 	const mutateAsync = useCallback(
 		async (payload: SendMessageOptions): Promise<SendMessageResult | null> => {
-			const {
-				conversationId: providedConversationId,
-				message,
-				defaultTimelineItems = [],
-				visitorId,
-				messageId: providedMessageId,
-				onSuccess,
-				onError,
-			} = payload;
+                        const {
+                                conversationId: providedConversationId,
+                                message,
+                                files = [],
+                                defaultTimelineItems = [],
+                                visitorId,
+                                messageId: providedMessageId,
+                                onSuccess,
+                                onError,
+                        } = payload;
 
-			if (!message.trim()) {
-				const emptyMessageError = new Error("Message cannot be empty");
-				setError(emptyMessageError);
-				onError?.(emptyMessageError);
-				return null;
-			}
+                        const trimmedMessage = message.trim();
+
+                        if (!trimmedMessage && files.length === 0) {
+                                const emptyMessageError = new Error(
+                                        "Please provide a message or attach files"
+                                );
+                                setError(emptyMessageError);
+                                onError?.(emptyMessageError);
+                                return null;
+                        }
 
 			setIsPending(true);
 			setError(null);
 
-			try {
-				let conversationId = providedConversationId ?? undefined;
-				let preparedDefaultTimelineItems = defaultTimelineItems;
-				let initialConversation:
-					| CreateConversationResponseBody["conversation"]
-					| undefined;
+                        try {
+                                let conversationId = providedConversationId ?? undefined;
+                                let preparedDefaultTimelineItems = defaultTimelineItems;
+                                let initialConversation:
+                                        | CreateConversationResponseBody["conversation"]
+                                        | undefined;
 
-				if (!conversationId) {
-					const initiated = client.initiateConversation({
-						defaultTimelineItems,
-						visitorId: visitorId ?? undefined,
-					});
-					conversationId = initiated.conversationId;
-					preparedDefaultTimelineItems = initiated.defaultTimelineItems;
-					initialConversation = initiated.conversation;
-				}
+                                if (!conversationId) {
+                                        const initiated = client.initiateConversation({
+                                                defaultTimelineItems,
+                                                visitorId: visitorId ?? undefined,
+                                        });
+                                        conversationId = initiated.conversationId;
+                                        preparedDefaultTimelineItems = initiated.defaultTimelineItems;
+                                        initialConversation = initiated.conversation;
+                                }
 
-				const timelineItemPayload = buildTimelineItemPayload(
-					message,
-					conversationId,
-					visitorId ?? null,
-					providedMessageId
-				);
+                                if (!conversationId) {
+                                        throw new Error("Conversation ID is required to send a message");
+                                }
+
+                                const website = await client.fetchWebsite();
+                                const messageId = providedMessageId ?? generateMessageId();
+                                const uploadScope: UploadScope = {
+                                        type: "conversation",
+                                        conversationId,
+                                        organizationId: website.organizationId,
+                                        websiteId: website.id,
+                                };
+
+                                const fileParts = files.length
+                                        ? await uploadFilesToTimelineParts({
+                                                client,
+                                                files,
+                                                scope: uploadScope,
+                                                websiteId: website.id,
+                                                messageId,
+                                        })
+                                        : [];
+
+                                const timelineParts: TimelineItem["parts"] = [
+                                        ...(trimmedMessage
+                                                ? ([
+                                                        {
+                                                                type: "text" as const,
+                                                                text: trimmedMessage,
+                                                        },
+                                                ] as const satisfies TimelineItem["parts"])
+                                                : []),
+                                        ...fileParts,
+                                ];
+
+                                const timelineItemPayload = await buildTimelineItemPayload(
+                                        trimmedMessage,
+                                        timelineParts,
+                                        conversationId,
+                                        visitorId ?? null,
+                                        messageId
+                                );
 
 				const response = await client.sendMessage({
 					conversationId,

--- a/packages/react/src/support/components/multimodal-input.tsx
+++ b/packages/react/src/support/components/multimodal-input.tsx
@@ -152,41 +152,41 @@ export const MultimodalInput: React.FC<MultimodalInputProps> = ({
 				<div className="flex items-center justify-between py-1 pr-1 pl-3">
 					<Watermark />
 
-					<div className="flex items-center gap-0.5">
-						{/* File attachment button */}
-						{/* {onFileSelect && (
-							<>
-								<button
-									aria-label={text("common.actions.attachFiles")}
-									className={cn(
-										"group flex h-8 w-8 items-center justify-center rounded-md text-co-muted-foreground hover:bg-co-muted hover:text-co-foreground disabled:cursor-not-allowed disabled:opacity-50",
-										files.length >= maxFiles && "opacity-50"
-									)}
-									disabled={
-										disabled || isSubmitting || files.length >= maxFiles
-									}
-									onClick={handleAttachClick}
-									type="button"
-								>
-									<Icon className="h-4 w-4" name="attachment" />
-								</button>
+                                                <div className="flex items-center gap-0.5">
+                                                        {/* File attachment button */}
+                                                        {onFileSelect && (
+                                                                <>
+                                                                        <button
+                                                                                aria-label={text("common.actions.attachFiles")}
+                                                                                className={cn(
+                                                                                        "group flex h-8 w-8 items-center justify-center rounded-md text-co-muted-foreground hover:bg-co-muted hover:text-co-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                                                                                        files.length >= maxFiles && "opacity-50"
+                                                                                )}
+                                                                                disabled={
+                                                                                        disabled || isSubmitting || files.length >= maxFiles
+                                                                                }
+                                                                                onClick={handleAttachClick}
+                                                                                type="button"
+                                                                        >
+                                                                                <Icon className="h-4 w-4" name="attachment" />
+                                                                        </button>
 
-								<Primitive.FileInput
-									accept={allowedFileTypes.join(",")}
-									className="hidden"
-									disabled={
-										disabled || isSubmitting || files.length >= maxFiles
-									}
-									onFileSelect={onFileSelect}
-									ref={fileInputRef}
-								/>
-							</>
-						)} */}
+                                                                        <Primitive.FileInput
+                                                                                accept={allowedFileTypes.join(",")}
+                                                                                className="hidden"
+                                                                                disabled={
+                                                                                        disabled || isSubmitting || files.length >= maxFiles
+                                                                                }
+                                                                                onFileSelect={onFileSelect}
+                                                                                ref={fileInputRef}
+                                                                        />
+                                                                </>
+                                                        )}
 
-						{/* Send button */}
-						<SendButton disabled={!canSubmit} />
-					</div>
-				</div>
+                                                        {/* Send button */}
+                                                        <SendButton disabled={!canSubmit} />
+                                                </div>
+                                        </div>
 			</div>
 		</form>
 	);

--- a/packages/react/src/support/components/timeline-message-item.tsx
+++ b/packages/react/src/support/components/timeline-message-item.tsx
@@ -1,17 +1,17 @@
 import type { TimelineItem } from "@cossistant/types/api/timeline-item";
 import type React from "react";
 import {
-	TimelineItem as PrimitiveTimelineItem,
-	TimelineItemContent,
-	TimelineItemTimestamp,
+        TimelineItem as PrimitiveTimelineItem,
+        TimelineItemContent,
+        TimelineItemTimestamp,
 } from "../../primitives/timeline-item";
 import { useSupportText } from "../text";
 import { cn } from "../utils";
 
 export type TimelineMessageItemProps = {
-	item: TimelineItem;
-	isLast?: boolean;
-	isSentByViewer?: boolean;
+        item: TimelineItem;
+        isLast?: boolean;
+        isSentByViewer?: boolean;
 };
 
 /**
@@ -19,68 +19,141 @@ export type TimelineMessageItemProps = {
  * or an agent sent the message.
  */
 export function TimelineMessageItem({
-	item,
-	isLast = false,
-	isSentByViewer = false,
+        item,
+        isLast = false,
+        isSentByViewer = false,
 }: TimelineMessageItemProps): React.ReactElement {
-	const text = useSupportText();
-	return (
-		<PrimitiveTimelineItem item={item}>
-			{({ isAI, timestamp }) => {
-				// isSentByViewer defaults to false, meaning messages are treated as received
-				// (left side with background) unless explicitly marked as sent by viewer
-				const isSentByViewerFinal = isSentByViewer;
+        const text = useSupportText();
+        const textPart = item.parts.find((part) => part.type === "text");
+        const textContent = textPart?.text ?? item.text ?? "";
+        const attachments = item.parts.filter(
+                (part): part is TimelineItem["parts"][number] =>
+                        part.type === "image" || part.type === "file"
+        );
 
-				return (
-					<div
-						className={cn(
-							"flex w-full gap-2",
-							isSentByViewerFinal && "flex-row-reverse",
-							!isSentByViewerFinal && "flex-row"
-						)}
-					>
-						<div
-							className={cn(
-								"flex w-full min-w-0 flex-1 flex-col gap-1",
-								isSentByViewerFinal && "items-end"
-							)}
-						>
-							<TimelineItemContent
-								className={cn(
-									"block min-w-0 max-w-[300px] whitespace-pre-wrap break-words rounded-lg px-3.5 py-2.5 text-sm",
-									{
-										"bg-co-background-300 text-co-foreground dark:bg-co-background-600":
-											!isSentByViewerFinal,
-										"bg-co-primary text-co-primary-foreground":
-											isSentByViewerFinal,
-										"rounded-br-sm": isLast && isSentByViewerFinal,
-										"rounded-bl-sm": isLast && !isSentByViewerFinal,
-									}
-								)}
-								renderMarkdown
-								text={item.text}
-							/>
-							{isLast && (
-								<TimelineItemTimestamp
-									className="px-1 text-co-muted-foreground text-xs"
-									timestamp={timestamp}
-								>
-									{() => (
-										<>
-											{timestamp.toLocaleTimeString([], {
-												hour: "2-digit",
-												minute: "2-digit",
-											})}
-											{isAI &&
-												` ${text("component.message.timestamp.aiIndicator")}`}
-										</>
-									)}
-								</TimelineItemTimestamp>
-							)}
-						</div>
-					</div>
-				);
-			}}
-		</PrimitiveTimelineItem>
-	);
+        const imageParts = attachments.filter((part) => part.type === "image");
+        const fileParts = attachments.filter((part) => part.type === "file");
+
+        const bubbleClass = cn(
+                "block min-w-0 max-w-[300px] whitespace-pre-wrap break-words rounded-lg px-3.5 py-2.5 text-sm",
+                {
+                        "bg-co-background-300 text-co-foreground dark:bg-co-background-600":
+                                !isSentByViewer,
+                        "bg-co-primary text-co-primary-foreground": isSentByViewer,
+                        "rounded-br-sm": isLast && isSentByViewer,
+                        "rounded-bl-sm": isLast && !isSentByViewer,
+                }
+        );
+
+        return (
+                <PrimitiveTimelineItem item={item}>
+                        {({ isAI, timestamp }) => {
+                                // isSentByViewer defaults to false, meaning messages are treated as received
+                                // (left side with background) unless explicitly marked as sent by viewer
+                                const isSentByViewerFinal = isSentByViewer;
+
+                                return (
+                                        <div
+                                                className={cn(
+                                                        "flex w-full gap-2",
+                                                        isSentByViewerFinal && "flex-row-reverse",
+                                                        !isSentByViewerFinal && "flex-row"
+                                                )}
+                                        >
+                                                <div
+                                                        className={cn(
+                                                                "flex w-full min-w-0 flex-1 flex-col gap-1",
+                                                                isSentByViewerFinal && "items-end"
+                                                        )}
+                                                >
+                                                        <div className={bubbleClass}>
+                                                                <div className="flex flex-col gap-2">
+                                                                        {textContent && (
+                                                                                <TimelineItemContent
+                                                                                        className="break-words p-0 text-inherit"
+                                                                                        renderMarkdown
+                                                                                        text={textContent}
+                                                                                />
+                                                                        )}
+
+                                                                        {imageParts.length > 0 && (
+                                                                                <div className="flex flex-col gap-2">
+                                                                                        {imageParts.map((part, index) => (
+                                                                                                <a
+                                                                                                        key={`${part.url}-${index}`}
+                                                                                                        className="group block overflow-hidden rounded-md border border-co-border/50"
+                                                                                                        href={part.url}
+                                                                                                        rel="noreferrer"
+                                                                                                        target="_blank"
+                                                                                                >
+                                                                                                        <img
+                                                                                                                alt={
+                                                                                                                        part.fileName ??
+                                                                                                                        "Attached image"
+                                                                                                                }
+                                                                                                                className="h-auto max-h-48 w-full object-cover transition group-hover:scale-[1.01]"
+                                                                                                                src={part.url}
+                                                                                                        />
+                                                                                                </a>
+                                                                                        ))}
+                                                                                </div>
+                                                                        )}
+
+                                                                        {fileParts.length > 0 && (
+                                                                                <div className="flex flex-col gap-2">
+                                                                                        {fileParts.map((part, index) => (
+                                                                                                <a
+                                                                                                        key={`${part.url}-${index}`}
+                                                                                                        className="flex items-center gap-2 rounded-md bg-co-background/60 px-3 py-2 text-sm underline-offset-2 hover:underline"
+                                                                                                        href={part.url}
+                                                                                                        rel="noreferrer"
+                                                                                                        target="_blank"
+                                                                                                        download={part.fileName ?? undefined}
+                                                                                               >
+                                                                                                       <span className="font-medium">
+                                                                                                                {part.fileName ?? "Attachment"}
+                                                                                                       </span>
+                                                                                                       {typeof part.size === "number" && (
+                                                                                                                <span className="text-xs opacity-70">
+                                                                                                                        {formatFileSize(part.size)}
+                                                                                                                </span>
+                                                                                                        )}
+                                                                                                </a>
+                                                                                        ))}
+                                                                                </div>
+                                                                        )}
+                                                                </div>
+                                                        </div>
+                                                        {isLast && (
+                                                                <TimelineItemTimestamp
+                                                                        className="px-1 text-co-muted-foreground text-xs"
+                                                                        timestamp={timestamp}
+                                                                >
+                                                                        {() => (
+                                                                                <>
+                                                                                        {timestamp.toLocaleTimeString([], {
+                                                                                                hour: "2-digit",
+                                                                                                minute: "2-digit",
+                                                                                        })}
+                                                                                        {isAI && ` ${text("component.message.timestamp.aiIndicator")}`}
+                                                                                </>
+                                                                        )}
+                                                                </TimelineItemTimestamp>
+                                                        )}
+                                                </div>
+                                        </div>
+                                );
+                        }}
+                </PrimitiveTimelineItem>
+        );
+}
+
+function formatFileSize(bytes: number): string {
+        if (bytes < 1024) {
+                return `${bytes} B`;
+        }
+        if (bytes < 1024 * 1024) {
+                return `${(bytes / 1024).toFixed(1)} KB`;
+        }
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }


### PR DESCRIPTION
## Summary
- upload dashboard conversation attachments to S3 and send their URLs together in one timeline item
- add client support for generating signed upload URLs and use it in the widget send-message flow
- pass website context into the dashboard composer hook so uploads scope to the right org/site

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929ac600ee8832b8be6f138df086cd9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File attachment support: Users can now upload and share files within conversations.
  * Enhanced message rendering: Files display as downloadable links with size indicators; images show as inline previews.
  
* **Improvements**
  * Automatic participant joining when sending first message in a conversation.
  * Support for multipart messages combining text and attachments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->