### PR TITLE
Add team-level lastSeenAt to conversation headers

### DIFF
--- a/apps/api/src/db/queries/conversation.ts
+++ b/apps/api/src/db/queries/conversation.ts
@@ -589,6 +589,7 @@ export async function listConversationsHeaders(
 
 	const seenDataMap = new Map<string, ConversationSeen[]>();
 	const userLastSeenMap = new Map<string, string | null>();
+	const teamLastSeenMap = new Map<string, string | null>();
 
 	for (const seen of seenRows) {
 		const collection = seenDataMap.get(seen.conversationId) ?? [];
@@ -608,6 +609,19 @@ export async function listConversationsHeaders(
 				const candidateDate = new Date(candidate);
 				if (candidateDate > currentDate) {
 					userLastSeenMap.set(seen.conversationId, candidate);
+				}
+			}
+		}
+
+		if (seen.userId && seen.lastSeenAt) {
+			const currentTeamLastSeen = teamLastSeenMap.get(seen.conversationId);
+			if (!currentTeamLastSeen) {
+				teamLastSeenMap.set(seen.conversationId, seen.lastSeenAt);
+			} else {
+				const currentDate = new Date(currentTeamLastSeen);
+				const candidateDate = new Date(seen.lastSeenAt);
+				if (candidateDate > currentDate) {
+					teamLastSeenMap.set(seen.conversationId, seen.lastSeenAt);
 				}
 			}
 		}
@@ -652,6 +666,7 @@ export async function listConversationsHeaders(
 			viewIds: viewIdsMap.get(conversationId) ?? [],
 			lastMessageAt,
 			lastSeenAt: userLastSeenMap.get(conversationId) ?? null,
+			teamLastSeenAt: teamLastSeenMap.get(conversationId) ?? null,
 			lastMessageTimelineItem,
 			lastTimelineItem,
 			activeClarification:
@@ -808,6 +823,18 @@ export async function getConversationHeader(
 			}, null)
 		: null;
 
+	const teamLastSeenAt = seenRows.reduce<string | null>((acc, seen) => {
+		if (!seen.userId || !seen.lastSeenAt) {
+			return acc;
+		}
+		if (!acc) {
+			return seen.lastSeenAt;
+		}
+		return new Date(seen.lastSeenAt) > new Date(acc)
+			? seen.lastSeenAt
+			: acc;
+	}, null);
+
 	return {
 		...row.conversation,
 		visitor: {
@@ -828,6 +855,7 @@ export async function getConversationHeader(
 		viewIds,
 		lastMessageAt,
 		lastSeenAt: userLastSeenAt ?? null,
+		teamLastSeenAt: teamLastSeenAt ?? null,
 		lastMessageTimelineItem,
 		lastTimelineItem,
 		activeClarification:

--- a/apps/api/src/rest/routers/conversation-auth.test.ts
+++ b/apps/api/src/rest/routers/conversation-auth.test.ts
@@ -259,6 +259,7 @@ function createInboxItem(overrides: Partial<Record<string, unknown>> = {}) {
 		deletedAt: null,
 		lastMessageAt: "2026-04-07T11:00:00.000Z",
 		lastSeenAt: null,
+		teamLastSeenAt: null,
 		lastMessageTimelineItem: null,
 		lastTimelineItem: null,
 		activeClarification: null,
@@ -399,6 +400,47 @@ describe("conversation auth and inbox routes", () => {
 			priority: "vip",
 			mrr: 299,
 		});
+	});
+
+	it("includes teamLastSeenAt in private inbox responses", async () => {
+		listConversationsHeadersMock.mockResolvedValue({
+			items: [
+				createInboxItem({
+					lastSeenAt: "2026-04-07T11:30:00.000Z",
+					teamLastSeenAt: "2026-04-07T12:00:00.000Z",
+				}),
+			],
+			nextCursor: null,
+		});
+		safelyExtractRequestQueryMock.mockResolvedValue({
+			db: {},
+			apiKey: { keyType: APIKeyType.PRIVATE },
+			organization: { id: "org-1" },
+			website: { id: "site-1", organizationId: "org-1", teamId: "team-1" },
+			query: {
+				limit: 20,
+				cursor: null,
+			},
+		});
+
+		const { conversationRouter } = await conversationRouterModulePromise;
+		const response = await conversationRouter.request(
+			new Request("http://localhost/inbox?limit=20", {
+				method: "GET",
+			})
+		);
+		const payload = (await response.json()) as {
+			items: Array<{
+				lastSeenAt: string | null;
+				teamLastSeenAt: string | null;
+			}>;
+		};
+
+		expect(response.status).toBe(200);
+		expect(payload.items[0]?.lastSeenAt).toBe("2026-04-07T11:30:00.000Z");
+		expect(payload.items[0]?.teamLastSeenAt).toBe(
+			"2026-04-07T12:00:00.000Z"
+		);
 	});
 
 	it("allows private API keys to read a conversation without a visitor header", async () => {

--- a/apps/api/src/ws/router.test.ts
+++ b/apps/api/src/ws/router.test.ts
@@ -525,6 +525,7 @@ describe("conversationCreated handler", () => {
 					deletedAt: null,
 					lastMessageAt: null,
 					lastSeenAt: null,
+					teamLastSeenAt: null,
 					visitorRating: null,
 					visitorRatingAt: null,
 					lastTimelineItem: null,

--- a/packages/types/src/api/conversation.ts
+++ b/packages/types/src/api/conversation.ts
@@ -280,6 +280,10 @@ export const conversationInboxItemSchema = z
 			description:
 				"User-specific last-seen timestamp when available, otherwise null.",
 		}),
+		teamLastSeenAt: nullableApiTimestampSchema.openapi({
+			description:
+				"Most recent last-seen timestamp across all human teammates who have seen the conversation, otherwise null.",
+		}),
 		lastMessageTimelineItem: timelineItemSchema.nullable().openapi({
 			description: "Latest message timeline item for the conversation, if any.",
 		}),

--- a/packages/types/src/trpc/conversation.ts
+++ b/packages/types/src/trpc/conversation.ts
@@ -110,6 +110,7 @@ export const conversationHeaderSchema = z.object({
 	deletedAt: z.string().nullable(),
 	lastMessageAt: z.string().nullable(),
 	lastSeenAt: z.string().nullable(),
+	teamLastSeenAt: z.string().nullable(),
 	lastMessageTimelineItem: timelineItemSchema.nullable(),
 	lastTimelineItem: timelineItemSchema.nullable(),
 	activeClarification: conversationClarificationSummarySchema.nullable(),


### PR DESCRIPTION
## Summary
- add `teamLastSeenAt` to shared conversation header / inbox response types
- compute it from the most recent `conversation_seen.lastSeenAt` across all human teammate `userId` rows
- expose it through the existing header query layer used by REST inbox, tRPC dashboard headers, and header-based realtime payloads
- add REST auth coverage for the new field and update the websocket header fixture

## Why
Today the backend exposes:
- `lastSeenAt`: current teammate-specific read state
- `visitor.lastSeenAt` / `visitorLastSeenAt`: visitor read/presence state
- `seenData`: full per-actor receipt rows

That is enough for per-user unread state, but it makes it hard for dashboard clients to implement a lightweight "someone on the team already saw this" UI without either:
- fetching `/seen` for many rows, or
- inferring from message authorship

This PR adds a dedicated aggregate field on conversation headers so clients can build a team-aware seen hint without extra per-conversation API calls.

## What this changes
`teamLastSeenAt` is defined as:
- the max `lastSeenAt` across `conversation_seen` rows where `userId IS NOT NULL`
- ignoring visitor and AI seen rows

The existing `lastSeenAt` behavior stays unchanged:
- it remains scoped to the current dashboard teammate when a `userId` is available
- it remains `null` when there is no acting teammate context

## Assumptions
This PR is only correct if these assumptions match the intended product semantics:

1. `lastSeenAt` on conversation headers is teammate-specific, not visitor-specific.
2. A separate team-level aggregate is useful and should be exposed explicitly rather than inferred client-side.
3. `teamLastSeenAt` should include only human teammate `userId` receipts.
4. `teamLastSeenAt` should not include visitor receipts.
5. `teamLastSeenAt` should not include AI agent receipts.
6. Multiple teammates can have different personal `lastSeenAt` values while sharing the same `teamLastSeenAt` aggregate.
7. This is intended as an additive signal for dashboard clients and should not change existing per-user unread semantics.
8. Returning `teamLastSeenAt = null` is still correct when no human teammate has seen the conversation.

If any of those assumptions are wrong, this PR should be adjusted or rejected rather than merged as-is.

## Scope boundaries
This PR intentionally does not:
- change how `POST /read` or `POST /unread` work
- change visitor/widget seen semantics
- change unread logic in the web dashboard
- add any new endpoints

It only adds an aggregate field to the existing header shape.

## Verification
- `bun test apps/api/src/rest/routers/conversation-auth.test.ts`
- `bun test apps/api/src/ws/router.test.ts`

## Notes
This is designed to be a clean forward-compatible backend addition:
- existing clients can ignore the field
- new clients can adopt it without extra API load
- it stays aligned with the current per-actor `conversation_seen` storage model