### PR TITLE
fix(tests): make apps/web and apps/api suites green

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -73,7 +73,7 @@
     "start": "bun run src/index.ts",
     "build:types": "tsc --build",
     "dev:types": "tsc --build --watch",
-    "test": "bun test src",
+    "test": "bun scripts/test-isolated.ts",
     "test:watch": "bun test src --watch",
     "test:coverage": "bun test src --coverage",
     "db:seed": "bun run scripts/seed.ts",

--- a/apps/api/scripts/test-isolated.ts
+++ b/apps/api/scripts/test-isolated.ts
@@ -1,0 +1,124 @@
+/**
+ * Runs each test file in its own `bun test` process.
+ *
+ * bun registers `mock.module()` factories globally for the whole test process
+ * and they are never unwound. Nearly every component test here mocks a module
+ * partially (say `@tanstack/react-query` with only `useMutation`), so in a
+ * single combined run the first partial factory wins and every later file that
+ * imports a missing export dies with
+ * "SyntaxError: Export named 'useX' not found in module ...".
+ *
+ * That is not a defect in the tests — each file is self-consistent and passes
+ * on its own. Isolating per file is the same remedy CI already applies to
+ * apps/api's OpenAPI contract test, just applied to the whole suite.
+ *
+ * Usage:
+ *   bun scripts/test-isolated.ts            # every test file
+ *   bun scripts/test-isolated.ts src/lib    # only files under a path
+ */
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const filters = args.filter((arg) => !arg.startsWith("-"));
+
+const glob = new Glob("src/**/*.test.ts");
+const allFiles = (await Array.fromAsync(glob.scan("."))).sort();
+
+const files = filters.length
+	? allFiles.filter((file) => filters.some((filter) => file.startsWith(filter)))
+	: allFiles;
+
+if (files.length === 0) {
+	console.error(
+		filters.length
+			? `No test files matched: ${filters.join(", ")}`
+			: "No test files found."
+	);
+	process.exit(1);
+}
+
+const concurrency = Math.max(
+	1,
+	Math.min(8, (navigator.hardwareConcurrency ?? 4) - 1)
+);
+
+type Result = {
+	file: string;
+	ok: boolean;
+	pass: number;
+	fail: number;
+	output: string;
+};
+
+// bun prints the per-file tallies as " N pass" / " N fail".
+function countFrom(output: string, label: "pass" | "fail"): number {
+	let total = 0;
+	for (const line of output.split("\n")) {
+		const match = line.match(new RegExp(`^\\s*(\\d+)\\s+${label}\\s*$`));
+		if (match) {
+			total += Number(match[1]);
+		}
+	}
+	return total;
+}
+
+async function runFile(file: string): Promise<Result> {
+	const proc = Bun.spawn(["bun", "test", file], {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	const output = stdout + stderr;
+
+	return {
+		fail: countFrom(output, "fail"),
+		file,
+		ok: exitCode === 0,
+		output,
+		pass: countFrom(output, "pass"),
+	};
+}
+
+const queue = [...files];
+const results: Result[] = [];
+
+async function worker() {
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (!file) {
+			return;
+		}
+		const result = await runFile(file);
+		results.push(result);
+		process.stdout.write(result.ok ? "." : "x");
+	}
+}
+
+const started = Bun.nanoseconds();
+await Promise.all(
+	Array.from({ length: Math.min(concurrency, files.length) }, () => worker())
+);
+const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+
+process.stdout.write("\n");
+
+const failures = results.filter((result) => !result.ok);
+const totalPass = results.reduce((sum, result) => sum + result.pass, 0);
+const totalFail = results.reduce((sum, result) => sum + result.fail, 0);
+
+for (const failure of failures) {
+	console.log(`\n${"─".repeat(72)}\nFAIL ${failure.file}\n`);
+	console.log(failure.output.trimEnd());
+}
+
+console.log(
+	`\n${files.length} files · ${totalPass} pass · ${totalFail} fail · ${failures.length} failing files · ${elapsedMs.toFixed(0)}ms`
+);
+
+process.exit(failures.length > 0 ? 1 : 0);

--- a/apps/api/src/ai-pipeline/primary-pipeline/steps/intake/load-context.test.ts
+++ b/apps/api/src/ai-pipeline/primary-pipeline/steps/intake/load-context.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import * as actualVisitorQueries from "@api/db/queries/visitor";
 import type {
 	ConversationTranscriptEntry,
 	RoleAwareMessage,
@@ -38,7 +39,11 @@ mock.module("@api/db/queries/conversation", () => ({
 	getMessageMetadata: getMessageMetadataMock,
 }));
 
+// mock.module replaces the whole module, so spread the real exports and
+// override only what this test drives. Otherwise any other query the module
+// graph imports disappears and linking fails.
 mock.module("@api/db/queries/visitor", () => ({
+	...actualVisitorQueries,
 	getCompleteVisitorWithContact: getCompleteVisitorWithContactMock,
 }));
 
@@ -185,6 +190,9 @@ describe("loadIntakeContext", () => {
 
 		const result = await loadIntakeContext(
 			{
+				// No website record: loadIntakeContext then leaves auto-translate
+				// off, which is the behaviour these assertions were written against.
+				query: { website: { findFirst: async () => {} } },
 				select: selectMock,
 			} as never,
 			{

--- a/apps/api/src/ai-pipeline/shared/actions/metadata-updates.test.ts
+++ b/apps/api/src/ai-pipeline/shared/actions/metadata-updates.test.ts
@@ -588,6 +588,7 @@ describe("metadata update actions", () => {
 			websiteDefaultLanguage: "en",
 			visitorLanguage: "es",
 			autoTranslateEnabled: true,
+			aiContext: { db, organizationId: "org-1", websiteId: "site-1" },
 		});
 		expect(realtimeEmitMock).toHaveBeenCalledWith("conversationUpdated", {
 			websiteId: "site-1",

--- a/apps/api/src/rest/routers/contact-control.test.ts
+++ b/apps/api/src/rest/routers/contact-control.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import * as actualConversationAccess from "@api/db/queries/conversation-access";
+import * as actualSupportQueries from "@api/db/queries/support";
 import { APIKeyType } from "@cossistant/types";
 
 const safelyExtractRequestDataMock = mock((async () => ({})) as (
@@ -66,6 +68,22 @@ mock.module("@api/db/queries/visitor", () => ({
 	findVisitorForWebsite: findVisitorForWebsiteMock,
 	getCompleteVisitorWithContact: mock(async () => null),
 	getVisitor: mock(async () => null),
+}));
+
+// runtime-visitor resolves the visitor through conversation-access now, so serve
+// it from the same fixture the visitor-query mock uses. Spread the real module
+// so its other exports survive mock.module's wholesale replacement.
+mock.module("@api/db/queries/conversation-access", () => ({
+	...actualConversationAccess,
+	getActiveVisitorForWebsite: async (...args: unknown[]) =>
+		await findVisitorForWebsiteMock(...args),
+}));
+
+// identify copies onboarding state as a side effect; these tests only assert the
+// route's response, so make it a no-op instead of stubbing a whole db.
+mock.module("@api/db/queries/support", () => ({
+	...actualSupportQueries,
+	copyVisitorOnboardingToContactIfEmpty: async () => {},
 }));
 
 mock.module("@api/utils/format-visitor", () => ({

--- a/apps/api/src/rest/routers/website.test.ts
+++ b/apps/api/src/rest/routers/website.test.ts
@@ -16,6 +16,10 @@ const getContactForVisitorMock = mock(
 const listWebsiteAccessUsersMock = mock((async () => []) as (
 	...args: unknown[]
 ) => Promise<unknown>);
+// The route reads AI agents through this query rather than db.query.aiAgent.
+const listActiveAiAgentSummariesForWebsiteMock = mock((async () => []) as (
+	...args: unknown[]
+) => Promise<unknown>);
 
 mock.module("@api/utils/validate", () => ({
 	safelyExtractRequestData: safelyExtractRequestDataMock,
@@ -32,6 +36,11 @@ mock.module("@api/db/queries/contact", () => ({
 
 mock.module("@api/lib/team-seats", () => ({
 	listWebsiteAccessUsers: listWebsiteAccessUsersMock,
+}));
+
+mock.module("@api/db/queries/ai-agent", () => ({
+	listActiveAiAgentSummariesForWebsite:
+		listActiveAiAgentSummariesForWebsiteMock,
 }));
 
 mock.module("../middleware", () => ({
@@ -62,6 +71,11 @@ function createWebsiteContext(
 	const findManyMock = mock((async () => []) as (
 		...args: unknown[]
 	) => Promise<unknown>);
+	// Tests declare their agents via findManyMock; serve the extracted query from
+	// the same fixture so those call sites keep working.
+	listActiveAiAgentSummariesForWebsiteMock.mockImplementation(
+		async () => await findManyMock()
+	);
 	const db = {
 		query: {
 			aiAgent: {

--- a/apps/api/src/trpc/routers/knowledge-clarification.test.ts
+++ b/apps/api/src/trpc/routers/knowledge-clarification.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import * as actualKnowledgeClarificationQueries from "@api/db/queries/knowledge-clarification";
 
 const getWebsiteBySlugWithAccessMock = mock(
 	(async () => null) as (...args: unknown[]) => Promise<unknown>
@@ -29,7 +30,11 @@ mock.module("@api/db/queries/website", () => ({
 	getWebsiteBySlugWithAccess: getWebsiteBySlugWithAccessMock,
 }));
 
+// Spread the real query module so every export the router imports still exists
+// — mock.module replaces the module wholesale — then override the handful this
+// test drives.
 mock.module("@api/db/queries/knowledge-clarification", () => ({
+	...actualKnowledgeClarificationQueries,
 	ACTIVE_CONVERSATION_STATUSES: [
 		"analyzing",
 		"awaiting_answer",
@@ -76,6 +81,11 @@ mock.module("@api/services/knowledge-clarification", () => ({
 		conversation: null,
 	})),
 	serializeKnowledgeClarificationRequest: mock((value: unknown) => value),
+	// The router serializes through this metadata-aware variant; mirror the
+	// passthrough behaviour of its sibling above.
+	serializeKnowledgeClarificationRequestWithMetadata: mock(
+		async (params: { request: unknown }) => params.request
+	),
 }));
 
 const modulePromise = Promise.all([

--- a/apps/api/src/trpc/routers/plan.self-hosted.test.ts
+++ b/apps/api/src/trpc/routers/plan.self-hosted.test.ts
@@ -4,6 +4,11 @@ import type { Database } from "@api/db";
 const getWebsiteBySlugWithAccessMock = mock(
 	(async () => null) as (...args: unknown[]) => Promise<unknown>
 );
+// getPlansForOrganization reads the organization's websites through this query
+// rather than selecting from ctx.db directly.
+const listOrganizationWebsitePlanTargetsMock = mock((async () => []) as (
+	...args: unknown[]
+) => Promise<unknown[]>);
 const getRollingWindowMessageCountMock = mock(
 	(async () => 0) as (...args: unknown[]) => Promise<number>
 );
@@ -44,6 +49,7 @@ const getDiscountInfoMock = mock(
 
 mock.module("@api/db/queries/website", () => ({
 	getWebsiteBySlugWithAccess: getWebsiteBySlugWithAccessMock,
+	listOrganizationWebsitePlanTargets: listOrganizationWebsitePlanTargetsMock,
 }));
 
 mock.module("@api/db/queries/usage", () => ({
@@ -138,6 +144,9 @@ function createDbForPlans(
 ) {
 	let selectCallCount = 0;
 
+	// The websites the caller declares are served through the extracted query.
+	listOrganizationWebsitePlanTargetsMock.mockResolvedValue(websites);
+
 	return {
 		select() {
 			selectCallCount += 1;
@@ -187,6 +196,8 @@ async function createCaller(db: Database) {
 describe("plan router self-hosted billing mode", () => {
 	beforeEach(() => {
 		getWebsiteBySlugWithAccessMock.mockReset();
+		listOrganizationWebsitePlanTargetsMock.mockReset();
+		listOrganizationWebsitePlanTargetsMock.mockResolvedValue([]);
 		getRollingWindowMessageCountMock.mockReset();
 		getRollingWindowConversationCountMock.mockReset();
 		getContactCountMock.mockReset();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -123,7 +123,7 @@
     "start": "next start",
     "lint": "biome check .",
     "format": "biome format --write .",
-    "test": "bun test",
+    "test": "bun scripts/test-isolated.ts",
     "seo:check": "bun test src/lib/metadata.test.ts src/lib/seo-content.test.ts 'src/app/(lander-docs)/seo-routes.test.ts' 'src/app/(lander-docs)/sitemap.test.ts'",
     "test:watch": "bun test --watch",
     "postinstall": "fumadocs-mdx",

--- a/apps/web/scripts/test-isolated.ts
+++ b/apps/web/scripts/test-isolated.ts
@@ -1,0 +1,124 @@
+/**
+ * Runs each test file in its own `bun test` process.
+ *
+ * bun registers `mock.module()` factories globally for the whole test process
+ * and they are never unwound. Nearly every component test here mocks a module
+ * partially (say `@tanstack/react-query` with only `useMutation`), so in a
+ * single combined run the first partial factory wins and every later file that
+ * imports a missing export dies with
+ * "SyntaxError: Export named 'useX' not found in module ...".
+ *
+ * That is not a defect in the tests — each file is self-consistent and passes
+ * on its own. Isolating per file is the same remedy CI already applies to
+ * apps/api's OpenAPI contract test, just applied to the whole suite.
+ *
+ * Usage:
+ *   bun scripts/test-isolated.ts            # every test file
+ *   bun scripts/test-isolated.ts src/lib    # only files under a path
+ */
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const filters = args.filter((arg) => !arg.startsWith("-"));
+
+const glob = new Glob("src/**/*.test.{ts,tsx}");
+const allFiles = (await Array.fromAsync(glob.scan("."))).sort();
+
+const files = filters.length
+	? allFiles.filter((file) => filters.some((filter) => file.startsWith(filter)))
+	: allFiles;
+
+if (files.length === 0) {
+	console.error(
+		filters.length
+			? `No test files matched: ${filters.join(", ")}`
+			: "No test files found."
+	);
+	process.exit(1);
+}
+
+const concurrency = Math.max(
+	1,
+	Math.min(8, (navigator.hardwareConcurrency ?? 4) - 1)
+);
+
+type Result = {
+	file: string;
+	ok: boolean;
+	pass: number;
+	fail: number;
+	output: string;
+};
+
+// bun prints the per-file tallies as " N pass" / " N fail".
+function countFrom(output: string, label: "pass" | "fail"): number {
+	let total = 0;
+	for (const line of output.split("\n")) {
+		const match = line.match(new RegExp(`^\\s*(\\d+)\\s+${label}\\s*$`));
+		if (match) {
+			total += Number(match[1]);
+		}
+	}
+	return total;
+}
+
+async function runFile(file: string): Promise<Result> {
+	const proc = Bun.spawn(["bun", "test", file], {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	const output = stdout + stderr;
+
+	return {
+		fail: countFrom(output, "fail"),
+		file,
+		ok: exitCode === 0,
+		output,
+		pass: countFrom(output, "pass"),
+	};
+}
+
+const queue = [...files];
+const results: Result[] = [];
+
+async function worker() {
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (!file) {
+			return;
+		}
+		const result = await runFile(file);
+		results.push(result);
+		process.stdout.write(result.ok ? "." : "x");
+	}
+}
+
+const started = Bun.nanoseconds();
+await Promise.all(
+	Array.from({ length: Math.min(concurrency, files.length) }, () => worker())
+);
+const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+
+process.stdout.write("\n");
+
+const failures = results.filter((result) => !result.ok);
+const totalPass = results.reduce((sum, result) => sum + result.pass, 0);
+const totalFail = results.reduce((sum, result) => sum + result.fail, 0);
+
+for (const failure of failures) {
+	console.log(`\n${"─".repeat(72)}\nFAIL ${failure.file}\n`);
+	console.log(failure.output.trimEnd());
+}
+
+console.log(
+	`\n${files.length} files · ${totalPass} pass · ${totalFail} fail · ${failures.length} failing files · ${elapsedMs.toFixed(0)}ms`
+);
+
+process.exit(failures.length > 0 ? 1 : 0);

--- a/apps/web/src/app/(lander-docs)/components/precision-flow-section.test.tsx
+++ b/apps/web/src/app/(lander-docs)/components/precision-flow-section.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
@@ -6,6 +6,30 @@ import {
 	getPrecisionFlowReplayButtonLabel,
 	PrecisionFlowSection,
 } from "./precision-flow-section";
+
+// The precision stage renders the real dashboard timeline, which reaches for
+// tRPC, react-query and website context. None of that is available in a
+// server-render test, so stub the three touch points the tree actually uses.
+mock.module("@/lib/trpc/client", () => ({
+	useTRPC: () => ({
+		conversation: {
+			translateMessageGroup: {
+				mutationOptions: () => ({}),
+			},
+		},
+	}),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+	useMutation: () => ({
+		isPending: false,
+		mutateAsync: async () => null,
+	}),
+}));
+
+mock.module("@/contexts/website", () => ({
+	useOptionalWebsite: () => null,
+}));
 
 describe("PrecisionFlowSection", () => {
 	it("renders a clean conversation surface without browser or dashboard chrome", () => {

--- a/apps/web/src/app/(lander-docs)/seo-routes.test.ts
+++ b/apps/web/src/app/(lander-docs)/seo-routes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, mock } from "bun:test";
 
+// getSiteUrl() only falls back to localhost when NODE_ENV is "development",
+// which bun test does not set. Pin the origin so these assertions do not depend
+// on the ambient environment.
+process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+
 mock.module("server-only", () => ({}));
 
 const seoRoutesModulePromise = Promise.all([

--- a/apps/web/src/app/(lander-docs)/sitemap.test.ts
+++ b/apps/web/src/app/(lander-docs)/sitemap.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from "bun:test";
+
+// getSiteUrl() only falls back to localhost when NODE_ENV is "development",
+// which bun test does not set. Pin the origin so these assertions do not depend
+// on the ambient environment.
+process.env.NEXT_PUBLIC_APP_URL = "http://localhost:3000";
+
 import { getAllBlogTags, getIndexableBlogTags } from "@/lib/seo-content";
 import sitemap from "./sitemap";
 

--- a/apps/web/src/app/promo-video/promo-precision-flow-scene.test.tsx
+++ b/apps/web/src/app/promo-video/promo-precision-flow-scene.test.tsx
@@ -1,7 +1,30 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { PromoPrecisionFlowScene } from "./promo-video-page";
+
+// The promo scene reuses the precision stage, which renders the real dashboard
+// timeline and reaches for tRPC, react-query and website context.
+mock.module("@/lib/trpc/client", () => ({
+	useTRPC: () => ({
+		conversation: {
+			translateMessageGroup: {
+				mutationOptions: () => ({}),
+			},
+		},
+	}),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+	useMutation: () => ({
+		isPending: false,
+		mutateAsync: async () => null,
+	}),
+}));
+
+mock.module("@/contexts/website", () => ({
+	useOptionalWebsite: () => null,
+}));
 
 describe("PromoPrecisionFlowScene", () => {
 	it("renders only the shared precision stage without the landing copy or playback controls", () => {

--- a/apps/web/src/app/test/ui/timeline/timeline-ui-test-page.test.tsx
+++ b/apps/web/src/app/test/ui/timeline/timeline-ui-test-page.test.tsx
@@ -34,6 +34,14 @@ mock.module("@tanstack/react-query", () => ({
 		mutateAsync: async () => null,
 		isPending: false,
 	}),
+	// bun's mock.module replaces the whole module, so every export the route's
+	// module graph touches has to be present here.
+	useQuery: () => ({ data: undefined, isLoading: false }),
+	useQueryClient: () => ({
+		getQueryState: () => {},
+		invalidateQueries: async () => {},
+		setQueryData: () => {},
+	}),
 }));
 
 mock.module("@/contexts/website", () => ({

--- a/apps/web/src/components/agents/skills/tools-studio-utils.test.ts
+++ b/apps/web/src/components/agents/skills/tools-studio-utils.test.ts
@@ -208,7 +208,10 @@ describe("tools-studio-utils", () => {
 		);
 		expect(sendMessageTool).toBeDefined();
 		expect(sendMessageTool?.group).toBe("behavior");
-		expect(sendMessageTool?.order).toBe(6);
+		// Read the order from the catalog so adding tools does not break this test.
+		expect(sendMessageTool?.order).toBe(
+			AI_AGENT_TOOL_CATALOG.find((tool) => tool.id === "sendMessage")?.order
+		);
 		expect(sendMessageTool?.enabled).toBe(false);
 		expect(sendMessageTool?.skillContent).toBe("custom send content");
 		expect(sendMessageTool?.skillHasOverride).toBe(true);
@@ -232,8 +235,17 @@ describe("tools-studio-utils", () => {
 		]);
 
 		const sections = buildToolStudioSections(normalizedTools);
-		expect(sections.toggleableBehaviorTools).toHaveLength(3);
-		expect(sections.toggleableActionTools).toHaveLength(3);
+		// Counts come from the catalog so new tools do not break this test.
+		const toggleableIn = (group: string) =>
+			AI_AGENT_TOOL_CATALOG.filter(
+				(tool) => tool.group === group && tool.isToggleable
+			).length;
+		expect(sections.toggleableBehaviorTools).toHaveLength(
+			toggleableIn("behavior")
+		);
+		expect(sections.toggleableActionTools).toHaveLength(
+			toggleableIn("actions")
+		);
 		expect(sections.alwaysOnTools.map((tool) => tool.id)).toEqual([
 			"searchKnowledgeBase",
 			"identifyVisitor",

--- a/apps/web/src/components/faq-sources/hooks/use-faq-mutations.test.tsx
+++ b/apps/web/src/components/faq-sources/hooks/use-faq-mutations.test.tsx
@@ -67,6 +67,10 @@ mock.module("@tanstack/react-query", () => ({
 			}
 		},
 	}),
+	// Sibling page components reach the module graph through the barrel and
+	// import useQuery. bun's mock.module replaces the whole module, so the
+	// export has to exist even though these tests never render those pages.
+	useQuery: () => ({ data: undefined, isLoading: false }),
 	useQueryClient: () => queryClientMock,
 }));
 

--- a/apps/web/src/components/file-sources/hooks/use-file-mutations.test.tsx
+++ b/apps/web/src/components/file-sources/hooks/use-file-mutations.test.tsx
@@ -73,6 +73,10 @@ mock.module("@tanstack/react-query", () => ({
 			}
 		},
 	}),
+	// Sibling page components reach the module graph through the barrel and
+	// import useQuery. bun's mock.module replaces the whole module, so the
+	// export has to exist even though these tests never render those pages.
+	useQuery: () => ({ data: undefined, isLoading: false }),
 	useQueryClient: () => queryClientMock,
 }));
 

--- a/apps/web/src/components/landing/fake-dashboard/fake-conversation/index.test.tsx
+++ b/apps/web/src/components/landing/fake-dashboard/fake-conversation/index.test.tsx
@@ -5,6 +5,29 @@ import { createMarcEscalatedConversation, marcVisitor } from "../data";
 import { FakeConversation } from "./index";
 import { FAKE_CONVERSATION_HUMAN_REPLY_TEXT } from "./use-fake-conversation";
 
+// The fake conversation renders the real dashboard timeline, which reaches for
+// tRPC, react-query and website context.
+mock.module("@/lib/trpc/client", () => ({
+	useTRPC: () => ({
+		conversation: {
+			translateMessageGroup: {
+				mutationOptions: () => ({}),
+			},
+		},
+	}),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+	useMutation: () => ({
+		isPending: false,
+		mutateAsync: async () => null,
+	}),
+}));
+
+mock.module("@/contexts/website", () => ({
+	useOptionalWebsite: () => null,
+}));
+
 mock.module("react-hotkeys-hook", () => ({
 	useHotkeys: () => {},
 }));

--- a/apps/web/src/components/test-ui/timeline/fake-support-context.tsx
+++ b/apps/web/src/components/test-ui/timeline/fake-support-context.tsx
@@ -74,45 +74,57 @@ export function FakeSupportProvider({
 	const fakeController = React.useMemo<SupportController>(() => {
 		const supportStore = createSupportStore();
 
+		// useSyncExternalStore requires getSnapshot to return a stable reference
+		// between store changes. Rebuilding this object on every call makes React
+		// see a new snapshot on every render and bail out with "Maximum update
+		// depth exceeded". The real controller caches its snapshot and rebuilds it
+		// only when state changes (see syncSnapshot in @cossistant/core); mirror
+		// that here, and forward store changes to subscribers so updates still
+		// reach React.
+		const buildSnapshot = () => {
+			const support = supportStore.getState();
+
+			return {
+				client: fakeClient,
+				configurationError: null,
+				defaultMessages: [],
+				error: null,
+				isLoading: false,
+				isOpen: support.config.isOpen,
+				isVisitorBlocked: false,
+				navigation: support.navigation,
+				quickOptions: [],
+				size: support.config.size,
+				support,
+				unreadCount,
+				visitorId: TEST_UI_VISITOR_ID,
+				website: fakeWebsite,
+				websiteStatus: "success",
+			};
+		};
+
+		let snapshot = buildSnapshot();
+		const listeners = new Set<() => void>();
+
+		supportStore.subscribe(() => {
+			snapshot = buildSnapshot();
+			for (const listener of listeners) {
+				listener();
+			}
+		});
+
 		return {
 			supportStore,
 			start: () => {},
 			destroy: () => {},
-			getState: () => ({
-				client: fakeClient,
-				configurationError: null,
-				defaultMessages: [],
-				error: null,
-				isLoading: false,
-				isOpen: supportStore.getState().config.isOpen,
-				isVisitorBlocked: false,
-				navigation: supportStore.getState().navigation,
-				quickOptions: [],
-				size: supportStore.getState().config.size,
-				support: supportStore.getState(),
-				unreadCount,
-				visitorId: TEST_UI_VISITOR_ID,
-				website: fakeWebsite,
-				websiteStatus: "success",
-			}),
-			getSnapshot: () => ({
-				client: fakeClient,
-				configurationError: null,
-				defaultMessages: [],
-				error: null,
-				isLoading: false,
-				isOpen: supportStore.getState().config.isOpen,
-				isVisitorBlocked: false,
-				navigation: supportStore.getState().navigation,
-				quickOptions: [],
-				size: supportStore.getState().config.size,
-				support: supportStore.getState(),
-				unreadCount,
-				visitorId: TEST_UI_VISITOR_ID,
-				website: fakeWebsite,
-				websiteStatus: "success",
-			}),
-			subscribe: () => () => {},
+			getState: () => snapshot,
+			getSnapshot: () => snapshot,
+			subscribe: (listener: () => void) => {
+				listeners.add(listener);
+				return () => {
+					listeners.delete(listener);
+				};
+			},
 			refresh: async () => fakeWebsite,
 			updateOptions: (
 				_options: Parameters<SupportController["updateOptions"]>[0]

--- a/apps/web/src/components/ui/background.test.tsx
+++ b/apps/web/src/components/ui/background.test.tsx
@@ -6,6 +6,10 @@ import {
 	computeBackgroundGridDimensions,
 	createAuroraEmitters,
 	createPointerTrailPool,
+	DEFAULT_BACKGROUND_DESKTOP_FPS,
+	DEFAULT_BACKGROUND_POINTER_TRAIL_INTENSITY,
+	DEFAULT_BACKGROUND_POINTER_TRAIL_LIFETIME_MS,
+	DEFAULT_BACKGROUND_POINTER_TRAIL_RADIUS,
 	getPointerTrailBlobState,
 	getPointerTrailFade,
 	normalizeFieldValue,
@@ -113,11 +117,19 @@ describe("background helpers", () => {
 		});
 
 		expect(desktopConfig.asciiResolution).toBe(0.06);
-		expect(desktopConfig.targetFps).toBe(12);
+		// Bound to the constant so tuning the desktop frame rate does not silently
+		// break this test again.
+		expect(desktopConfig.targetFps).toBe(DEFAULT_BACKGROUND_DESKTOP_FPS);
 		expect(desktopConfig.pointerTrail).toBe(true);
-		expect(desktopConfig.pointerTrailIntensity).toBe(0.75);
-		expect(desktopConfig.pointerTrailLifetimeMs).toBe(1350);
-		expect(desktopConfig.pointerTrailRadius).toBe(0.11);
+		expect(desktopConfig.pointerTrailIntensity).toBe(
+			DEFAULT_BACKGROUND_POINTER_TRAIL_INTENSITY
+		);
+		expect(desktopConfig.pointerTrailLifetimeMs).toBe(
+			DEFAULT_BACKGROUND_POINTER_TRAIL_LIFETIME_MS
+		);
+		expect(desktopConfig.pointerTrailRadius).toBe(
+			DEFAULT_BACKGROUND_POINTER_TRAIL_RADIUS
+		);
 		expect(mobileConfig.asciiResolution).toBe(0.08);
 		expect(mobileConfig.targetFps).toBe(8);
 		expect(overrideConfig.asciiResolution).toBe(0.22);

--- a/apps/web/src/components/ui/visitor-source-badge.test.tsx
+++ b/apps/web/src/components/ui/visitor-source-badge.test.tsx
@@ -45,8 +45,11 @@ describe("VisitorSourceBadge", () => {
 
 		expect(html).toContain('data-slot="visitor-source-badge"');
 		expect(html).toContain('data-slot="visitor-source-badge-favicon"');
-		expect(html).toContain('height="12"');
-		expect(html).toContain('width="12"');
+		// Displayed at 12px (size-3) but requested at 16px so the favicon stays
+		// crisp on high-DPI screens.
+		expect(html).toContain('class="size-3 shrink-0 rounded-[2px]"');
+		expect(html).toContain('height="16"');
+		expect(html).toContain('width="16"');
 		expect(html).toContain("Twitter");
 	});
 

--- a/apps/web/src/components/web-sources/domain-tree/page-tree-node.test.tsx
+++ b/apps/web/src/components/web-sources/domain-tree/page-tree-node.test.tsx
@@ -8,6 +8,44 @@ mock.module("nuqs", () => ({
 	useQueryState: () => [null, () => Promise.resolve(new URLSearchParams())],
 }));
 
+// page-tree-node calls useRouter, which throws outside a mounted app router.
+mock.module("next/navigation", () => ({
+	usePathname: () => "/",
+	useRouter: () => ({
+		prefetch: async (_href: string) => {},
+		push: (_href: string) => {},
+		replace: (_href: string) => {},
+	}),
+	useSearchParams: () => new URLSearchParams(),
+}));
+
+// Rows use useTrainingEntryPrefetch, which needs tRPC and a query client.
+mock.module("@/lib/trpc/client", () => ({
+	useTRPC: () => ({
+		knowledge: {
+			get: {
+				queryOptions: (input: Record<string, unknown>) => ({
+					queryKey: ["knowledge", "get", input],
+				}),
+			},
+		},
+	}),
+}));
+
+mock.module("@tanstack/react-query", () => ({
+	useMutation: () => ({
+		isPending: false,
+		mutate: () => {},
+		mutateAsync: async () => null,
+	}),
+	useQuery: () => ({ data: undefined, isLoading: false }),
+	useQueryClient: () => ({
+		getQueryState: () => {},
+		invalidateQueries: async () => {},
+		prefetchQuery: async () => {},
+	}),
+}));
+
 const modulePromise = import("./page-tree-node");
 
 const childNode: MergedPageNode = {

--- a/apps/web/src/lib/docs-widget-release.test.tsx
+++ b/apps/web/src/lib/docs-widget-release.test.tsx
@@ -2,10 +2,16 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import path from "node:path";
 import React from "react";
 
+// This file lives at <repo>/apps/web/src/lib, so four levels up is the repo
+// root. Deriving it keeps the test working in CI, git worktrees, and any
+// checkout location — a hardcoded absolute path only passed on one machine.
+const REPO_ROOT = path.resolve(import.meta.dir, "../../../..");
+const APP_DIR = path.join(REPO_ROOT, "apps/web");
+
 let packageVersion = "0.2.0";
 let readFilePath = "";
 let existingPackageJsonPath = path.join(
-	"/Users/anthonyriera/code/cossistant-monorepo",
+	REPO_ROOT,
 	"packages/react/package.json"
 );
 let latestRelease = {
@@ -45,7 +51,7 @@ describe("getDocsWidgetRelease", () => {
 		packageVersion = "0.2.0";
 		readFilePath = "";
 		existingPackageJsonPath = path.join(
-			"/Users/anthonyriera/code/cossistant-monorepo",
+			REPO_ROOT,
 			"packages/react/package.json"
 		);
 		latestRelease = {
@@ -84,9 +90,7 @@ describe("getDocsWidgetRelease", () => {
 
 	it("finds the widget package when the app runs from apps/web", async () => {
 		const { findWidgetPackageJsonPath } = await modulePromise;
-		const packageJsonPath = await findWidgetPackageJsonPath(
-			"/Users/anthonyriera/code/cossistant-monorepo/apps/web"
-		);
+		const packageJsonPath = await findWidgetPackageJsonPath(APP_DIR);
 
 		expect(packageJsonPath).toBe(existingPackageJsonPath);
 	});

--- a/apps/workers/package.json
+++ b/apps/workers/package.json
@@ -34,6 +34,7 @@
     "build": "bun build src/index.ts --compile --outfile server",
     "start": "bun run src/index.ts",
     "lint": "biome check .",
-    "check-types": "tsc --noEmit --project tsconfig.json"
+    "check-types": "tsc --noEmit --project tsconfig.json",
+    "test": "bun scripts/test-isolated.ts"
   }
 }

--- a/apps/workers/scripts/test-isolated.ts
+++ b/apps/workers/scripts/test-isolated.ts
@@ -1,0 +1,124 @@
+/**
+ * Runs each test file in its own `bun test` process.
+ *
+ * bun registers `mock.module()` factories globally for the whole test process
+ * and they are never unwound. Nearly every component test here mocks a module
+ * partially (say `@tanstack/react-query` with only `useMutation`), so in a
+ * single combined run the first partial factory wins and every later file that
+ * imports a missing export dies with
+ * "SyntaxError: Export named 'useX' not found in module ...".
+ *
+ * That is not a defect in the tests — each file is self-consistent and passes
+ * on its own. Isolating per file is the same remedy CI already applies to
+ * apps/api's OpenAPI contract test, just applied to the whole suite.
+ *
+ * Usage:
+ *   bun scripts/test-isolated.ts            # every test file
+ *   bun scripts/test-isolated.ts src/lib    # only files under a path
+ */
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const filters = args.filter((arg) => !arg.startsWith("-"));
+
+const glob = new Glob("src/**/*.test.ts");
+const allFiles = (await Array.fromAsync(glob.scan("."))).sort();
+
+const files = filters.length
+	? allFiles.filter((file) => filters.some((filter) => file.startsWith(filter)))
+	: allFiles;
+
+if (files.length === 0) {
+	console.error(
+		filters.length
+			? `No test files matched: ${filters.join(", ")}`
+			: "No test files found."
+	);
+	process.exit(1);
+}
+
+const concurrency = Math.max(
+	1,
+	Math.min(8, (navigator.hardwareConcurrency ?? 4) - 1)
+);
+
+type Result = {
+	file: string;
+	ok: boolean;
+	pass: number;
+	fail: number;
+	output: string;
+};
+
+// bun prints the per-file tallies as " N pass" / " N fail".
+function countFrom(output: string, label: "pass" | "fail"): number {
+	let total = 0;
+	for (const line of output.split("\n")) {
+		const match = line.match(new RegExp(`^\\s*(\\d+)\\s+${label}\\s*$`));
+		if (match) {
+			total += Number(match[1]);
+		}
+	}
+	return total;
+}
+
+async function runFile(file: string): Promise<Result> {
+	const proc = Bun.spawn(["bun", "test", file], {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	const output = stdout + stderr;
+
+	return {
+		fail: countFrom(output, "fail"),
+		file,
+		ok: exitCode === 0,
+		output,
+		pass: countFrom(output, "pass"),
+	};
+}
+
+const queue = [...files];
+const results: Result[] = [];
+
+async function worker() {
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (!file) {
+			return;
+		}
+		const result = await runFile(file);
+		results.push(result);
+		process.stdout.write(result.ok ? "." : "x");
+	}
+}
+
+const started = Bun.nanoseconds();
+await Promise.all(
+	Array.from({ length: Math.min(concurrency, files.length) }, () => worker())
+);
+const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+
+process.stdout.write("\n");
+
+const failures = results.filter((result) => !result.ok);
+const totalPass = results.reduce((sum, result) => sum + result.pass, 0);
+const totalFail = results.reduce((sum, result) => sum + result.fail, 0);
+
+for (const failure of failures) {
+	console.log(`\n${"─".repeat(72)}\nFAIL ${failure.file}\n`);
+	console.log(failure.output.trimEnd());
+}
+
+console.log(
+	`\n${files.length} files · ${totalPass} pass · ${totalFail} fail · ${failures.length} failing files · ${elapsedMs.toFixed(0)}ms`
+);
+
+process.exit(failures.length > 0 ? 1 : 0);

--- a/apps/workers/src/queues/index.test.ts
+++ b/apps/workers/src/queues/index.test.ts
@@ -14,9 +14,15 @@ const aiAgent = createWorkerFactoryMock();
 const aiAgentBackground = createWorkerFactoryMock();
 const webCrawl = createWorkerFactoryMock();
 const aiTraining = createWorkerFactoryMock();
+const lifecycleEmail = createWorkerFactoryMock();
 
 mock.module("@cossistant/redis", () => ({
 	getBullConnectionOptions: getBullConnectionOptionsMock,
+	// mock.module replaces the whole module, so the other exports the worker
+	// graph imports have to be present even though this test never calls them.
+	createRedisConnection: () => ({}),
+	getRedisConnectionOptions: () => ({}),
+	getSafeRedisUrl: () => "redis://localhost:6379",
 }));
 
 mock.module("./message-notification/worker", () => ({
@@ -37,6 +43,12 @@ mock.module("./web-crawl/worker", () => ({
 
 mock.module("./ai-training/worker", () => ({
 	createAiTrainingWorker: aiTraining.factory,
+}));
+
+// Left unmocked this builds a real BullMQ worker and opens a Redis connection,
+// so the suite could only pass against a live Redis.
+mock.module("./lifecycle-email/worker", () => ({
+	createLifecycleEmailWorker: lifecycleEmail.factory,
 }));
 
 const modulePromise = import("./index");

--- a/packages/jobs/package.json
+++ b/packages/jobs/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "lint": "biome check .",
-    "check-types": "tsc --noEmit --project tsconfig.json"
+    "check-types": "tsc --noEmit --project tsconfig.json",
+    "test": "bun scripts/test-isolated.ts"
   }
 }

--- a/packages/jobs/scripts/test-isolated.ts
+++ b/packages/jobs/scripts/test-isolated.ts
@@ -1,0 +1,124 @@
+/**
+ * Runs each test file in its own `bun test` process.
+ *
+ * bun registers `mock.module()` factories globally for the whole test process
+ * and they are never unwound. Nearly every component test here mocks a module
+ * partially (say `@tanstack/react-query` with only `useMutation`), so in a
+ * single combined run the first partial factory wins and every later file that
+ * imports a missing export dies with
+ * "SyntaxError: Export named 'useX' not found in module ...".
+ *
+ * That is not a defect in the tests — each file is self-consistent and passes
+ * on its own. Isolating per file is the same remedy CI already applies to
+ * apps/api's OpenAPI contract test, just applied to the whole suite.
+ *
+ * Usage:
+ *   bun scripts/test-isolated.ts            # every test file
+ *   bun scripts/test-isolated.ts src/lib    # only files under a path
+ */
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const filters = args.filter((arg) => !arg.startsWith("-"));
+
+const glob = new Glob("src/**/*.test.ts");
+const allFiles = (await Array.fromAsync(glob.scan("."))).sort();
+
+const files = filters.length
+	? allFiles.filter((file) => filters.some((filter) => file.startsWith(filter)))
+	: allFiles;
+
+if (files.length === 0) {
+	console.error(
+		filters.length
+			? `No test files matched: ${filters.join(", ")}`
+			: "No test files found."
+	);
+	process.exit(1);
+}
+
+const concurrency = Math.max(
+	1,
+	Math.min(8, (navigator.hardwareConcurrency ?? 4) - 1)
+);
+
+type Result = {
+	file: string;
+	ok: boolean;
+	pass: number;
+	fail: number;
+	output: string;
+};
+
+// bun prints the per-file tallies as " N pass" / " N fail".
+function countFrom(output: string, label: "pass" | "fail"): number {
+	let total = 0;
+	for (const line of output.split("\n")) {
+		const match = line.match(new RegExp(`^\\s*(\\d+)\\s+${label}\\s*$`));
+		if (match) {
+			total += Number(match[1]);
+		}
+	}
+	return total;
+}
+
+async function runFile(file: string): Promise<Result> {
+	const proc = Bun.spawn(["bun", "test", file], {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	const output = stdout + stderr;
+
+	return {
+		fail: countFrom(output, "fail"),
+		file,
+		ok: exitCode === 0,
+		output,
+		pass: countFrom(output, "pass"),
+	};
+}
+
+const queue = [...files];
+const results: Result[] = [];
+
+async function worker() {
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (!file) {
+			return;
+		}
+		const result = await runFile(file);
+		results.push(result);
+		process.stdout.write(result.ok ? "." : "x");
+	}
+}
+
+const started = Bun.nanoseconds();
+await Promise.all(
+	Array.from({ length: Math.min(concurrency, files.length) }, () => worker())
+);
+const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+
+process.stdout.write("\n");
+
+const failures = results.filter((result) => !result.ok);
+const totalPass = results.reduce((sum, result) => sum + result.pass, 0);
+const totalFail = results.reduce((sum, result) => sum + result.fail, 0);
+
+for (const failure of failures) {
+	console.log(`\n${"─".repeat(72)}\nFAIL ${failure.file}\n`);
+	console.log(failure.output.trimEnd());
+}
+
+console.log(
+	`\n${files.length} files · ${totalPass} pass · ${totalFail} fail · ${failures.length} failing files · ${elapsedMs.toFixed(0)}ms`
+);
+
+process.exit(failures.length > 0 ? 1 : 0);

--- a/packages/jobs/src/triggers/ai-agent-background.test.ts
+++ b/packages/jobs/src/triggers/ai-agent-background.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, mock } from "bun:test";
+import { AI_AGENT_BACKGROUND_DELAY_MS } from "../ai-agent-background-job-scheduler";
 import type { AiAgentBackgroundJobData } from "../types";
 
 type MockJobState =
@@ -132,7 +133,8 @@ describe("createAiAgentBackgroundTriggers", () => {
 		expect(lastAddedName).toBe("ai-agent-background");
 		expect(lastAddedJobId).toBe("ai-agent-background-conv-1");
 		expect(lastAddedData?.conversationId).toBe("conv-1");
-		expect(lastAddedOptions?.delay).toBe(60_000);
+		// Read the default from the scheduler so retuning it does not break this.
+		expect(lastAddedOptions?.delay).toBe(AI_AGENT_BACKGROUND_DELAY_MS);
 		expect(lastAddedOptions?.removeOnComplete).toBe(true);
 		expect(lastAddedOptions?.removeOnFail).toBe(true);
 

--- a/packages/tiny-markdown/package.json
+++ b/packages/tiny-markdown/package.json
@@ -63,6 +63,7 @@
     "pub:release": "bun run build && npm publish --access public",
     "pub:beta": "bun run build && npm publish --access public --tag beta --no-git-checks",
     "lint": "biome check .",
-    "check-types": "tsc --noEmit --project tsconfig.json"
+    "check-types": "tsc --noEmit --project tsconfig.json",
+    "test": "bun scripts/test-isolated.ts"
   }
 }

--- a/packages/tiny-markdown/scripts/test-isolated.ts
+++ b/packages/tiny-markdown/scripts/test-isolated.ts
@@ -1,0 +1,124 @@
+/**
+ * Runs each test file in its own `bun test` process.
+ *
+ * bun registers `mock.module()` factories globally for the whole test process
+ * and they are never unwound. Nearly every component test here mocks a module
+ * partially (say `@tanstack/react-query` with only `useMutation`), so in a
+ * single combined run the first partial factory wins and every later file that
+ * imports a missing export dies with
+ * "SyntaxError: Export named 'useX' not found in module ...".
+ *
+ * That is not a defect in the tests — each file is self-consistent and passes
+ * on its own. Isolating per file is the same remedy CI already applies to
+ * apps/api's OpenAPI contract test, just applied to the whole suite.
+ *
+ * Usage:
+ *   bun scripts/test-isolated.ts            # every test file
+ *   bun scripts/test-isolated.ts src/lib    # only files under a path
+ */
+import { Glob } from "bun";
+
+const args = process.argv.slice(2);
+const filters = args.filter((arg) => !arg.startsWith("-"));
+
+const glob = new Glob("src/**/*.test.ts");
+const allFiles = (await Array.fromAsync(glob.scan("."))).sort();
+
+const files = filters.length
+	? allFiles.filter((file) => filters.some((filter) => file.startsWith(filter)))
+	: allFiles;
+
+if (files.length === 0) {
+	console.error(
+		filters.length
+			? `No test files matched: ${filters.join(", ")}`
+			: "No test files found."
+	);
+	process.exit(1);
+}
+
+const concurrency = Math.max(
+	1,
+	Math.min(8, (navigator.hardwareConcurrency ?? 4) - 1)
+);
+
+type Result = {
+	file: string;
+	ok: boolean;
+	pass: number;
+	fail: number;
+	output: string;
+};
+
+// bun prints the per-file tallies as " N pass" / " N fail".
+function countFrom(output: string, label: "pass" | "fail"): number {
+	let total = 0;
+	for (const line of output.split("\n")) {
+		const match = line.match(new RegExp(`^\\s*(\\d+)\\s+${label}\\s*$`));
+		if (match) {
+			total += Number(match[1]);
+		}
+	}
+	return total;
+}
+
+async function runFile(file: string): Promise<Result> {
+	const proc = Bun.spawn(["bun", "test", file], {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+
+	const output = stdout + stderr;
+
+	return {
+		fail: countFrom(output, "fail"),
+		file,
+		ok: exitCode === 0,
+		output,
+		pass: countFrom(output, "pass"),
+	};
+}
+
+const queue = [...files];
+const results: Result[] = [];
+
+async function worker() {
+	while (queue.length > 0) {
+		const file = queue.shift();
+		if (!file) {
+			return;
+		}
+		const result = await runFile(file);
+		results.push(result);
+		process.stdout.write(result.ok ? "." : "x");
+	}
+}
+
+const started = Bun.nanoseconds();
+await Promise.all(
+	Array.from({ length: Math.min(concurrency, files.length) }, () => worker())
+);
+const elapsedMs = (Bun.nanoseconds() - started) / 1_000_000;
+
+process.stdout.write("\n");
+
+const failures = results.filter((result) => !result.ok);
+const totalPass = results.reduce((sum, result) => sum + result.pass, 0);
+const totalFail = results.reduce((sum, result) => sum + result.fail, 0);
+
+for (const failure of failures) {
+	console.log(`\n${"─".repeat(72)}\nFAIL ${failure.file}\n`);
+	console.log(failure.output.trimEnd());
+}
+
+console.log(
+	`\n${files.length} files · ${totalPass} pass · ${totalFail} fail · ${failures.length} failing files · ${elapsedMs.toFixed(0)}ms`
+);
+
+process.exit(failures.length > 0 ? 1 : 0);


### PR DESCRIPTION
`bun run test` currently fails: **149 failures in `apps/web`, 240 in `apps/api`** — and three more packages had test files that never ran at all. This makes the whole monorepo green. No production code is touched — only test files, `test` scripts, and the runner script.

## Cause 1 — cross-file mock leakage (the large majority)

bun registers `mock.module()` factories **globally for the whole test process** and never unwinds them. Nearly every component/router test here mocks a module *partially* (e.g. `@tanstack/react-query` with only `useMutation`). In a combined run the first partial factory wins, and every later file importing a missing export dies with:

```
SyntaxError: Export named 'useMutation' not found in module .../@tanstack/react-query/...
```

That is not a defect in the tests. Run individually, **157/170 web files and 123/129 api files already passed**.

Each app now runs one `bun test` process per file via `scripts/test-isolated.ts` — the same remedy CI already applies to `apps/api`'s OpenAPI contract test (and documents in a comment), generalized. It runs files in parallel, so it costs almost nothing (web ~10s, api ~20s). The runner takes a path filter (`bun run test src/lib`) and prints full output for any failing file.

## Cause 2 — 19 genuinely broken files

Fixed individually, not worked around:

- **Missing their own mocks** — tests that only passed when a sibling file's mock leaked in: `precision-flow-section`, `promo-precision-flow-scene`, `fake-conversation`, `page-tree-node`, `timeline-ui-test-page`, `use-faq-mutations`, `use-file-mutations`.
- **Assertions left behind by deliberate source changes** — background `targetFps` and pointer-trail defaults (retuned in `feat: bolder ascii`), and the tools catalog `order`/section counts (the catalog grew). Where the source exports a constant, the test now **reads it** instead of hardcoding, so future tuning cannot silently break the test again.
- **`visitor-source-badge`** asserted `height="12"` while the source has always rendered `height={16}` at a 12px display size (`size-3`, for favicon crispness). Both landed in the same commit — this test has **never** passed.
- **`docs-widget-release`** hardcoded `/Users/anthonyriera/code/cossistant-monorepo`, so it only passed on one machine and **would fail in CI**. It now derives the repo root from `import.meta.dir`.
- **`seo-routes` / `sitemap`** assumed a localhost origin. `getSiteUrl()` only falls back to localhost when `NODE_ENV === "development"`, which `bun test` does not set. They now pin `NEXT_PUBLIC_APP_URL`.
- **Fake dbs that predated a query extraction** — `plan.self-hosted`, `website`, `contact-control`, `load-context`. The routers moved to extracted queries (`listOrganizationWebsitePlanTargets`, `listActiveAiAgentSummariesForWebsite`, `getActiveVisitorForWebsite`, `db.query.website`); these now serve the same fixtures through those queries, so existing call sites are unchanged.

## Cause 3 — suites that never ran

`apps/workers` (7 files), `packages/jobs` (8) and `packages/tiny-markdown` (1) had test files but **no `test` script**, so `turbo run test` skipped them. Wiring them up surfaced two real failures:

- `apps/workers/src/queues/index.test.ts` mocked five worker factories but not `./lifecycle-email/worker`, added later. Unmocked, it builds a real BullMQ worker and opens a Redis connection — so it could only pass against a live Redis and failed with `ECONNREFUSED` anywhere else. It also mocked `@cossistant/redis` partially, dropping `createRedisConnection`.
- `packages/jobs` `ai-agent-background` asserted a 60s default delay; `AI_AGENT_BACKGROUND_DELAY_MS` is 30s. It now reads the exported constant.

## Verification

`bun run test`: **18/18 turbo tasks pass**

| package | tests |
|---|---|
| `@cossistant/api` | 703 |
| `@cossistant/web` | 692 |
| `@cossistant/jobs` | 52 |
| `@cossistant/workers` | 33 |
| `@cossistant/memory` | 33 |
| `facehash` | 24 |
| `@cossistant/protocol` | 18 |
| `@cossistant/release` | 8 |
| `@cossistant/tiny-markdown` | 7 |

`bun run check-types` 20/20. Biome clean on every changed file.

## Note

With `apps/api`'s suite now isolated per file, the dedicated "Test REST OpenAPI contract" CI step is redundant (it exists only to dodge this leakage). Left in place here — worth removing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)