### PR TITLE
fix: create pgvector extension in migration

### DIFF
--- a/apps/api/drizzle/migrations/0030_enable_pgvector.sql
+++ b/apps/api/drizzle/migrations/0030_enable_pgvector.sql
@@ -1,7 +1,9 @@
 -- Enable pgvector extension for vector similarity search
 -- NOTE: This extension must be enabled by a database administrator with superuser privileges.
 -- On managed services (Neon, Supabase, Railway, etc.), enable it via their dashboard.
--- This migration is intentionally empty - the extension should already exist.
+-- This migration creates the extension when permissions allow.
 
 -- To enable manually as superuser:
 -- CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE EXTENSION IF NOT EXISTS vector;


### PR DESCRIPTION
### Motivation
- CI DB migrations fail with `type "vector" does not exist` when the `vector` extension isn't present, so the migration should attempt to create the pgvector extension where permissions allow.

### Description
- Add `CREATE EXTENSION IF NOT EXISTS vector;` and update the migration note in `apps/api/drizzle/migrations/0030_enable_pgvector.sql` so CI can create the `vector` type during schema setup.

### Testing
- No automated tests were run for this migration-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971858a6cfc832bbd9e1a0d76c2dbfc)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the pgvector type exists during schema setup, reducing migration failures.
> 
> - Adds `CREATE EXTENSION IF NOT EXISTS vector;` to `0030_enable_pgvector.sql` so CI/DB can create the `vector` type when permitted
> - Updates migration comments to reflect automatic creation behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8ca366c0bb8cd744d5ece2f897845246bbddfd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->