### PR TITLE
chore(release): gate SDK tests in CI and fix protocol publish target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,18 @@ jobs:
       - name: Test protocol package
         run: bun run test --filter @cossistant/protocol
 
+      # The SDK regression suites pin the provider lifecycle, data-hook and
+      # embed behaviour. They are the safety net for the published packages, so
+      # they gate merges rather than relying on a local `bun test` run.
+      - name: Test SDK packages
+        run: >-
+          bun run test
+          --filter @cossistant/react
+          --filter @cossistant/core
+          --filter @cossistant/types
+          --filter @cossistant/next
+          --filter @cossistant/browser
+
       - name: Test REST OpenAPI contract
         # Run this file on its own: bun's mock.module registrations are global to
         # the test process, so partial factories in other files leak across a

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -49,9 +49,9 @@
     "generate:openapi": "bun run scripts/generate-openapi.ts",
     "check:openapi": "bun run scripts/generate-openapi.ts --check",
     "prepare-package": "bun ../../scripts/prepare-package.ts",
-    "pub:release": "bun run build && npm publish --access public",
-    "pub:beta": "bun run build && npm publish --access public --tag beta --no-git-checks",
-    "pub:next": "bun run build && npm publish --access public --tag next --no-git-checks",
+    "pub:release": "bun run build && npm publish ./dist --access public",
+    "pub:beta": "bun run build && npm publish ./dist --access public --tag beta --no-git-checks",
+    "pub:next": "bun run build && npm publish ./dist --access public --tag next --no-git-checks",
     "lint": "biome check .",
     "test": "bun test src",
     "check-types": "tsc --noEmit --project tsconfig.json"


### PR DESCRIPTION
Two release-hygiene gaps found while auditing #161. Both are small and independent of that PR's review.

## 1. CI never ran the SDK regression suites

`@cossistant/{react,core,types,next,browser}` have no `test` script, so `turbo run test` skipped them entirely — the suites only ever ran locally, by hand.

#161 adds the `test` scripts. This adds the CI step that consumes them, so the provider-lifecycle, data-hook and embed regressions gate merges.

Ordering is safe either way:
- **Merged before #161** — no `test` task exists yet, so turbo executes nothing and the step passes. Verified green against current `main`.
- **Merged after #161** — the step runs 473 tests across the five packages (react 301, core 137, browser 18, types 14, next 3).

The step is deliberately *not* in #161: that branch's `ci.yml` predates the protocol steps from #162, so editing it there produces a merge conflict and would cost #161 its clean merge status.

## 2. `@cossistant/protocol` publishes a broken tarball

`pub:*` used bare `npm publish`, which ignores `publishConfig.directory`. Combined with `files: ["dist"]`, the tarball root `package.json` still pointed `main`/`exports` at `./src/*.ts` — excluded from the tarball — so **all 12 entry points resolved to missing files**.

```
before: 12 entrypoints, 12 missing
after:  12 entrypoints,  0 missing
```

#161 fixed this for `react`/`next`/`browser`; its follow-up commit fixed `core`/`types`/`tiny-markdown`. `protocol` is the last one.

To be clear about blast radius: **`changeset publish` — the CI release path — was never affected.** It resolves `publishConfig.directory` and calls `npm publish <dir>`. This only ever broke a manual `bun run pub:release`.

## Verification

All 7 CI gates pass on this branch against current `main`: `check-types`, `check:openapi`, protocol tests, the new SDK test step, the REST OpenAPI contract test, browser embed build, example app build.

## Follow-up not included here

Re-enabling the browser embed size gate. It's currently disabled, and `main` is **+65.2 KB gzip over the recorded baseline**. #161 brings the widget back to +3.3 KB, so the gate becomes enforceable again — but only once #161 has landed, since the baselines have to reflect the post-merge build. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)