### PR TITLE
Fix private REST inbox teammate lastSeenAt context

### DIFF
--- a/apps/api/src/rest/routers/conversation-auth.test.ts
+++ b/apps/api/src/rest/routers/conversation-auth.test.ts
@@ -8,6 +8,9 @@ const safelyExtractRequestQueryMock = mock((async () => ({})) as (
 	...args: unknown[]
 ) => Promise<unknown>);
 const validateResponseMock = mock(<T>(value: T) => value);
+const resolvePrivateApiKeyActorUserMock = mock(
+	(async () => null) as (...args: unknown[]) => Promise<unknown>
+);
 
 const getVisitorMock = mock(
 	(async () => null) as (...args: unknown[]) => Promise<unknown>
@@ -53,6 +56,10 @@ mock.module("@api/utils/validate", () => ({
 	safelyExtractRequestData: safelyExtractRequestDataMock,
 	safelyExtractRequestQuery: safelyExtractRequestQueryMock,
 	validateResponse: validateResponseMock,
+}));
+
+mock.module("@api/lib/private-api-key-actor", () => ({
+	resolvePrivateApiKeyActorUser: resolvePrivateApiKeyActorUserMock,
 }));
 
 mock.module("@api/db/queries", () => ({
@@ -317,15 +324,19 @@ describe("conversation auth and inbox routes", () => {
 			items: [createInboxItem()],
 			nextCursor: "cursor_2",
 		});
+		resolvePrivateApiKeyActorUserMock.mockResolvedValue(null);
 		mergeConversationMetadataMock.mockResolvedValue(createConversationRecord());
 	});
 
 	it("lists inbox conversations for private API keys", async () => {
+		resolvePrivateApiKeyActorUserMock.mockResolvedValue({
+			userId: "user-1",
+		});
 		safelyExtractRequestQueryMock.mockResolvedValue({
 			db: {},
 			apiKey: { keyType: APIKeyType.PRIVATE },
 			organization: { id: "org-1" },
-			website: { id: "site-1", organizationId: "org-1" },
+			website: { id: "site-1", organizationId: "org-1", teamId: "team-1" },
 			query: {
 				limit: 20,
 				cursor: null,
@@ -347,6 +358,39 @@ describe("conversation auth and inbox routes", () => {
 		expect(response.status).toBe(200);
 		expect(payload.nextCursor).toBe("cursor_2");
 		expect(payload.items[0]?.id).toBe(conversationId);
+		expect(listConversationsHeadersMock).toHaveBeenCalledWith(
+			{},
+			{
+				organizationId: "org-1",
+				websiteId: "site-1",
+				userId: "user-1",
+				limit: 20,
+				cursor: null,
+			}
+		);
+	});
+
+	it("keeps inbox lastSeenAt actorless when no teammate context is available", async () => {
+		resolvePrivateApiKeyActorUserMock.mockResolvedValue(null);
+		safelyExtractRequestQueryMock.mockResolvedValue({
+			db: {},
+			apiKey: { keyType: APIKeyType.PRIVATE },
+			organization: { id: "org-1" },
+			website: { id: "site-1", organizationId: "org-1", teamId: "team-1" },
+			query: {
+				limit: 20,
+				cursor: null,
+			},
+		});
+
+		const { conversationRouter } = await conversationRouterModulePromise;
+		const response = await conversationRouter.request(
+			new Request("http://localhost/inbox?limit=20", {
+				method: "GET",
+			})
+		);
+
+		expect(response.status).toBe(200);
 		expect(listConversationsHeadersMock).toHaveBeenCalledWith(
 			{},
 			{

--- a/apps/api/src/rest/routers/conversation.ts
+++ b/apps/api/src/rest/routers/conversation.ts
@@ -2043,12 +2043,21 @@ conversationRouter.openapi(
 			return privateContext;
 		}
 
+		const actor = await requirePrivateConversationActor({
+			c,
+			db: extracted.db,
+			apiKey: privateContext.apiKey,
+			organizationId: privateContext.organization.id,
+			websiteTeamId: privateContext.website.teamId,
+			required: false,
+		});
+
 		const [planInfo, result] = await Promise.all([
 			getPlanForWebsite(privateContext.website),
 			listConversationsHeaders(extracted.db, {
 				organizationId: privateContext.organization.id,
 				websiteId: privateContext.website.id,
-				userId: null,
+				userId: actor?.userId ?? null,
 				limit: extracted.query.limit,
 				cursor: extracted.query.cursor ?? null,
 			}),


### PR DESCRIPTION
## Summary
- make the private REST `/conversations/inbox` route resolve the acting teammate when available
- pass that teammate `userId` into `listConversationsHeaders(...)` so dashboard inbox items can surface teammate-specific `lastSeenAt`
- keep actorless private-key integrations working by falling back to `userId: null`
- add regression tests for both the actor-aware and actorless inbox cases

## Problem
The backend already models two distinct seen concepts:
- visitor seen state via `visitorLastSeenAt`
- dashboard teammate read state via `conversation_seen.userId -> lastSeenAt`

The shared dashboard header query already supports teammate-specific `lastSeenAt`, and the tRPC dashboard path passes the acting `user.id` into that query.

However, the private REST inbox route currently hardcodes `userId: null` when calling `listConversationsHeaders(...)`. That means REST dashboard clients never receive teammate-specific `lastSeenAt` from inbox payloads, even when the private key resolves to a valid actor user.

## Reasoning
This PR assumes the private REST inbox is intended to behave like the dashboard surface, not like the public/widget surface.

Why this looks like a bug rather than an intentional design:
- the inbox response schema documents `lastSeenAt` as user-specific when available
- `listConversationsHeaders(...)` computes teammate `lastSeenAt` already
- the tRPC dashboard path passes `user.id` into that same query
- `POST /conversations/{id}/read` explicitly writes read state for the acting teammate
- only the private REST inbox route drops actor context by forcing `userId: null`

So the narrow fix here is to let the private REST inbox use the resolved actor user when one exists.

## Assumptions
This PR is only correct if these assumptions are correct:
- `lastSeenAt` on private inbox items is teammate-specific, not visitor-specific
- private REST inbox is intended to support the same unread/read semantics as the dashboard tRPC path
- linked private keys or explicit actor-user headers should influence inbox `lastSeenAt`
- actorless private-key integrations should still be allowed and should keep receiving `lastSeenAt: null`
- public/widget routes should continue to use visitor seen state and are intentionally out of scope here

If any of those assumptions are wrong, the change should be reconsidered.

## Scope
This PR intentionally does **not**:
- change public/widget conversation routes
- change the REST `markRead` response shape
- change realtime behavior
- change frontend client logic directly

It only fixes actor propagation for the private REST inbox route.

## Testing
- `bun test apps/api/src/rest/routers/conversation-auth.test.ts`
- added coverage for:
  - private inbox with a resolved actor user
  - private inbox without teammate context