### PR TITLE
fix: make ai-agent worker scaling configurable, add unique-job helper, and standardize worker configs

### DIFF
--- a/apps/workers/src/env.ts
+++ b/apps/workers/src/env.ts
@@ -30,6 +30,19 @@ export const env = {
 	NODE_ENV: getEnvVariable("NODE_ENV"),
 	PORT: +getEnvVariable("PORT", "8790"),
 	REDIS_URL: getEnvVariable("REDIS_URL"),
+	AI_AGENT_CONCURRENCY: +getEnvVariable("AI_AGENT_CONCURRENCY", "10"),
+	AI_AGENT_LOCK_DURATION_MS: +getEnvVariable(
+		"AI_AGENT_LOCK_DURATION_MS",
+		"120000"
+	),
+	AI_AGENT_STALLED_INTERVAL_MS: +getEnvVariable(
+		"AI_AGENT_STALLED_INTERVAL_MS",
+		"30000"
+	),
+	AI_AGENT_MAX_STALLED_COUNT: +getEnvVariable(
+		"AI_AGENT_MAX_STALLED_COUNT",
+		"2"
+	),
 	// Database (needed for notification queries)
 	DATABASE_HOST: getEnvVariable("DATABASE_HOST"),
 	DATABASE_PORT: +getEnvVariable("DATABASE_PORT"),

--- a/apps/workers/src/queues/ai-agent/worker.ts
+++ b/apps/workers/src/queues/ai-agent/worker.ts
@@ -29,6 +29,7 @@ import {
 	type RedisOptions,
 } from "@cossistant/redis";
 import { db } from "@workers/db";
+import { env } from "@workers/env";
 import { type Job, Queue, QueueEvents, Worker } from "bullmq";
 
 const AI_AGENT_DIRECTION: WorkflowDirection = "ai-agent-response";
@@ -37,10 +38,10 @@ const AI_AGENT_DIRECTION: WorkflowDirection = "ai-agent-response";
  * Worker configuration for reliability
  */
 const WORKER_CONFIG = {
-	concurrency: 10, // Process 10 jobs in parallel per worker
-	lockDuration: 60_000, // 60s lock to prevent duplicate processing
-	stalledInterval: 30_000, // Check for stalled jobs every 30s
-	maxStalledCount: 2, // Retry stalled jobs up to 2 times
+	concurrency: env.AI_AGENT_CONCURRENCY,
+	lockDuration: env.AI_AGENT_LOCK_DURATION_MS,
+	stalledInterval: env.AI_AGENT_STALLED_INTERVAL_MS,
+	maxStalledCount: env.AI_AGENT_MAX_STALLED_COUNT,
 };
 
 type WorkerConfig = {

--- a/apps/workers/src/queues/message-notification/worker.tsx
+++ b/apps/workers/src/queues/message-notification/worker.tsx
@@ -19,6 +19,13 @@ import { db } from "../../db";
 // Constants
 const MAX_MESSAGES_IN_EMAIL = 3;
 
+const WORKER_CONFIG = {
+	concurrency: 10,
+	lockDuration: 60_000,
+	stalledInterval: 30_000,
+	maxStalledCount: 2,
+};
+
 type MemberRecipient = {
 	kind: "member";
 	userId: string;
@@ -92,7 +99,10 @@ export function createMessageNotificationWorker({
 				},
 				{
 					connection: buildConnectionOptions(),
-					concurrency: 10,
+					concurrency: WORKER_CONFIG.concurrency,
+					lockDuration: WORKER_CONFIG.lockDuration,
+					stalledInterval: WORKER_CONFIG.stalledInterval,
+					maxStalledCount: WORKER_CONFIG.maxStalledCount,
 				}
 			);
 

--- a/apps/workers/src/queues/web-crawl/worker.ts
+++ b/apps/workers/src/queues/web-crawl/worker.ts
@@ -24,6 +24,13 @@ const LEADING_SLASH_REGEX = /^\//;
 const POLL_INTERVAL_MS = 5000; // 5 seconds
 const MAX_POLL_ATTEMPTS = 360; // 30 minutes max (360 * 5s)
 
+const WORKER_CONFIG = {
+	concurrency: 3,
+	lockDuration: 120_000,
+	stalledInterval: 30_000,
+	maxStalledCount: 2,
+};
+
 // Convert MB to bytes
 const MB_TO_BYTES = 1024 * 1024;
 
@@ -117,7 +124,10 @@ export function createWebCrawlWorker({
 				},
 				{
 					connection: buildConnectionOptions(),
-					concurrency: 3, // Limit parallel crawls
+					concurrency: WORKER_CONFIG.concurrency, // Limit parallel crawls
+					lockDuration: WORKER_CONFIG.lockDuration,
+					stalledInterval: WORKER_CONFIG.stalledInterval,
+					maxStalledCount: WORKER_CONFIG.maxStalledCount,
 				}
 			);
 

--- a/packages/jobs/src/utils/unique-job.ts
+++ b/packages/jobs/src/utils/unique-job.ts
@@ -1,0 +1,98 @@
+/**
+ * Unique Job Utility
+ *
+ * Ensures a single job per logical ID while allowing replacements for
+ * completed/failed jobs. Active/waiting/delayed jobs are skipped to avoid
+ * concurrent duplicates.
+ */
+
+import type { Job, JobsOptions, Queue } from "bullmq";
+
+// Use simpler Job type to avoid BullMQ's complex generic inference
+type SimpleJob<T> = Job<T, unknown, string>;
+
+export type UniqueJobResult<T> =
+	| { status: "created"; job: SimpleJob<T> }
+	| {
+			status: "replaced";
+			job: SimpleJob<T>;
+			previousState: "completed" | "failed";
+	  }
+	| {
+			status: "skipped";
+			reason: "active" | "debouncing" | "unexpected";
+			existingState: string;
+			existingJob: SimpleJob<T>;
+			existingJobData: T;
+	  };
+
+export type AddUniqueJobParams<T> = {
+	queue: Queue<T>;
+	jobId: string;
+	jobName: string;
+	data: T;
+	options: Omit<JobsOptions, "jobId">;
+	logPrefix: string;
+};
+
+/**
+ * Add a job ensuring uniqueness by jobId:
+ * - If no existing job → create new job
+ * - If existing job is completed/failed → remove and create new job
+ * - If existing job is delayed/waiting/active → skip to avoid duplicates
+ * - If existing job is in an unexpected state → skip to avoid conflicts
+ */
+export async function addUniqueJob<T>(
+	params: AddUniqueJobParams<T>
+): Promise<UniqueJobResult<T>> {
+	const { queue, jobId, jobName, data, options, logPrefix } = params;
+	const existingJob = await queue.getJob(jobId);
+
+	if (existingJob) {
+		const existingState = await existingJob.getState();
+
+		if (existingState === "completed" || existingState === "failed") {
+			await existingJob.remove();
+			console.log(`${logPrefix} Removed ${existingState} job ${jobId}`);
+			const job = (await (queue as Queue).add(jobName, data, {
+				...options,
+				jobId,
+			})) as SimpleJob<T>;
+			return { status: "replaced", job, previousState: existingState };
+		}
+
+		if (
+			existingState === "delayed" ||
+			existingState === "waiting" ||
+			existingState === "active"
+		) {
+			console.log(
+				`${logPrefix} Job ${jobId} already ${existingState}, skipping`
+			);
+			return {
+				status: "skipped",
+				reason: existingState === "active" ? "active" : "debouncing",
+				existingState,
+				existingJob: existingJob as SimpleJob<T>,
+				existingJobData: existingJob.data as T,
+			};
+		}
+
+		console.warn(
+			`${logPrefix} Job ${jobId} in unexpected state: ${existingState}, skipping`
+		);
+		return {
+			status: "skipped",
+			reason: "unexpected",
+			existingState,
+			existingJob: existingJob as SimpleJob<T>,
+			existingJobData: existingJob.data as T,
+		};
+	}
+
+	const job = (await (queue as Queue).add(jobName, data, {
+		...options,
+		jobId,
+	})) as SimpleJob<T>;
+	return { status: "created", job };
+}


### PR DESCRIPTION
### Motivation

- Allow the AI agent worker to safely scale to high parallel workloads (hundreds to thousands of concurrent conversations) by making concurrency and lock/stall tuning configurable. 
- Prevent completed/failed jobs from blocking re-enqueue attempts and reduce duplicate processing by skipping active/delayed/waiting jobs. 
- Make worker lock and stall settings consistent across queues to improve stall detection and reliable retries. 

### Description

- Added environment variables in `apps/workers/src/env.ts` for AI agent tuning: `AI_AGENT_CONCURRENCY`, `AI_AGENT_LOCK_DURATION_MS`, `AI_AGENT_STALLED_INTERVAL_MS`, and `AI_AGENT_MAX_STALLED_COUNT`. 
- Wired the ai-agent worker to use the env-driven `WORKER_CONFIG` in `apps/workers/src/queues/ai-agent/worker.ts` so concurrency/lock/stall settings are configurable at runtime. 
- Introduced a reusable `addUniqueJob` helper at `packages/jobs/src/utils/unique-job.ts` that creates, replaces, or skips jobs by `jobId` depending on existing job state. 
- Updated triggers to use `addUniqueJob` and tightened retention by switching `removeOnComplete`/`removeOnFail` to explicit count objects; changes are in `packages/jobs/src/triggers/ai-training.ts` and `packages/jobs/src/triggers/web-crawl.ts`. 
- Standardized worker runtime options (`concurrency`, `lockDuration`, `stalledInterval`, `maxStalledCount`) for `message-notification`, `ai-training`, and `web-crawl` workers to improve consistent stall handling across queues. 

### Testing

- No automated tests were executed for this change (`bun test` / `bun run check-types` were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698208b05364832b8a550b79163c9354)